### PR TITLE
[BE] 사용자 등록 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/controller/MemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.bottari.controller;
+
+import com.bottari.dto.CreateMemberRequest;
+import com.bottari.service.MemberService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<Void> register(
+            @RequestBody final CreateMemberRequest request
+    ) {
+        final Long id = memberService.create(request);
+
+        return ResponseEntity.created(URI.create("/members/" + id)).build();
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/domain/Member.java
+++ b/backend/bottari/src/main/java/com/bottari/domain/Member.java
@@ -1,0 +1,38 @@
+package com.bottari.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String ssaid;
+
+    private String name;
+
+    public Member(
+            final String ssaid,
+            final String name
+    ) {
+        validateName(name);
+        this.ssaid = ssaid;
+        this.name = name;
+    }
+
+    private void validateName(final String name) {
+        if (name.length() < 3 || name.length() > 10) {
+            throw new IllegalArgumentException("사용자 이름은 3글자 이상 10글자 이하여야 합니다.");
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/dto/CreateMemberRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/CreateMemberRequest.java
@@ -1,0 +1,13 @@
+package com.bottari.dto;
+
+import com.bottari.domain.Member;
+
+public record CreateMemberRequest(
+        String ssaid,
+        String name
+) {
+
+    public Member toMember() {
+        return new Member(ssaid, name);
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/repository/MemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.bottari.repository;
+
+import com.bottari.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/backend/bottari/src/main/java/com/bottari/repository/MemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/MemberRepository.java
@@ -4,4 +4,6 @@ import com.bottari.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsBySsaid(final String ssaid);
 }

--- a/backend/bottari/src/main/java/com/bottari/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/MemberService.java
@@ -1,0 +1,21 @@
+package com.bottari.service;
+
+import com.bottari.domain.Member;
+import com.bottari.dto.CreateMemberRequest;
+import com.bottari.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Long create(final CreateMemberRequest request) {
+        final Member member = request.toMember();
+        final Member savedMember = memberRepository.save(member);
+
+        return savedMember.getId();
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/MemberService.java
@@ -5,6 +5,7 @@ import com.bottari.dto.CreateMemberRequest;
 import com.bottari.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,10 +13,18 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional
     public Long create(final CreateMemberRequest request) {
+        validateDuplicateSsaid(request.ssaid());
         final Member member = request.toMember();
         final Member savedMember = memberRepository.save(member);
 
         return savedMember.getId();
+    }
+
+    private void validateDuplicateSsaid(final String ssaid) {
+        if (memberRepository.existsBySsaid(ssaid)) {
+            throw new IllegalArgumentException("중복된 ssaid입니다.");
+        }
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
@@ -29,7 +29,7 @@ class MemberControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @DisplayName("멤버를 생성한다")
+    @DisplayName("사용자를 생성한다.")
     @Test
     void register() throws Exception {
         // given

--- a/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
@@ -1,0 +1,47 @@
+package com.bottari.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bottari.dto.CreateMemberRequest;
+import com.bottari.service.MemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("멤버를 생성한다")
+    @Test
+    void register() throws Exception {
+        // given
+        final CreateMemberRequest request = new CreateMemberRequest("ssaid", "name");
+        given(memberService.create(request))
+                .willReturn(1L);
+
+        // when & then
+        mockMvc.perform(post("/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/members/1"));
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/domain/MemberTest.java
+++ b/backend/bottari/src/test/java/com/bottari/domain/MemberTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class MemberTest {
 
-    @DisplayName("이름이 3글자 미만 10글자 초과인 경우, 예외를 던진다")
+    @DisplayName("이름이 3글자 미만 10글자 초과인 경우, 예외를 던진다.")
     @ParameterizedTest
     @ValueSource(strings = {"12", "12345678910"})
     void validateName_throwException(final String name) {

--- a/backend/bottari/src/test/java/com/bottari/domain/MemberTest.java
+++ b/backend/bottari/src/test/java/com/bottari/domain/MemberTest.java
@@ -1,0 +1,20 @@
+package com.bottari.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MemberTest {
+
+    @DisplayName("이름이 3글자 미만 10글자 초과인 경우, 예외를 던진다")
+    @ParameterizedTest
+    @ValueSource(strings = {"12", "12345678910"})
+    void validateName_throwException(final String name) {
+        // when & then
+        assertThatThrownBy(() -> new Member("ssaid", name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("사용자 이름은 3글자 이상 10글자 이하여야 합니다.");
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
@@ -1,7 +1,9 @@
 package com.bottari.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bottari.domain.Member;
 import com.bottari.dto.CreateMemberRequest;
 import com.bottari.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,5 +36,19 @@ class MemberServiceTest {
 
         // then
         assertThat(actual).isNotNull();
+    }
+
+    @DisplayName("중복된 ssaid로 사용자를 생성할 경우, 예외를 던진다.")
+    @Test
+    void create_Exception_DuplicateSsaid() {
+        // given
+        final String duplicateSsaid = "duplicateSsaid";
+        memberRepository.save(new Member(duplicateSsaid, "name"));
+        final CreateMemberRequest request = new CreateMemberRequest(duplicateSsaid, "name");
+
+        // when & then
+        assertThatThrownBy(() -> memberService.create(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("중복된 ssaid입니다.");
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
@@ -1,0 +1,38 @@
+package com.bottari.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bottari.dto.CreateMemberRequest;
+import com.bottari.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class MemberServiceTest {
+
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberService = new MemberService(memberRepository);
+    }
+
+    @DisplayName("멤버를 생성한다")
+    @Test
+    void create() {
+        // given
+        final CreateMemberRequest request = new CreateMemberRequest("ssaid", "name");
+
+        // when
+        final Long actual = memberService.create(request);
+
+        // then
+        assertThat(actual).isNotNull();
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
@@ -25,7 +25,7 @@ class MemberServiceTest {
         memberService = new MemberService(memberRepository);
     }
 
-    @DisplayName("멤버를 생성한다")
+    @DisplayName("사용자를 생성한다.")
     @Test
     void create() {
         // given


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 사용자 등록 기능 구현 및 검증

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
Closed #1 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- `Member` 도메인 추가 및 사용자 이름 검증
- `Member` 관련 controller, service, repository 추가

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- 4인 페어 진행
<br>
