### PR TITLE
[BE] 보따리 물품 일괄 추가 및 삭제 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/controller/BottariItemController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/BottariItemController.java
@@ -1,6 +1,7 @@
 package com.bottari.controller;
 
 import com.bottari.dto.CreateBottariItemRequest;
+import com.bottari.dto.EditBottariItemsRequest;
 import com.bottari.dto.ReadBottariItemResponse;
 import com.bottari.service.BottariItemService;
 import java.net.URI;
@@ -38,6 +39,16 @@ public class BottariItemController {
         final Long id = bottariItemService.create(bottariId, request);
 
         return ResponseEntity.created(URI.create("/bottaries/" + bottariId + "/bottari-items/" + id)).build();
+    }
+
+    @PatchMapping("/bottaries/{bottariId}/bottari-items")
+    public ResponseEntity<Void> update(
+            @PathVariable final Long bottariId,
+            @RequestBody final EditBottariItemsRequest request
+    ) {
+        bottariItemService.update(bottariId, request);
+
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/bottari-items/{id}")

--- a/backend/bottari/src/main/java/com/bottari/dto/EditBottariItemsRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/EditBottariItemsRequest.java
@@ -1,0 +1,9 @@
+package com.bottari.dto;
+
+import java.util.List;
+
+public record EditBottariItemsRequest(
+        List<Long> deleteIds,
+        List<String> createItemNames
+) {
+}

--- a/backend/bottari/src/main/java/com/bottari/dto/EditBottariItemsRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/EditBottariItemsRequest.java
@@ -3,7 +3,7 @@ package com.bottari.dto;
 import java.util.List;
 
 public record EditBottariItemsRequest(
-        List<Long> deleteIds,
+        List<Long> deleteItemIds,
         List<String> createItemNames
 ) {
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
@@ -26,5 +26,7 @@ public interface BottariItemRepository extends JpaRepository<BottariItem, Long> 
             final List<Long> ids
     );
 
+    int countAllByBottariId(final Long bottariId);
+
     void deleteByIdIn(final List<Long> ids);
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
@@ -9,10 +9,22 @@ public interface BottariItemRepository extends JpaRepository<BottariItem, Long> 
 
     List<BottariItem> findAllByBottariId(final Long bottariId);
 
+    List<BottariItem> findAllByBottariIn(final List<Bottari> bottaries);
+
     boolean existsByBottariIdAndName(
             final Long bottariId,
             final String name
     );
 
-    List<BottariItem> findAllByBottariIn(final List<Bottari> bottaries);
+    boolean existsByBottariIdAndNameIn(
+            final Long bottariId,
+            final List<String> itemNames
+    );
+
+    int countAllByBottariIdAndIdIn(
+            final Long bottariId,
+            final List<Long> ids
+    );
+
+    void deleteByIdIn(final List<Long> ids);
 }

--- a/backend/bottari/src/main/java/com/bottari/service/BottariItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/BottariItemService.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BottariItemService {
 
+    private static final int MAX_BOTTARI_ITEMS_COUNT = 200;
+
     private final BottariItemRepository bottariItemRepository;
     private final BottariRepository bottariRepository;
 
@@ -54,6 +56,7 @@ public class BottariItemService {
         validateDuplicateDeleteItemIds(request.deleteItemIds());
         validateAllItemsInBottari(bottariId, request.deleteItemIds());
         bottariItemRepository.deleteByIdIn(request.deleteItemIds());
+        validateTotalItemCount(bottariId, request.createItemNames());
         validateUpdateItemNames(bottariId, request.createItemNames());
         final List<BottariItem> bottariItems = request.createItemNames()
                 .stream()
@@ -137,6 +140,17 @@ public class BottariItemService {
             if (!uniqueItemNames.add(itemName)) {
                 throw new IllegalArgumentException("중복된 물품이 존재합니다.");
             }
+        }
+    }
+
+    private void validateTotalItemCount(
+            final Long bottariId,
+            final List<String> itemNames
+    ) {
+        int bottariItemCount = bottariItemRepository.countAllByBottariId(bottariId);
+        int totalItemCount = bottariItemCount + itemNames.size();
+        if (totalItemCount > MAX_BOTTARI_ITEMS_COUNT) {
+            throw new IllegalArgumentException("물품은 최대 200개까지 보따리에 넣을 수 있습니다.");
         }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/service/BottariItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/BottariItemService.java
@@ -51,6 +51,7 @@ public class BottariItemService {
     ) {
         final Bottari bottari = bottariRepository.findById(bottariId)
                 .orElseThrow(() -> new IllegalArgumentException("보따리를 찾을 수 없습니다."));
+        validateDuplicateDeleteItemIds(request.deleteItemIds());
         validateAllItemsInBottari(bottariId, request.deleteItemIds());
         bottariItemRepository.deleteByIdIn(request.deleteItemIds());
         validateUpdateItemNames(bottariId, request.createItemNames());
@@ -91,6 +92,15 @@ public class BottariItemService {
     ) {
         if (bottariItemRepository.existsByBottariIdAndName(bottariId, name)) {
             throw new IllegalArgumentException("중복된 보따리 물품명입니다.");
+        }
+    }
+
+    private void validateDuplicateDeleteItemIds(final List<Long> deleteIds) {
+        final Set<Long> uniqueDeleteIds = new HashSet<>();
+        for (final Long deleteId : deleteIds) {
+            if (!uniqueDeleteIds.add(deleteId)) {
+                throw new IllegalArgumentException("삭제하려는 아이템에 중복이 있습니다.");
+            }
         }
     }
 

--- a/backend/bottari/src/main/java/com/bottari/service/BottariItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/BottariItemService.java
@@ -49,8 +49,8 @@ public class BottariItemService {
     ) {
         final Bottari bottari = bottariRepository.findById(bottariId)
                 .orElseThrow(() -> new IllegalArgumentException("보따리를 찾을 수 없습니다."));
-        validateItemsInBottari(bottariId, request.deleteIds());
-        bottariItemRepository.deleteByIdIn(request.deleteIds());
+        validateAllItemsInBottari(bottariId, request.deleteItemIds());
+        bottariItemRepository.deleteByIdIn(request.deleteItemIds());
         validateUpdateItemNames(bottariId, request.createItemNames());
         final List<BottariItem> bottariItems = request.createItemNames()
                 .stream()
@@ -92,12 +92,12 @@ public class BottariItemService {
         }
     }
 
-    private void validateItemsInBottari(
+    private void validateAllItemsInBottari(
             final Long bottariId,
-            final List<Long> deleteIds
+            final List<Long> itemIds
     ) {
-        final int countItemInBottari = bottariItemRepository.countAllByBottariIdAndIdIn(bottariId, deleteIds);
-        if (countItemInBottari != deleteIds.size()) {
+        final int countItemInBottari = bottariItemRepository.countAllByBottariIdAndIdIn(bottariId, itemIds);
+        if (countItemInBottari != itemIds.size()) {
             throw new IllegalArgumentException("보따리 안에 없는 물품은 삭제할 수 없습니다.");
         }
     }

--- a/backend/bottari/src/main/java/com/bottari/service/BottariItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/BottariItemService.java
@@ -7,7 +7,9 @@ import com.bottari.dto.EditBottariItemsRequest;
 import com.bottari.dto.ReadBottariItemResponse;
 import com.bottari.repository.BottariItemRepository;
 import com.bottari.repository.BottariRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -120,11 +122,11 @@ public class BottariItemService {
     }
 
     private void validateDuplicateItemNames(final List<String> itemNames) {
-        final long countCreateItemNames = itemNames.stream()
-                .distinct()
-                .count();
-        if (countCreateItemNames != itemNames.size()) {
-            throw new IllegalArgumentException("중복된 물품이 존재합니다.");
+        final Set<String> uniqueItemNames = new HashSet<>();
+        for (final String itemName : itemNames) {
+            if (!uniqueItemNames.add(itemName)) {
+                throw new IllegalArgumentException("중복된 물품이 존재합니다.");
+            }
         }
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/controller/BottariItemControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/BottariItemControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bottari.dto.CreateBottariItemRequest;
+import com.bottari.dto.EditBottariItemsRequest;
 import com.bottari.dto.ReadBottariItemResponse;
 import com.bottari.service.BottariItemService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -70,6 +71,25 @@ class BottariItemControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/bottaries/" + bottariId + "/bottari-items/1"));
+    }
+
+    @DisplayName("보따리 물품을 수정한다.")
+    @Test
+    void update() throws Exception {
+        // given
+        final Long bottariId = 1L;
+        final EditBottariItemsRequest request = new EditBottariItemsRequest(
+                List.of(1L, 2L),
+                List.of("newName1", "newName2")
+        );
+        willDoNothing().given(bottariItemService)
+                .update(bottariId, request);
+
+        // when & then
+        mockMvc.perform(patch("/bottaries/" + bottariId + "/bottari-items")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
     }
 
     @DisplayName("보따리 안에 있는 물품을 삭제한다.")

--- a/backend/bottari/src/test/java/com/bottari/service/BottariItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/BottariItemServiceTest.java
@@ -101,6 +101,25 @@ class BottariItemServiceTest {
                 .hasMessage("보따리를 찾을 수 없습니다.");
     }
 
+    @DisplayName("삭제하려는 아이템 아이디에 중복이 존재하는 경우, 예외를 던진다.")
+    @Test
+    void update_Exception_DuplicateDeleteIds() {
+        // given
+        final Member member = new Member("ssaid", "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        final List<Long> duplicateDeleteIds = List.of(1L, 1L, 2L);
+        final EditBottariItemsRequest request = new EditBottariItemsRequest(duplicateDeleteIds, List.of());
+
+        // when & then
+        assertThatThrownBy(() -> bottariItemService.update(bottari.getId(), request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("삭제하려는 아이템에 중복이 있습니다.");
+    }
+
     @DisplayName("같은 보따리 내에 중복되는 물품명이 존재할 경우, 예외를 던진다.")
     @Test
     void create_Exception_DuplicateName() {

--- a/backend/bottari/src/test/java/com/bottari/service/BottariItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/BottariItemServiceTest.java
@@ -187,8 +187,7 @@ class BottariItemServiceTest {
                 .getResultList();
 
         assertAll(() -> {
-            assertThat(actual).hasSize(3);
-            assertThat(actual.stream().map(BottariItem::getName).toList()).contains("name_3", "newName_1", "newName_2");
+            assertThat(actual).extracting("name").containsExactly("name_3", "newName_1", "newName_2");
             assertThat(anotherActual).hasSize(1);
             assertThat(anotherActual.getFirst().getName()).isEqualTo("another_name");
         });

--- a/backend/bottari/src/test/java/com/bottari/service/BottariItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/BottariItemServiceTest.java
@@ -8,6 +8,7 @@ import com.bottari.domain.Bottari;
 import com.bottari.domain.BottariItem;
 import com.bottari.domain.Member;
 import com.bottari.dto.CreateBottariItemRequest;
+import com.bottari.dto.EditBottariItemsRequest;
 import com.bottari.dto.ReadBottariItemResponse;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -121,6 +122,160 @@ class BottariItemServiceTest {
         assertThatThrownBy(() -> bottariItemService.create(bottari.getId(), request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("중복된 보따리 물품명입니다.");
+    }
+
+    @DisplayName("보따리 물품을 수정한다.")
+    @Test
+    void update() {
+        // given
+        final Member member = new Member("ssaid", "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        final BottariItem bottariItem_1 = new BottariItem("name_1", bottari);
+        final BottariItem bottariItem_2 = new BottariItem("name_2", bottari);
+        final BottariItem bottariItem_3 = new BottariItem("name_3", bottari);
+        entityManager.persist(bottariItem_1);
+        entityManager.persist(bottariItem_2);
+        entityManager.persist(bottariItem_3);
+
+        final Bottari anotherBottari = new Bottari("another_title", member);
+        entityManager.persist(anotherBottari);
+
+        final BottariItem anotherBottariItem = new BottariItem("another_name", anotherBottari);
+        entityManager.persist(anotherBottariItem);
+
+        final Long updateBottariId = bottari.getId();
+
+        final List<Long> deleteIds = List.of(bottariItem_1.getId(), bottariItem_2.getId());
+        final List<String> createNames = List.of("newName_1", "newName_2");
+        final EditBottariItemsRequest request = new EditBottariItemsRequest(deleteIds, createNames);
+
+        // when
+        bottariItemService.update(updateBottariId, request);
+
+        // then
+        final List<BottariItem> actual = entityManager.createQuery(
+                        "select i from BottariItem i where i.bottari.id = :bottariId", BottariItem.class)
+                .setParameter("bottariId", updateBottariId)
+                .getResultList();
+
+        final List<BottariItem> anotherActual = entityManager.createQuery(
+                        "select i from BottariItem i where i.bottari.id = :bottariId", BottariItem.class)
+                .setParameter("bottariId", anotherBottari.getId())
+                .getResultList();
+
+        assertAll(() -> {
+            assertThat(actual).hasSize(3);
+            assertThat(actual.stream().map(BottariItem::getName).toList()).contains("name_3", "newName_1", "newName_2");
+            assertThat(anotherActual).hasSize(1);
+            assertThat(anotherActual.getFirst().getName()).isEqualTo("another_name");
+        });
+    }
+
+    @DisplayName("수정 시 보따리가 존재하지 않는 경우, 예외를 던진다.")
+    @Test
+    void update_Exception_NotFoundBottari() {
+        // given
+        final Long invalidBottariId = -1L;
+        final EditBottariItemsRequest request = new EditBottariItemsRequest(List.of(), List.of());
+
+        // when & then
+        assertThatThrownBy(() -> bottariItemService.update(invalidBottariId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("보따리를 찾을 수 없습니다.");
+    }
+
+    @DisplayName("수정 시 삭제하려는 물품이 보따리 내에 존재하지 않는 경우, 예외를 던진다.")
+    @Test
+    void update_Exception_NotExistsItemInBottari() {
+        // given
+        final Member member = new Member("ssaid", "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        final BottariItem bottariItem_1 = new BottariItem("name_1", bottari);
+        final BottariItem bottariItem_2 = new BottariItem("name_2", bottari);
+        final BottariItem bottariItem_3 = new BottariItem("name_3", bottari);
+        entityManager.persist(bottariItem_1);
+        entityManager.persist(bottariItem_2);
+        entityManager.persist(bottariItem_3);
+
+        final Long bottariId = bottari.getId();
+
+        final List<Long> deleteIds = List.of(
+                bottariItem_1.getId(),
+                bottariItem_2.getId(),
+                Long.MAX_VALUE
+        );
+
+        final EditBottariItemsRequest request = new EditBottariItemsRequest(deleteIds, List.of());
+
+        // when & then
+        assertThatThrownBy(() -> bottariItemService.update(bottariId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("보따리 안에 없는 물품은 삭제할 수 없습니다.");
+    }
+
+    @DisplayName("수정 시 추가하려는 물품명에 중복이 존재하는 경우, 예외를 던진다.")
+    @Test
+    void update_Exception_DuplicateItemNameInRequest() {
+        // given
+        final Member member = new Member("ssaid", "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        final Long bottariId = bottari.getId();
+
+        final List<String> duplicateCreateNames = List.of(
+                "newName",
+                "duplicate_name",
+                "duplicate_name"
+        );
+
+        final EditBottariItemsRequest request = new EditBottariItemsRequest(List.of(), duplicateCreateNames);
+
+        // when & then
+        assertThatThrownBy(() -> bottariItemService.update(bottariId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("중복된 물품이 존재합니다.");
+    }
+
+    @DisplayName("수정 시 추가하려는 물품이 이미 존재하는 경우, 예외를 던진다.")
+    @Test
+    void update_Exception_AlreadyExistsItemName() {
+        // given
+        final Member member = new Member("ssaid", "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        final String duplicateName = "duplicateName";
+        final BottariItem bottariItem = new BottariItem(duplicateName, bottari);
+        entityManager.persist(bottariItem);
+
+        final Long bottariId = bottari.getId();
+
+        final List<String> duplicateNameInDB = List.of(
+                "newName",
+                duplicateName
+        );
+        final EditBottariItemsRequest request = new EditBottariItemsRequest(
+                List.of(),
+                duplicateNameInDB
+        );
+
+        // when & then
+        assertThatThrownBy(() -> bottariItemService.update(bottariId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("중복된 물품이 존재합니다.");
     }
 
     @DisplayName("보따리 물품을 삭제한다.")

--- a/backend/bottari/src/test/java/com/bottari/service/BottariItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/BottariItemServiceTest.java
@@ -297,6 +297,32 @@ class BottariItemServiceTest {
                 .hasMessage("중복된 물품이 존재합니다.");
     }
 
+    @DisplayName("아이템 추가 시 총 보따리 물품이 200개가 넘어가는 경우, 예외가 발생한다.")
+    @Test
+    void update_Exception_OverMaxBottariItemsCount() {
+        // given
+        final Member member = new Member("ssaid", "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        for (int i = 0; i < 198; i++) {
+            final BottariItem bottariItem = new BottariItem("name" + i, bottari);
+            entityManager.persist(bottariItem);
+        }
+
+        final EditBottariItemsRequest request = new EditBottariItemsRequest(
+                List.of(),
+                List.of("newItem1", "newItem2", "newItem3")
+        );
+
+        // when & then
+        assertThatThrownBy(() -> bottariItemService.update(bottari.getId(), request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("물품은 최대 200개까지 보따리에 넣을 수 있습니다.");
+    }
+
     @DisplayName("보따리 물품을 삭제한다.")
     @Test
     void delete() {


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 보따리 물품 일괄 추가 및 삭제 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #45 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 보따리 물품 일괄 추가 및 삭제 기능 구현
    - 보따리가 존재하지 않는 경우 검증
    - 삭제하려는 물품이 특정 보따리 내에 존재하지 않는 경우 검증
    - 추가하려는 물품명에 중복이 존재하는 경우 검증 (요청 내)
    - 추가하려는 물품명이 이미 DB에 존재하는 경우 검증
- 보따리 수정 API 대응
    - PATCH /bottaries/{bottariId}/bottari-items

## 🚨 논의 필요 사항
요청 내의 delete_id 리스트 내에 중복이 존재하는 경우,
이를 올바르지 않은 요청으로 처리하여 예외를 던질지, 서버 내에서 중복을 제거하고 삭제할지
논의 필요

- 현재 중복을 제거하지 않고, 올바르지 않은 요청으로 처리하여 예외를 던지는 중

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- 페어프로그래밍 with 코기 / 훌라
<br>
