### PR TITLE
[BE] 알람 생성 및 수정 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/controller/AlarmController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/AlarmController.java
@@ -1,12 +1,14 @@
 package com.bottari.controller;
 
 import com.bottari.dto.CreateAlarmRequest;
+import com.bottari.dto.UpdateAlarmRequest;
 import com.bottari.service.AlarmService;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,11 +20,21 @@ public class AlarmController {
 
     @PostMapping("/bottaries/{bottariId}/alarms")
     public ResponseEntity<Void> create(
-            @PathVariable Long bottariId,
-            @RequestBody CreateAlarmRequest request
+            @PathVariable final Long bottariId,
+            @RequestBody final CreateAlarmRequest request
     ) {
         final Long id = alarmService.create(bottariId, request);
 
         return ResponseEntity.created(URI.create("/alarms/" + id)).build();
+    }
+
+    @PutMapping("/alarms/{id}")
+    public ResponseEntity<Void> update(
+            @PathVariable final Long id,
+            @RequestBody final UpdateAlarmRequest request
+    ) {
+        alarmService.update(id, request);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/controller/AlarmController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/AlarmController.java
@@ -1,0 +1,28 @@
+package com.bottari.controller;
+
+import com.bottari.dto.CreateAlarmRequest;
+import com.bottari.service.AlarmService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @PostMapping("/bottaries/{bottariId}/alarms")
+    public ResponseEntity<Void> create(
+            @PathVariable Long bottariId,
+            @RequestBody CreateAlarmRequest request
+    ) {
+        final Long id = alarmService.create(bottariId, request);
+
+        return ResponseEntity.created(URI.create("/alarms/" + id)).build();
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/domain/Alarm.java
+++ b/backend/bottari/src/main/java/com/bottari/domain/Alarm.java
@@ -46,6 +46,15 @@ public class Alarm {
         this.bottari = bottari;
     }
 
+    public void update(
+            final RoutineAlarm routineAlarm,
+            final LocationAlarm locationAlarm
+    ) {
+        validateLocationAlarm(routineAlarm, locationAlarm);
+        this.routineAlarm = routineAlarm;
+        this.locationAlarm = locationAlarm;
+    }
+
     private void validateLocationAlarm(
             final RoutineAlarm routineAlarm,
             final LocationAlarm locationAlarm

--- a/backend/bottari/src/main/java/com/bottari/dto/CreateAlarmRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/CreateAlarmRequest.java
@@ -1,0 +1,56 @@
+package com.bottari.dto;
+
+import com.bottari.domain.LocationAlarm;
+import com.bottari.domain.RepeatType;
+import com.bottari.domain.RoutineAlarm;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record CreateAlarmRequest(
+        RoutineAlarmRequest routineAlarm,
+        LocationAlarmRequest locationAlarm
+) {
+
+    public RoutineAlarm toRoutineAlarm() {
+        return new RoutineAlarm(
+                routineAlarm.time,
+                routineAlarm.type,
+                routineAlarm.date,
+                routineAlarm.repeatDayOfWeekValues.stream()
+                        .map(DayOfWeek::of)
+                        .collect(Collectors.toSet())
+        );
+    }
+
+    public LocationAlarm toLocationAlarm() {
+        if (locationAlarm == null) {
+            return null;
+        }
+
+        return new LocationAlarm(
+                locationAlarm.isLocationAlarmActive,
+                locationAlarm.latitude,
+                locationAlarm.longitude,
+                locationAlarm.radius
+        );
+    }
+
+    public record RoutineAlarmRequest(
+            LocalTime time,
+            RepeatType type,
+            LocalDate date,
+            List<Integer> repeatDayOfWeekValues
+    ) {
+    }
+
+    public record LocationAlarmRequest(
+            boolean isLocationAlarmActive,
+            Double latitude,
+            Double longitude,
+            int radius
+    ) {
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/dto/CreateAlarmRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/CreateAlarmRequest.java
@@ -7,6 +7,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public record CreateAlarmRequest(
@@ -15,13 +16,15 @@ public record CreateAlarmRequest(
 ) {
 
     public RoutineAlarm toRoutineAlarm() {
+        final Set<DayOfWeek> dayOfWeeks = routineAlarm.repeatDayOfWeekValues.stream()
+                .map(DayOfWeek::of)
+                .collect(Collectors.toSet());
+
         return new RoutineAlarm(
                 routineAlarm.time,
                 routineAlarm.type,
                 routineAlarm.date,
-                routineAlarm.repeatDayOfWeekValues.stream()
-                        .map(DayOfWeek::of)
-                        .collect(Collectors.toSet())
+                dayOfWeeks
         );
     }
 

--- a/backend/bottari/src/main/java/com/bottari/dto/UpdateAlarmRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/UpdateAlarmRequest.java
@@ -7,6 +7,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public record UpdateAlarmRequest(
@@ -15,13 +16,15 @@ public record UpdateAlarmRequest(
 ) {
 
     public RoutineAlarm toRoutineAlarm() {
+        final Set<DayOfWeek> dayOfWeeks = routineAlarm.repeatDayOfWeekValues.stream()
+                .map(DayOfWeek::of)
+                .collect(Collectors.toSet());
+
         return new RoutineAlarm(
                 routineAlarm.time,
                 routineAlarm.type,
                 routineAlarm.date,
-                routineAlarm.repeatDayOfWeekValues.stream()
-                        .map(DayOfWeek::of)
-                        .collect(Collectors.toSet())
+                dayOfWeeks
         );
     }
 

--- a/backend/bottari/src/main/java/com/bottari/dto/UpdateAlarmRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/UpdateAlarmRequest.java
@@ -1,0 +1,56 @@
+package com.bottari.dto;
+
+import com.bottari.domain.LocationAlarm;
+import com.bottari.domain.RepeatType;
+import com.bottari.domain.RoutineAlarm;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record UpdateAlarmRequest(
+        RoutineAlarmRequest routineAlarm,
+        LocationAlarmRequest locationAlarm
+) {
+
+    public RoutineAlarm toRoutineAlarm() {
+        return new RoutineAlarm(
+                routineAlarm.time,
+                routineAlarm.type,
+                routineAlarm.date,
+                routineAlarm.repeatDayOfWeekValues.stream()
+                        .map(DayOfWeek::of)
+                        .collect(Collectors.toSet())
+        );
+    }
+
+    public LocationAlarm toLocationAlarm() {
+        if (locationAlarm == null) {
+            return null;
+        }
+
+        return new LocationAlarm(
+                locationAlarm.isLocationAlarmActive,
+                locationAlarm.latitude,
+                locationAlarm.longitude,
+                locationAlarm.radius
+        );
+    }
+
+    public record RoutineAlarmRequest(
+            LocalTime time,
+            RepeatType type,
+            LocalDate date,
+            List<Integer> repeatDayOfWeekValues
+    ) {
+    }
+
+    public record LocationAlarmRequest(
+            boolean isLocationAlarmActive,
+            Double latitude,
+            Double longitude,
+            int radius
+    ) {
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/service/AlarmService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/AlarmService.java
@@ -1,0 +1,34 @@
+package com.bottari.service;
+
+import com.bottari.domain.Alarm;
+import com.bottari.domain.Bottari;
+import com.bottari.dto.CreateAlarmRequest;
+import com.bottari.repository.AlarmRepository;
+import com.bottari.repository.BottariRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+
+    private final AlarmRepository alarmRepository;
+    private final BottariRepository bottariRepository;
+
+    public Long create(
+            final Long bottariId,
+            final CreateAlarmRequest request
+    ) {
+        final Bottari bottari = bottariRepository.findById(bottariId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 보따리입니다."));
+        final Alarm alarm = new Alarm(
+                true,
+                request.toRoutineAlarm(),
+                request.toLocationAlarm(),
+                bottari
+        );
+        final Alarm savedAlarm = alarmRepository.save(alarm);
+
+        return savedAlarm.getId();
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/service/AlarmService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/AlarmService.java
@@ -3,6 +3,7 @@ package com.bottari.service;
 import com.bottari.domain.Alarm;
 import com.bottari.domain.Bottari;
 import com.bottari.dto.CreateAlarmRequest;
+import com.bottari.dto.UpdateAlarmRequest;
 import com.bottari.repository.AlarmRepository;
 import com.bottari.repository.BottariRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +33,15 @@ public class AlarmService {
         final Alarm savedAlarm = alarmRepository.save(alarm);
 
         return savedAlarm.getId();
+    }
+
+    @Transactional
+    public void update(
+            final Long id,
+            final UpdateAlarmRequest request
+    ) {
+        final Alarm alarm = alarmRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 알람입니다."));
+        alarm.update(request.toRoutineAlarm(), request.toLocationAlarm());
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/service/AlarmService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/AlarmService.java
@@ -7,6 +7,7 @@ import com.bottari.repository.AlarmRepository;
 import com.bottari.repository.BottariRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +16,7 @@ public class AlarmService {
     private final AlarmRepository alarmRepository;
     private final BottariRepository bottariRepository;
 
+    @Transactional
     public Long create(
             final Long bottariId,
             final CreateAlarmRequest request

--- a/backend/bottari/src/test/java/com/bottari/controller/AlarmControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/AlarmControllerTest.java
@@ -1,0 +1,64 @@
+package com.bottari.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bottari.domain.RepeatType;
+import com.bottari.dto.CreateAlarmRequest;
+import com.bottari.service.AlarmService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AlarmController.class)
+class AlarmControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AlarmService alarmService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("알람을 생성한다.")
+    @Test
+    void create() throws Exception {
+        // given
+         final Long bottariId = 1L;
+        final CreateAlarmRequest request = new CreateAlarmRequest(
+                new CreateAlarmRequest.RoutineAlarmRequest(
+                        LocalTime.MAX,
+                        RepeatType.EVERY_WEEK_REPEAT,
+                        null,
+                        List.of(1, 4, 7) // 월, 목, 일
+                ),
+                new CreateAlarmRequest.LocationAlarmRequest(
+                        true,
+                        1.23,
+                        1.23,
+                        100
+                )
+        );
+        given(alarmService.create(bottariId, request))
+                .willReturn(1L);
+
+        // when & then
+        mockMvc.perform(post("/bottaries/" + bottariId + "/alarms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/alarms/1"));
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/controller/AlarmControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/AlarmControllerTest.java
@@ -1,12 +1,15 @@
 package com.bottari.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bottari.domain.RepeatType;
 import com.bottari.dto.CreateAlarmRequest;
+import com.bottari.dto.UpdateAlarmRequest;
 import com.bottari.service.AlarmService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalTime;
@@ -36,7 +39,7 @@ class AlarmControllerTest {
     @Test
     void create() throws Exception {
         // given
-         final Long bottariId = 1L;
+        final Long bottariId = 1L;
         final CreateAlarmRequest request = new CreateAlarmRequest(
                 new CreateAlarmRequest.RoutineAlarmRequest(
                         LocalTime.MAX,
@@ -60,5 +63,34 @@ class AlarmControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/alarms/1"));
+    }
+
+    @DisplayName("알람을 수정한다.")
+    @Test
+    void update() throws Exception {
+        // given
+        final Long alarmId = 1L;
+        final UpdateAlarmRequest request = new UpdateAlarmRequest(
+                new UpdateAlarmRequest.RoutineAlarmRequest(
+                        LocalTime.MAX,
+                        RepeatType.EVERY_WEEK_REPEAT,
+                        null,
+                        List.of(1, 4, 7) // 월, 목, 일
+                ),
+                new UpdateAlarmRequest.LocationAlarmRequest(
+                        true,
+                        1.23,
+                        1.23,
+                        100
+                )
+        );
+        willDoNothing().given(alarmService)
+                .update(alarmId, request);
+
+        // when & then
+        mockMvc.perform(put("/alarms/" + alarmId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/domain/AlarmTest.java
+++ b/backend/bottari/src/test/java/com/bottari/domain/AlarmTest.java
@@ -2,6 +2,9 @@ package com.bottari.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +20,27 @@ class AlarmTest {
 
         // when & then
         assertThatThrownBy(() -> new Alarm(false, null, locationAlarm, bottari))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("루틴 알람이 존재하지 않으면 위치 알람을 설정할 수 없습니다.");
+    }
+
+    @DisplayName("알람을 수정할 때, 위치 알람 없이 루틴 알람을 설정하는 경우, 예외를 던진다.")
+    @Test
+    void update_Exception_LocationAlarm() {
+        // given
+        final Member member = new Member("ssaid", "name");
+        final Bottari bottari = new Bottari("title", member);
+        final RoutineAlarm routineAlarm = new RoutineAlarm(
+                LocalTime.NOON,
+                RepeatType.NON_REPEAT,
+                LocalDate.MAX,
+                Set.of()
+        );
+        final LocationAlarm locationAlarm = new LocationAlarm(false, 1.23, 1.23, 100);
+        final Alarm alarm = new Alarm(false, routineAlarm, locationAlarm, bottari);
+
+        // when & then
+        assertThatThrownBy(() -> alarm.update(null, locationAlarm))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("루틴 알람이 존재하지 않으면 위치 알람을 설정할 수 없습니다.");
     }

--- a/backend/bottari/src/test/java/com/bottari/service/AlarmServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/AlarmServiceTest.java
@@ -1,0 +1,87 @@
+package com.bottari.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bottari.domain.Bottari;
+import com.bottari.domain.Member;
+import com.bottari.domain.RepeatType;
+import com.bottari.dto.CreateAlarmRequest;
+import jakarta.persistence.EntityManager;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(AlarmService.class)
+class AlarmServiceTest {
+
+    @Autowired
+    private AlarmService alarmService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @DisplayName("알람을 추가한다.")
+    @Test
+    void create() {
+        // given
+        final String ssaid = "ssaid";
+        final Member member = new Member(ssaid, "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        final CreateAlarmRequest request = new CreateAlarmRequest(
+                new CreateAlarmRequest.RoutineAlarmRequest(
+                        LocalTime.MAX,
+                        RepeatType.EVERY_WEEK_REPEAT,
+                        null,
+                        List.of(1, 4, 7) // 월, 목, 일
+                ),
+                new CreateAlarmRequest.LocationAlarmRequest(
+                        true,
+                        1.23,
+                        1.23,
+                        100
+                )
+        );
+
+        // when
+        final Long actual = alarmService.create(bottari.getId(), request);
+
+        // then
+        assertThat(actual).isNotNull();
+    }
+
+    @DisplayName("존재하지 않는 보따리에 알람을 추가할 경우, 예외를 던진다.")
+    @Test
+    void create_Exception_NotExistsBottari() {
+        // given
+        final CreateAlarmRequest request = new CreateAlarmRequest(
+                new CreateAlarmRequest.RoutineAlarmRequest(
+                        LocalTime.MAX,
+                        RepeatType.EVERY_WEEK_REPEAT,
+                        null,
+                        List.of(1, 4, 7) // 월, 목, 일
+                ),
+                new CreateAlarmRequest.LocationAlarmRequest(
+                        true,
+                        1.23,
+                        1.23,
+                        100
+                )
+        );
+        final Long invalidBottariId = 1L;
+
+        // when & then
+        assertThatThrownBy(() -> alarmService.create(invalidBottariId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 보따리입니다.");
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/service/AlarmServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/AlarmServiceTest.java
@@ -2,14 +2,22 @@ package com.bottari.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.bottari.domain.Alarm;
 import com.bottari.domain.Bottari;
+import com.bottari.domain.LocationAlarm;
 import com.bottari.domain.Member;
 import com.bottari.domain.RepeatType;
+import com.bottari.domain.RoutineAlarm;
 import com.bottari.dto.CreateAlarmRequest;
+import com.bottari.dto.UpdateAlarmRequest;
 import jakarta.persistence.EntityManager;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,5 +91,62 @@ class AlarmServiceTest {
         assertThatThrownBy(() -> alarmService.create(invalidBottariId, request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("존재하지 않는 보따리입니다.");
+    }
+
+    @DisplayName("알람을 수정한다.")
+    @Test
+    void update() {
+        // given
+        final String ssaid = "ssaid";
+        final Member member = new Member(ssaid, "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        final RoutineAlarm routineAlarm = new RoutineAlarm(
+                LocalTime.now(),
+                RepeatType.EVERY_WEEK_REPEAT,
+                null,
+                Set.of(DayOfWeek.MONDAY)
+        );
+        final LocationAlarm locationAlarm = new LocationAlarm(
+                true,
+                37.5,
+                127.5,
+                100
+        );
+        final Alarm alarm = new Alarm(true, routineAlarm, locationAlarm, bottari);
+        entityManager.persist(alarm);
+
+        final UpdateAlarmRequest updateRequest = new UpdateAlarmRequest(
+                new UpdateAlarmRequest.RoutineAlarmRequest(
+                        LocalTime.NOON,
+                        RepeatType.NON_REPEAT,
+                        LocalDate.MAX,
+                        List.of()
+                ),
+                new UpdateAlarmRequest.LocationAlarmRequest(
+                        false,
+                        1.23,
+                        1.23,
+                        100
+                )
+        );
+
+        // when
+        alarmService.update(alarm.getId(), updateRequest);
+
+        // then
+        final Alarm actual = entityManager.find(Alarm.class, alarm.getId());
+        assertAll(() -> {
+            assertThat(actual.getRoutineAlarm().getTime()).isEqualTo(LocalTime.NOON);
+            assertThat(actual.getRoutineAlarm().getType()).isEqualTo(RepeatType.NON_REPEAT);
+            assertThat(actual.getRoutineAlarm().getDate()).isEqualTo(LocalDate.MAX);
+            assertThat(actual.getRoutineAlarm().getRepeatDayOfWeeksBitmask()).isEqualTo(0);
+            assertThat(actual.getLocationAlarm().isLocationAlarmActive()).isFalse();
+            assertThat(actual.getLocationAlarm().latitude()).isEqualTo(1.23);
+            assertThat(actual.getLocationAlarm().longitude()).isEqualTo(1.23);
+        });
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/service/AlarmServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/AlarmServiceTest.java
@@ -149,4 +149,37 @@ class AlarmServiceTest {
             assertThat(actual.getLocationAlarm().longitude()).isEqualTo(1.23);
         });
     }
+
+    @DisplayName("존재하지 않는 알람을 수정할 경우, 예외를 던진다.")
+    @Test
+    void update_Exception_NotExistsAlarm() {
+        // given
+        final String ssaid = "ssaid";
+        final Member member = new Member(ssaid, "name");
+        entityManager.persist(member);
+
+        final Bottari bottari = new Bottari("title", member);
+        entityManager.persist(bottari);
+
+        final UpdateAlarmRequest updateRequest = new UpdateAlarmRequest(
+                new UpdateAlarmRequest.RoutineAlarmRequest(
+                        LocalTime.NOON,
+                        RepeatType.NON_REPEAT,
+                        LocalDate.MAX,
+                        List.of()
+                ),
+                new UpdateAlarmRequest.LocationAlarmRequest(
+                        false,
+                        1.23,
+                        1.23,
+                        100
+                )
+        );
+        final Long invalidAlarmId = 1L;
+
+        // when & then
+        assertThatThrownBy(() -> alarmService.update(invalidAlarmId, updateRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 알람입니다.");
+    }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 알람 생성 기능 구현
- 알람 수정 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #44 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 알람 생성 및 수정 기능 구현
- 알람 생성 및 수정 기능 테스트 작성

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- 2인 페어 진행
- 알람 on/off API 구현 필요 @unh6unh6 

### 알람 on/off API가 필요한 이유

<img width="414" height="734" alt="image" src="https://github.com/user-attachments/assets/aba6953c-e5e9-473d-82a9-bcd7b965b797" />

- 알람을 아직 생성하지 않았다면, 알람 활성화 버튼(`isActive`)를 누를 수 없다.

<img width="852" height="189" alt="image" src="https://github.com/user-attachments/assets/70381fea-0a62-4e67-9323-e98610ea9141" />

- 알람을 생성한 이후에는 isActive 토글 버튼을 누를 수 있다.
- 따라서 알람 추가 및 수정 시에는 알람의 isActive 필드를 저장하지 않고, 별도로 API를 추가해야 한다.
- <안드로이드 팀원과 협의된 내용>


<br>
