### PR TITLE
[AN] 개인 보따리 편집 화면 구현

### DIFF
--- a/android/Bottari/gradle/libs.versions.toml
+++ b/android/Bottari/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 # Android Gradle Plugin & Kotlin
 agp = "8.9.0"
-flexbox = "3.0.0"
 kotlin = "2.0.21"
 jetbrainsKotlinJvm = "2.0.21"
 
@@ -15,6 +14,7 @@ constraintlayout = "2.2.1"
 # UI Components
 material = "1.12.0"
 cardstackview = "3.0.0"
+flexbox = "3.0.0"
 
 # Network
 retrofit = "3.0.0"

--- a/android/Bottari/gradle/libs.versions.toml
+++ b/android/Bottari/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 # Android Gradle Plugin & Kotlin
 agp = "8.9.0"
+flexbox = "3.0.0"
 kotlin = "2.0.21"
 jetbrainsKotlinJvm = "2.0.21"
 
@@ -47,6 +48,7 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 
 # --- UI ---
 cardstackview = { module = "com.github.jens-muenker:CardStackView", version.ref = "cardstackview" }
+flexbox = { module = "com.google.android.flexbox:flexbox", version.ref = "flexbox" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # --- Network ---

--- a/android/Bottari/presentation/build.gradle.kts
+++ b/android/Bottari/presentation/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.material)
     implementation(libs.cardstackview)
-    implementation (libs.flexbox)
+    implementation(libs.flexbox)
     testImplementation(libs.bundles.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/Bottari/presentation/build.gradle.kts
+++ b/android/Bottari/presentation/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.material)
     implementation(libs.cardstackview)
+    implementation (libs.flexbox)
     testImplementation(libs.bundles.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/Bottari/presentation/src/main/AndroidManifest.xml
+++ b/android/Bottari/presentation/src/main/AndroidManifest.xml
@@ -3,9 +3,11 @@
 
     <application>
         <activity
+            android:name=".view.edit.PersonalBottariEditActivity"
+            android:exported="false" />
+        <activity
             android:name=".view.home.HomeActivity"
             android:exported="false" />
-
         <activity
             android:name=".view.checklist.ChecklistActivity"
             android:exported="false" />

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/BottariUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/BottariUiModel.kt
@@ -5,5 +5,5 @@ data class BottariUiModel(
     val title: String,
     val totalQuantity: Int,
     val checkedQuantity: Int,
-    val alarmTypeUiModel: AlarmTypeUiModel,
+    val alarmTypeUiModel: AlarmTypeUiModel?,
 )

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/MainEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/MainEditFragment.kt
@@ -19,7 +19,10 @@ class MainEditFragment : BaseFragment<FragmentMainEditBinding>(FragmentMainEditB
     private val itemAdapter = PersonalBottariItemAdapter()
     private val alarmAdapter = PersonalBottariAlarmAdapter()
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
         setupItemRecyclerView()
@@ -47,7 +50,7 @@ class MainEditFragment : BaseFragment<FragmentMainEditBinding>(FragmentMainEditB
         binding.rvEditItem.isVisible = hasItems
     }
 
-    private fun toggleAlarmSelection(hasAlarms: Boolean){
+    private fun toggleAlarmSelection(hasAlarms: Boolean) {
         binding.tvClickEditAlarmTitle.isVisible = !hasAlarms
         binding.tvClickEditAlarmDescription.isVisible = !hasAlarms
         binding.viewClickEditAlarm.isVisible = !hasAlarms
@@ -57,16 +60,17 @@ class MainEditFragment : BaseFragment<FragmentMainEditBinding>(FragmentMainEditB
 
     private fun setupItemRecyclerView() {
         binding.rvEditItem.apply {
-            layoutManager = FlexboxLayoutManager(requireContext()).apply {
-                flexDirection = FlexDirection.ROW
-                flexWrap = FlexWrap.WRAP
-                justifyContent = JustifyContent.FLEX_START
-            }
+            layoutManager =
+                FlexboxLayoutManager(requireContext()).apply {
+                    flexDirection = FlexDirection.ROW
+                    flexWrap = FlexWrap.WRAP
+                    justifyContent = JustifyContent.FLEX_START
+                }
             adapter = this@MainEditFragment.itemAdapter
         }
     }
 
-    private fun setupAlarmRecyclerView(){
+    private fun setupAlarmRecyclerView() {
         binding.rvEditAlarm.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = this@MainEditFragment.alarmAdapter
@@ -77,5 +81,4 @@ class MainEditFragment : BaseFragment<FragmentMainEditBinding>(FragmentMainEditB
         viewModel.fetchItemsById(1)
         viewModel.fetchAlarmById(1)
     }
-
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/MainEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/MainEditFragment.kt
@@ -1,0 +1,81 @@
+package com.bottari.presentation.view.edit
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.bottari.presentation.base.BaseFragment
+import com.bottari.presentation.databinding.FragmentMainEditBinding
+import com.bottari.presentation.view.edit.adapter.PersonalBottariAlarmAdapter
+import com.bottari.presentation.view.edit.adapter.PersonalBottariItemAdapter
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.JustifyContent
+
+class MainEditFragment : BaseFragment<FragmentMainEditBinding>(FragmentMainEditBinding::inflate) {
+    private val viewModel: MainEditViewModel by viewModels()
+    private val itemAdapter = PersonalBottariItemAdapter()
+    private val alarmAdapter = PersonalBottariAlarmAdapter()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+        setupItemRecyclerView()
+        setupAlarmRecyclerView()
+        fetchInitialData()
+    }
+
+    private fun setupObservers() {
+        viewModel.items.observe(viewLifecycleOwner) { items ->
+            itemAdapter.submitList(items)
+            toggleItemSection(items.isNotEmpty())
+        }
+
+        viewModel.alarms.observe(viewLifecycleOwner) { alarms ->
+            alarmAdapter.submitList(alarms)
+            toggleAlarmSelection(alarms.isNotEmpty())
+        }
+    }
+
+    private fun toggleItemSection(hasItems: Boolean) {
+        binding.tvClickEditItemTitle.isVisible = !hasItems
+        binding.tvClickEditItemDescription.isVisible = !hasItems
+        binding.viewClickEditItem.isVisible = !hasItems
+        binding.tvClickEditItemDescriptionNotEmpty.isVisible = hasItems
+        binding.rvEditItem.isVisible = hasItems
+    }
+
+    private fun toggleAlarmSelection(hasAlarms: Boolean){
+        binding.tvClickEditAlarmTitle.isVisible = !hasAlarms
+        binding.tvClickEditAlarmDescription.isVisible = !hasAlarms
+        binding.viewClickEditAlarm.isVisible = !hasAlarms
+        binding.tvClickEditAlarmDescriptionNotEmpty.isVisible = hasAlarms
+        binding.rvEditAlarm.isVisible = hasAlarms
+    }
+
+    private fun setupItemRecyclerView() {
+        binding.rvEditItem.apply {
+            layoutManager = FlexboxLayoutManager(requireContext()).apply {
+                flexDirection = FlexDirection.ROW
+                flexWrap = FlexWrap.WRAP
+                justifyContent = JustifyContent.FLEX_START
+            }
+            adapter = this@MainEditFragment.itemAdapter
+        }
+    }
+
+    private fun setupAlarmRecyclerView(){
+        binding.rvEditAlarm.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = this@MainEditFragment.alarmAdapter
+        }
+    }
+
+    private fun fetchInitialData() {
+        viewModel.fetchItemsById(1)
+        viewModel.fetchAlarmById(1)
+    }
+
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/MainEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/MainEditViewModel.kt
@@ -14,7 +14,7 @@ class MainEditViewModel : ViewModel() {
     val bottari: LiveData<BottariUiModel> = _bottari
 
     private val _items = MutableLiveData<List<ItemUiModel>>()
-    val items : LiveData<List<ItemUiModel>> = _items
+    val items: LiveData<List<ItemUiModel>> = _items
 
     private val _alarms = MutableLiveData<List<AlarmTypeUiModel>>()
     val alarms: LiveData<List<AlarmTypeUiModel>> = _alarms
@@ -27,17 +27,18 @@ class MainEditViewModel : ViewModel() {
         _items.value = dummyChecklist
     }
 
-    fun fetchAlarmById(id: Int){
+    fun fetchAlarmById(id: Int) {
         _alarms.value = dummyAlarm
     }
 
-    val dummyBottariUiModel = BottariUiModel(
-        id = 1,
-        title = "내가 만든 보따리",
-        totalQuantity = 0,
-        checkedQuantity = 0,
-        alarmTypeUiModel = null,
-    )
+    val dummyBottariUiModel =
+        BottariUiModel(
+            id = 1,
+            title = "내가 만든 보따리",
+            totalQuantity = 0,
+            checkedQuantity = 0,
+            alarmTypeUiModel = null,
+        )
 
     private val dummyChecklist =
         listOf(
@@ -66,14 +67,10 @@ class MainEditViewModel : ViewModel() {
     private val dummyAlarm =
         listOf(
             AlarmTypeUiModel.EveryDayRepeat(time = LocalTime.of(12, 0)),
-            AlarmTypeUiModel.EveryWeekRepeat(days = listOf(1,3,4),time = LocalTime.of(12,0)),
+            AlarmTypeUiModel.EveryWeekRepeat(days = listOf(1, 3, 4), time = LocalTime.of(12, 0)),
             AlarmTypeUiModel.NonRepeat(
-                date = LocalDate.of(2024,12,4),
-                time = LocalTime.of(12,0)
+                date = LocalDate.of(2024, 12, 4),
+                time = LocalTime.of(12, 0),
             ),
         )
-
 }
-
-
-

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/MainEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/MainEditViewModel.kt
@@ -1,0 +1,79 @@
+package com.bottari.presentation.view.edit
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.bottari.presentation.model.AlarmTypeUiModel
+import com.bottari.presentation.model.BottariUiModel
+import com.bottari.presentation.model.ItemUiModel
+import java.time.LocalDate
+import java.time.LocalTime
+
+class MainEditViewModel : ViewModel() {
+    private val _bottari = MutableLiveData<BottariUiModel>()
+    val bottari: LiveData<BottariUiModel> = _bottari
+
+    private val _items = MutableLiveData<List<ItemUiModel>>()
+    val items : LiveData<List<ItemUiModel>> = _items
+
+    private val _alarms = MutableLiveData<List<AlarmTypeUiModel>>()
+    val alarms: LiveData<List<AlarmTypeUiModel>> = _alarms
+
+    fun fetchBottariById(id: Int) {
+        _bottari.value = dummyBottariUiModel
+    }
+
+    fun fetchItemsById(id: Int) {
+        _items.value = dummyChecklist
+    }
+
+    fun fetchAlarmById(id: Int){
+        _alarms.value = dummyAlarm
+    }
+
+    val dummyBottariUiModel = BottariUiModel(
+        id = 1,
+        title = "내가 만든 보따리",
+        totalQuantity = 0,
+        checkedQuantity = 0,
+        alarmTypeUiModel = null,
+    )
+
+    private val dummyChecklist =
+        listOf(
+            ItemUiModel(id = 0, isChecked = true, name = "우유"),
+            ItemUiModel(id = 1, isChecked = false, name = "계란"),
+            ItemUiModel(id = 2, isChecked = true, name = "식빵"),
+            ItemUiModel(id = 3, isChecked = false, name = "세제"),
+            ItemUiModel(id = 4, isChecked = true, name = "샴푸"),
+            ItemUiModel(id = 5, isChecked = false, name = "물티슈"),
+            ItemUiModel(id = 6, isChecked = true, name = "칫솔"),
+            ItemUiModel(id = 7, isChecked = false, name = "치약"),
+            ItemUiModel(id = 8, isChecked = true, name = "라면"),
+            ItemUiModel(id = 9, isChecked = false, name = "과자"),
+            ItemUiModel(id = 10, isChecked = true, name = "커피"),
+            ItemUiModel(id = 11, isChecked = false, name = "쌀"),
+            ItemUiModel(id = 12, isChecked = true, name = "김치"),
+            ItemUiModel(id = 13, isChecked = false, name = "휴지"),
+            ItemUiModel(id = 14, isChecked = true, name = "세탁세제"),
+            ItemUiModel(id = 15, isChecked = false, name = "청소기 필터"),
+            ItemUiModel(id = 16, isChecked = true, name = "텀블러"),
+            ItemUiModel(id = 17, isChecked = false, name = "포스트잇"),
+            ItemUiModel(id = 18, isChecked = true, name = "USB 케이블"),
+            ItemUiModel(id = 19, isChecked = false, name = "보조 배터리"),
+        )
+
+    private val dummyAlarm =
+        listOf(
+            AlarmTypeUiModel.EveryDayRepeat(time = LocalTime.of(12, 0)),
+            AlarmTypeUiModel.EveryWeekRepeat(days = listOf(1,3,4),time = LocalTime.of(12,0)),
+            AlarmTypeUiModel.NonRepeat(
+                date = LocalDate.of(2024,12,4),
+                time = LocalTime.of(12,0)
+            ),
+        )
+
+}
+
+
+

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/PersonalBottariEditActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/PersonalBottariEditActivity.kt
@@ -9,8 +9,7 @@ import com.bottari.presentation.R
 import com.bottari.presentation.base.BaseActivity
 import com.bottari.presentation.databinding.ActivityPersonalBottariEditBinding
 
-class PersonalBottariEditActivity :
-    BaseActivity<ActivityPersonalBottariEditBinding>(ActivityPersonalBottariEditBinding::inflate) {
+class PersonalBottariEditActivity : BaseActivity<ActivityPersonalBottariEditBinding>(ActivityPersonalBottariEditBinding::inflate) {
     private val viewModel: MainEditViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,17 +21,18 @@ class PersonalBottariEditActivity :
         handleBackPress()
     }
 
-    private fun setupListener(){
+    private fun setupListener() {
         binding.btnPrevious.setOnClickListener { onBackPressedDispatcher.onBackPressed() }
     }
-    private fun navigateToEdit(){
+
+    private fun navigateToEdit() {
         supportFragmentManager.beginTransaction().apply {
             setCustomAnimations(android.R.anim.fade_in, android.R.anim.fade_out)
             replace(
                 R.id.fcv_edit,
                 MainEditFragment::class.java,
                 null,
-                MainEditFragment::class.java.name
+                MainEditFragment::class.java.name,
             )
             commit()
         }
@@ -47,20 +47,22 @@ class PersonalBottariEditActivity :
             supportFragmentManager.popBackStack()
         }
     }
-    private fun setupObsever(){
-        viewModel.bottari.observe(this){
+
+    private fun setupObsever() {
+        viewModel.bottari.observe(this) {
             binding.tvBottariTitle.text = it.title
         }
     }
 
-    private fun getBottari(bottariId : Int){
+    private fun getBottari(bottariId: Int) {
         viewModel.fetchBottariById(bottariId)
     }
 
-    companion object{
+    companion object {
         private const val BOTTARI_ID = "BOTTARI_ID"
         private const val MIN_FRAGMENT_ENTRY_COUNT = 0
         private const val DEFAULT_BOTTARI_ID = 0
+
         fun newIntent(
             context: Context,
             bottariId: Long,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/PersonalBottariEditActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/PersonalBottariEditActivity.kt
@@ -1,0 +1,72 @@
+package com.bottari.presentation.view.edit
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.addCallback
+import androidx.activity.viewModels
+import com.bottari.presentation.R
+import com.bottari.presentation.base.BaseActivity
+import com.bottari.presentation.databinding.ActivityPersonalBottariEditBinding
+
+class PersonalBottariEditActivity :
+    BaseActivity<ActivityPersonalBottariEditBinding>(ActivityPersonalBottariEditBinding::inflate) {
+    private val viewModel: MainEditViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setupObsever()
+        setupListener()
+        getBottari(intent.getIntExtra(BOTTARI_ID, DEFAULT_BOTTARI_ID))
+        navigateToEdit()
+        handleBackPress()
+    }
+
+    private fun setupListener(){
+        binding.btnPrevious.setOnClickListener { onBackPressedDispatcher.onBackPressed() }
+    }
+    private fun navigateToEdit(){
+        supportFragmentManager.beginTransaction().apply {
+            setCustomAnimations(android.R.anim.fade_in, android.R.anim.fade_out)
+            replace(
+                R.id.fcv_edit,
+                MainEditFragment::class.java,
+                null,
+                MainEditFragment::class.java.name
+            )
+            commit()
+        }
+    }
+
+    private fun handleBackPress() {
+        onBackPressedDispatcher.addCallback(this) {
+            if (supportFragmentManager.backStackEntryCount == MIN_FRAGMENT_ENTRY_COUNT) {
+                finish()
+                return@addCallback
+            }
+            supportFragmentManager.popBackStack()
+        }
+    }
+    private fun setupObsever(){
+        viewModel.bottari.observe(this){
+            binding.tvBottariTitle.text = it.title
+        }
+    }
+
+    private fun getBottari(bottariId : Int){
+        viewModel.fetchBottariById(bottariId)
+    }
+
+    companion object{
+        private const val BOTTARI_ID = "BOTTARI_ID"
+        private const val MIN_FRAGMENT_ENTRY_COUNT = 0
+        private const val DEFAULT_BOTTARI_ID = 0
+        fun newIntent(
+            context: Context,
+            bottariId: Long,
+        ): Intent =
+            Intent(context, PersonalBottariEditActivity::class.java).apply {
+                putExtra(BOTTARI_ID, bottariId)
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariAlarmAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariAlarmAdapter.kt
@@ -1,0 +1,37 @@
+package com.bottari.presentation.view.edit.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.bottari.presentation.model.AlarmTypeUiModel
+
+class PersonalBottariAlarmAdapter() :
+    ListAdapter<AlarmTypeUiModel, PersonalBottariAlarmViewHolder>(DiffUtil) {
+    override fun onBindViewHolder(
+        holder: PersonalBottariAlarmViewHolder,
+        position: Int,
+    ) {
+        holder.bind(getItem(position))
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): PersonalBottariAlarmViewHolder = PersonalBottariAlarmViewHolder.from(parent)
+
+    companion object {
+        private val DiffUtil =
+            object : DiffUtil.ItemCallback<AlarmTypeUiModel>() {
+                override fun areContentsTheSame(
+                    oldItem: AlarmTypeUiModel,
+                    newItem: AlarmTypeUiModel,
+                ): Boolean = oldItem == newItem
+
+                override fun areItemsTheSame(
+                    oldItem: AlarmTypeUiModel,
+                    newItem: AlarmTypeUiModel
+                ): Boolean = oldItem == newItem
+
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariAlarmAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariAlarmAdapter.kt
@@ -5,8 +5,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.bottari.presentation.model.AlarmTypeUiModel
 
-class PersonalBottariAlarmAdapter() :
-    ListAdapter<AlarmTypeUiModel, PersonalBottariAlarmViewHolder>(DiffUtil) {
+class PersonalBottariAlarmAdapter : ListAdapter<AlarmTypeUiModel, PersonalBottariAlarmViewHolder>(DiffUtil) {
     override fun onBindViewHolder(
         holder: PersonalBottariAlarmViewHolder,
         position: Int,
@@ -29,9 +28,8 @@ class PersonalBottariAlarmAdapter() :
 
                 override fun areItemsTheSame(
                     oldItem: AlarmTypeUiModel,
-                    newItem: AlarmTypeUiModel
+                    newItem: AlarmTypeUiModel,
                 ): Boolean = oldItem == newItem
-
             }
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariAlarmViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariAlarmViewHolder.kt
@@ -62,9 +62,7 @@ class PersonalBottariAlarmViewHolder private constructor(
         }
 
     companion object {
-        fun from(
-            parent: ViewGroup,
-        ): PersonalBottariAlarmViewHolder {
+        fun from(parent: ViewGroup): PersonalBottariAlarmViewHolder {
             val inflater = LayoutInflater.from(parent.context)
             val binding = ItemChecklistAlarmBinding.inflate(inflater, parent, false)
             return PersonalBottariAlarmViewHolder(binding)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariAlarmViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariAlarmViewHolder.kt
@@ -1,0 +1,73 @@
+package com.bottari.presentation.view.edit.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bottari.presentation.R
+import com.bottari.presentation.databinding.ItemChecklistAlarmBinding
+import com.bottari.presentation.extension.formatWithPattern
+import com.bottari.presentation.model.AlarmTypeUiModel
+import java.time.DayOfWeek
+import java.time.format.TextStyle
+import java.util.Locale
+
+class PersonalBottariAlarmViewHolder private constructor(
+    private val binding: ItemChecklistAlarmBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+    private val dateFormat: String by lazy {
+        itemView.context.getString(R.string.bottari_item_alarm_date_format)
+    }
+    private val timeFormat: String by lazy {
+        itemView.context.getString(R.string.bottari_item_alarm_time_format)
+    }
+    private val separator: String by lazy {
+        itemView.context.getString(R.string.bottari_item_alarm_info_separator)
+    }
+
+    fun bind(item: AlarmTypeUiModel) {
+        when (item) {
+            is AlarmTypeUiModel.EveryDayRepeat -> {
+                binding.tvChecklistAlarmType.text = item.formatted()
+                binding.tvChecklistAlarmTime.text = item.time.formatWithPattern(timeFormat)
+            }
+
+            is AlarmTypeUiModel.EveryWeekRepeat -> {
+                binding.tvChecklistAlarmType.text = item.formatted()
+                binding.tvChecklistAlarmTime.text = item.time.formatWithPattern(timeFormat)
+            }
+
+            is AlarmTypeUiModel.NonRepeat -> {
+                binding.tvChecklistAlarmType.text = item.formatted()
+                binding.tvChecklistAlarmTime.text = item.time.formatWithPattern(timeFormat)
+            }
+        }
+    }
+
+    private fun AlarmTypeUiModel.NonRepeat.formatted(): String = date.formatWithPattern(dateFormat)
+
+    private fun AlarmTypeUiModel.EveryDayRepeat.formatted(): String =
+        itemView.context.getString(R.string.bottari_item_alarm_type_everyday_repeat)
+
+    private fun AlarmTypeUiModel.EveryWeekRepeat.formatted(): String =
+        buildString {
+            append(itemView.context.getString(R.string.bottari_item_alarm_type_everyweek_repeat))
+            append(separator)
+            append(
+                days.joinToString {
+                    DayOfWeek
+                        .of(it)
+                        .getDisplayName(TextStyle.SHORT, Locale.getDefault())
+                },
+            )
+        }
+
+    companion object {
+        fun from(
+            parent: ViewGroup,
+        ): PersonalBottariAlarmViewHolder {
+            val inflater = LayoutInflater.from(parent.context)
+            val binding = ItemChecklistAlarmBinding.inflate(inflater, parent, false)
+            return PersonalBottariAlarmViewHolder(binding)
+        }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariItemAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariItemAdapter.kt
@@ -5,9 +5,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.bottari.presentation.model.ItemUiModel
 
-class PersonalBottariItemAdapter() : ListAdapter<ItemUiModel, PersonalBottariItemViewHolder>(
-    DiffUtil
-) {
+class PersonalBottariItemAdapter :
+    ListAdapter<ItemUiModel, PersonalBottariItemViewHolder>(
+        DiffUtil,
+    ) {
     override fun onBindViewHolder(
         holder: PersonalBottariItemViewHolder,
         position: Int,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariItemAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariItemAdapter.kt
@@ -1,0 +1,37 @@
+package com.bottari.presentation.view.edit.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.bottari.presentation.model.ItemUiModel
+
+class PersonalBottariItemAdapter() : ListAdapter<ItemUiModel, PersonalBottariItemViewHolder>(
+    DiffUtil
+) {
+    override fun onBindViewHolder(
+        holder: PersonalBottariItemViewHolder,
+        position: Int,
+    ) {
+        holder.bind(getItem(position))
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): PersonalBottariItemViewHolder = PersonalBottariItemViewHolder.from(parent)
+
+    companion object {
+        private val DiffUtil =
+            object : DiffUtil.ItemCallback<ItemUiModel>() {
+                override fun areContentsTheSame(
+                    oldItem: ItemUiModel,
+                    newItem: ItemUiModel,
+                ): Boolean = oldItem == newItem
+
+                override fun areItemsTheSame(
+                    oldItem: ItemUiModel,
+                    newItem: ItemUiModel,
+                ): Boolean = oldItem.id == newItem.id
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariItemViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariItemViewHolder.kt
@@ -1,0 +1,28 @@
+package com.bottari.presentation.view.edit.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bottari.presentation.databinding.ItemChecklistMiniBinding
+import com.bottari.presentation.model.ItemUiModel
+
+class PersonalBottariItemViewHolder private constructor(
+    private val binding: ItemChecklistMiniBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+    private var itemId: Long? = null
+
+    fun bind(item: ItemUiModel) {
+        itemId = item.id
+        binding.tvChecklistItemMiniTitle.text = item.name
+    }
+
+    companion object {
+        fun from(
+            parent: ViewGroup,
+        ): PersonalBottariItemViewHolder {
+            val inflater = LayoutInflater.from(parent.context)
+            val binding = ItemChecklistMiniBinding.inflate(inflater, parent, false)
+            return PersonalBottariItemViewHolder(binding)
+        }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariItemViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/adapter/PersonalBottariItemViewHolder.kt
@@ -17,9 +17,7 @@ class PersonalBottariItemViewHolder private constructor(
     }
 
     companion object {
-        fun from(
-            parent: ViewGroup,
-        ): PersonalBottariItemViewHolder {
+        fun from(parent: ViewGroup): PersonalBottariItemViewHolder {
             val inflater = LayoutInflater.from(parent.context)
             val binding = ItemChecklistMiniBinding.inflate(inflater, parent, false)
             return PersonalBottariItemViewHolder(binding)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/BottariFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/BottariFragment.kt
@@ -21,16 +21,18 @@ import com.bottari.presentation.view.home.bottari.listener.OnBottariClickListene
 class BottariFragment : BaseFragment<FragmentBottariBinding>(FragmentBottariBinding::inflate) {
     private val viewModel: BottariViewModel by viewModels()
     private val adapter: BottariAdapter by lazy {
-        BottariAdapter(object : OnBottariClickListener {
-            override fun onClick(bottariId: Long) {
-                navigateToChecklist(bottariId)
-            }
-            override fun onMoreClick(bottariId: Long) {
-                navigateToEdit(bottariId)
-            }
-        })
-    }
+        BottariAdapter(
+            object : OnBottariClickListener {
+                override fun onClick(bottariId: Long) {
+                    navigateToChecklist(bottariId)
+                }
 
+                override fun onMoreClick(bottariId: Long) {
+                    navigateToEdit(bottariId)
+                }
+            },
+        )
+    }
 
     override fun onViewCreated(
         view: View,
@@ -96,7 +98,7 @@ class BottariFragment : BaseFragment<FragmentBottariBinding>(FragmentBottariBind
         startActivity(intent)
     }
 
-    private fun navigateToEdit(bottariId: Long){
+    private fun navigateToEdit(bottariId: Long) {
         val intent = PersonalBottariEditActivity.newIntent(requireContext(), bottariId)
         startActivity(intent)
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/BottariFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/BottariFragment.kt
@@ -13,16 +13,24 @@ import com.bottari.presentation.extension.fadeIn
 import com.bottari.presentation.extension.fadeOut
 import com.bottari.presentation.model.BottariUiModel
 import com.bottari.presentation.view.checklist.ChecklistActivity
+import com.bottari.presentation.view.edit.PersonalBottariEditActivity
 import com.bottari.presentation.view.home.bottari.adapter.BottariAdapter
 import com.bottari.presentation.view.home.bottari.create.BottariCreateDialog
+import com.bottari.presentation.view.home.bottari.listener.OnBottariClickListener
 
 class BottariFragment : BaseFragment<FragmentBottariBinding>(FragmentBottariBinding::inflate) {
     private val viewModel: BottariViewModel by viewModels()
     private val adapter: BottariAdapter by lazy {
-        BottariAdapter {
-            navigateToChecklist(it)
-        }
+        BottariAdapter(object : OnBottariClickListener {
+            override fun onClick(bottariId: Long) {
+                navigateToChecklist(bottariId)
+            }
+            override fun onMoreClick(bottariId: Long) {
+                navigateToEdit(bottariId)
+            }
+        })
     }
+
 
     override fun onViewCreated(
         view: View,
@@ -85,6 +93,11 @@ class BottariFragment : BaseFragment<FragmentBottariBinding>(FragmentBottariBind
 
     private fun navigateToChecklist(bottariId: Long) {
         val intent = ChecklistActivity.newIntent(requireContext(), bottariId)
+        startActivity(intent)
+    }
+
+    private fun navigateToEdit(bottariId: Long){
+        val intent = PersonalBottariEditActivity.newIntent(requireContext(), bottariId)
         startActivity(intent)
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/adapter/BottariViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/adapter/BottariViewHolder.kt
@@ -33,6 +33,10 @@ class BottariViewHolder private constructor(
         itemView.setOnClickListener {
             bottariId?.let { onBottariClickListener.onClick(it) }
         }
+
+        binding.btnBottariMore.setOnClickListener {
+            bottariId?.let { onBottariClickListener.onMoreClick(it) }
+        }
     }
 
     fun bind(bottari: BottariUiModel) {
@@ -55,13 +59,16 @@ class BottariViewHolder private constructor(
         return formatPattern.format(checked, total)
     }
 
-    private fun formatAlarmInfo(alarmType: AlarmTypeUiModel): String =
+    private fun formatAlarmInfo(alarmType: AlarmTypeUiModel?): String =
         when (alarmType) {
+
             is AlarmTypeUiModel.NonRepeat -> alarmType.formatted()
 
             is AlarmTypeUiModel.EveryDayRepeat -> alarmType.formatted()
 
             is AlarmTypeUiModel.EveryWeekRepeat -> alarmType.formatted()
+
+            null -> ""
         }
 
     private fun updateProgressBar(
@@ -128,15 +135,12 @@ class BottariViewHolder private constructor(
         color: Int,
     ): Drawable {
         if (drawable !is LayerDrawable) return drawable
-
         val progressLayer = drawable.findDrawableByLayerId(android.R.id.progress)
         val innerDrawable = (progressLayer as? ClipDrawable)?.drawable ?: return drawable
-
         when (innerDrawable) {
             is ShapeDrawable -> innerDrawable.paint.color = color
             is GradientDrawable -> innerDrawable.setColor(color)
         }
-
         return drawable
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/adapter/BottariViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/adapter/BottariViewHolder.kt
@@ -61,7 +61,6 @@ class BottariViewHolder private constructor(
 
     private fun formatAlarmInfo(alarmType: AlarmTypeUiModel?): String =
         when (alarmType) {
-
             is AlarmTypeUiModel.NonRepeat -> alarmType.formatted()
 
             is AlarmTypeUiModel.EveryDayRepeat -> alarmType.formatted()

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateDialog.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateDialog.kt
@@ -83,11 +83,10 @@ class BottariCreateDialog :
         }
     }
 
-    private fun navigateToEdit(){
+    private fun navigateToEdit() {
         val intent = Intent(requireContext(), PersonalBottariEditActivity::class.java)
         intent.putExtra(BOTTARI_ID, viewModel.bottariId)
         startActivity(intent)
-
     }
 
     companion object {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateDialog.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateDialog.kt
@@ -1,5 +1,6 @@
 package com.bottari.presentation.view.home.bottari.create
 
+import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -9,6 +10,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.bottari.presentation.databinding.DialogBottariCreateBinding
+import com.bottari.presentation.view.edit.PersonalBottariEditActivity
 
 class BottariCreateDialog :
     DialogFragment(),
@@ -77,10 +79,19 @@ class BottariCreateDialog :
         binding.btnBottariCreateClose.setOnClickListener { dismiss() }
         binding.btnBottariCreate.setOnClickListener {
             viewModel.createBottari(binding.etBottariCreateName.text.toString())
+            navigateToEdit()
         }
     }
 
+    private fun navigateToEdit(){
+        val intent = Intent(requireContext(), PersonalBottariEditActivity::class.java)
+        intent.putExtra(BOTTARI_ID, viewModel.bottariId)
+        startActivity(intent)
+
+    }
+
     companion object {
+        private const val BOTTARI_ID = "BOTTARI_ID"
         private const val DISABLED_ALPHA_VALUE = 0.4f
         private const val ENABLED_ALPHA_VALUE = 1f
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 
 class BottariCreateViewModel : ViewModel() {
     var bottariId: Int = 0
+
     fun createBottari(name: String) {
         bottariId = 1
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateViewModel.kt
@@ -3,6 +3,8 @@ package com.bottari.presentation.view.home.bottari.create
 import androidx.lifecycle.ViewModel
 
 class BottariCreateViewModel : ViewModel() {
+    var bottariId: Int = 0
     fun createBottari(name: String) {
+        bottariId = 1
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/listener/OnBottariClickListener.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/listener/OnBottariClickListener.kt
@@ -1,5 +1,6 @@
 package com.bottari.presentation.view.home.bottari.listener
 
-fun interface OnBottariClickListener {
+interface OnBottariClickListener {
     fun onClick(bottariId: Long)
+    fun onMoreClick(bottariId: Long)
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/listener/OnBottariClickListener.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/listener/OnBottariClickListener.kt
@@ -2,5 +2,6 @@ package com.bottari.presentation.view.home.bottari.listener
 
 interface OnBottariClickListener {
     fun onClick(bottariId: Long)
+
     fun onMoreClick(bottariId: Long)
 }

--- a/android/Bottari/presentation/src/main/res/drawable/bg_primary_radius_100dp.xml
+++ b/android/Bottari/presentation/src/main/res/drawable/bg_primary_radius_100dp.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <corners android:radius="100dp" />
+    <solid android:color="@color/primary" />
+
+</shape>

--- a/android/Bottari/presentation/src/main/res/drawable/bg_white_radius_12dp_dotted_boder.xml
+++ b/android/Bottari/presentation/src/main/res/drawable/bg_white_radius_12dp_dotted_boder.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <corners android:radius="12dp" />
+    <solid android:color="@color/white" />
+
+    <stroke
+        android:width="2dp"
+        android:color="@color/gray_a6a6a6"
+        android:dashWidth="5dp"
+        android:dashGap="5dp" />
+</shape>

--- a/android/Bottari/presentation/src/main/res/layout/activity_personal_bottari_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/activity_personal_bottari_edit.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.edit.PersonalBottariEditActivity">
+
+    <Toolbar
+        android:id="@+id/toolbar_edit"
+        style="@style/Pretendard_Medium_20"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:contentInsetStart="0dp"
+        android:titleTextColor="@color/black"
+        app:layout_constraintBottom_toTopOf="@id/fcv_edit"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/btn_previous"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/previous_button_description"
+            android:padding="@dimen/space_small"
+            android:src="@drawable/btn_previous" />
+
+        <TextView
+            android:id="@+id/tv_bottari_title"
+            style="@style/Pretendard_Bold_20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textColor="@color/black"
+            tools:text="나의 보따리" />
+
+        <ImageView
+            android:id="@+id/btn_swipe"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="end"
+            android:contentDescription="@string/bottari_item_more_button_description"
+            android:padding="@dimen/space_small"
+            android:src="@drawable/btn_more" />
+
+    </Toolbar>
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fcv_edit"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_edit" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Bottari/presentation/src/main/res/layout/fragment_main_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_main_edit.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    tools:context=".view.edit.MainEditFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_edit_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_large"
+            android:layout_marginBottom="@dimen/space_median"
+            android:background="@drawable/bg_white_radius_12dp"
+            android:elevation="2dp"
+            android:padding="@dimen/space_median"
+            app:layout_constraintBottom_toTopOf="@id/layout_edit_alarm"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/tv_edit_item"
+                style="@style/Pretendard_Bold_20"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bottari_edit_item_list_title"
+                android:textColor="@color/black"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_click_edit_item_description_notEmpty"
+                style="@style/Pretendard_Medium_14"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/space_x_small"
+                android:text="@string/bottari_edit_add_item_description"
+                android:textColor="@color/gray_a6a6a6"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_edit_item" />
+
+            <View
+                android:id="@+id/view_click_edit_item"
+                android:layout_width="0dp"
+                android:layout_height="150dp"
+                android:layout_margin="@dimen/space_median"
+                android:background="@drawable/bg_white_radius_12dp_dotted_boder"
+                android:elevation="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_edit_item" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_edit_item"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/space_median"
+                android:nestedScrollingEnabled="false"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_click_edit_item_description_notEmpty" />
+
+            <TextView
+                android:id="@+id/tv_click_edit_item_title"
+                style="@style/Pretendard_Bold_20"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bottari_edit_add_item_title"
+                android:textColor="@color/gray_a6a6a6"
+                app:layout_constraintBottom_toTopOf="@id/tv_click_edit_item_description"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/view_click_edit_item"
+                app:layout_constraintVertical_chainStyle="packed" />
+
+            <TextView
+                android:id="@+id/tv_click_edit_item_description"
+                style="@style/Pretendard_Medium_14"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/bottari_edit_add_item_description"
+                android:textColor="@color/gray_a6a6a6"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_click_edit_item_title" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_edit_alarm"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_large"
+            android:layout_marginTop="@dimen/space_x_large"
+            android:background="@drawable/bg_white_radius_12dp"
+            android:elevation="2dp"
+            android:padding="@dimen/space_median"
+            app:layout_constraintTop_toBottomOf="@id/layout_edit_item">
+
+            <TextView
+                android:id="@+id/tv_edit_alarm"
+                style="@style/Pretendard_Bold_20"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bottari_edit_alarm_list_title"
+                android:textColor="@color/black"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_click_edit_alarm_description_not_empty"
+                style="@style/Pretendard_Medium_14"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/space_x_small"
+                android:text="@string/bottari_edit_add_alarm_description"
+                android:textColor="@color/gray_a6a6a6"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_edit_alarm" />
+
+            <View
+                android:id="@+id/view_click_edit_alarm"
+                android:layout_width="0dp"
+                android:layout_height="150dp"
+                android:layout_margin="@dimen/space_median"
+                android:background="@drawable/bg_white_radius_12dp_dotted_boder"
+                android:elevation="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_edit_alarm" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_edit_alarm"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/space_median"
+                android:nestedScrollingEnabled="false"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_click_edit_alarm_description_not_empty" />
+
+            <TextView
+                android:id="@+id/tv_click_edit_alarm_title"
+                style="@style/Pretendard_Bold_20"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bottari_edit_add_alarm_title"
+                android:textColor="@color/gray_a6a6a6"
+                app:layout_constraintBottom_toTopOf="@id/tv_click_edit_alarm_description"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/view_click_edit_alarm"
+                app:layout_constraintVertical_chainStyle="packed" />
+
+            <TextView
+                android:id="@+id/tv_click_edit_alarm_description"
+                style="@style/Pretendard_Medium_14"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/bottari_edit_add_alarm_description"
+                android:textColor="@color/gray_a6a6a6"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_click_edit_alarm_title" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/android/Bottari/presentation/src/main/res/layout/item_checklist_alarm.xml
+++ b/android/Bottari/presentation/src/main/res/layout/item_checklist_alarm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/space_small">
+
+    <TextView
+        android:id="@+id/tv_checklist_alarm_time"
+        style="@style/Pretendard_Bold_32"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/space_small"
+        tools:text="10:00"
+        android:textColor="@color/black"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_checklist_alarm_type"
+        style="@style/Pretendard_Medium_16"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="매주 반복 | 월, 화, 수, 목, 금"
+        android:textColor="@color/black"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_checklist_alarm_time" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Bottari/presentation/src/main/res/layout/item_checklist_mini.xml
+++ b/android/Bottari/presentation/src/main/res/layout/item_checklist_mini.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/cl_checklist_item"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_primary_radius_100dp"
+    android:layout_marginStart="@dimen/space_x_small"
+    android:layout_marginTop="@dimen/space_x_small"
+    android:paddingHorizontal="@dimen/space_small"
+    android:paddingVertical="@dimen/space_x_small">
+
+    <TextView
+        android:id="@+id/tv_checklist_item_mini_title"
+        style="@style/Pretendard_Medium_14"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="시계" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Bottari/presentation/src/main/res/values/font_style.xml
+++ b/android/Bottari/presentation/src/main/res/values/font_style.xml
@@ -1,4 +1,9 @@
 <resources>
+    <style name="Pretendard_Bold_32">
+        <item name="fontFamily">@font/pretendard</item>
+        <item name="android:textFontWeight">700</item>
+        <item name="android:textSize">32sp</item>
+    </style>
 
     <style name="Pretendard_Bold_20">
         <item name="fontFamily">@font/pretendard</item>

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -30,4 +30,12 @@
     <string name="previous_button_description">뒤로가기 버튼</string>
     <string name="checklist_swipe_button_description">스와이프 화면 전환 버튼</string>
     <string name="dialog_bottari_create_close_button_description">보따리 생성 다이얼로그 닫기 버튼</string>
+
+    <!-- Bottari edit item -->
+    <string name="bottari_edit_item_list_title">물건 목록</string>
+    <string name="bottari_edit_add_item_title">물건 추가</string>
+    <string name="bottari_edit_add_item_description">여기를 눌러 보따리에 물건을 추가하세요</string>
+    <string name="bottari_edit_alarm_list_title">알람</string>
+    <string name="bottari_edit_add_alarm_description">여기를 눌러 알람을 설정하세요</string>
+    <string name="bottari_edit_add_alarm_title">알람 설정</string>
 </resources>


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
-  개인 보따리 편집 화면 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
Closed #37 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 개인 보따리 편집 화면 구현
- flexbox 의존성 추가

<br>

## 📸 스크린샷 (선택)
<img width="360" height="800" alt="Screenshot_20250721_142401" src="https://github.com/user-attachments/assets/8d294f9a-aebe-4327-aa8a-b38f232dbb31" />

<img width="360" height="800" alt="Screenshot_20250721_142414" src="https://github.com/user-attachments/assets/4a56e431-90ac-4c5e-b407-1cf6d05d713e" />

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- 삭제 및 공유 들어가는 툴바 버튼 기능 추가 필요
- 데이터 받는 부분은 임시로 작성, 차후 수정 필요
- 물건 목록, 알람 클릭 시 화면 전환 되는 기능 추가 필요
<br>
