### PR TITLE
[BE] 보따리 조회 시, 알람 ID 추가

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/dto/AlarmResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/AlarmResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 
 public record AlarmResponse(
+        Long id,
         RoutineAlarmResponse routine,
         LocationAlarmResponse location
 ) {
@@ -21,6 +22,7 @@ public record AlarmResponse(
         }
 
         return new AlarmResponse(
+                alarm.getId(),
                 RoutineAlarmResponse.from(alarm.getRoutineAlarm()),
                 LocationAlarmResponse.from(alarm.getLocationAlarm())
         );

--- a/backend/bottari/src/test/java/com/bottari/service/BottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/BottariServiceTest.java
@@ -67,13 +67,14 @@ class BottariServiceTest {
         final ReadBottariResponse actual = bottariService.getById(ssaid, bottari.getId());
 
         // then
-        assertAll(
-                () -> assertThat(actual.id()).isEqualTo(bottari.getId()),
-                () -> assertThat(actual.items()).hasSize(1),
-                () -> assertThat(actual.alarm()).isNotNull(),
-                () -> assertThat(actual.alarm().routine().type()).isEqualTo(RepeatType.EVERY_WEEK_REPEAT),
-                () -> assertThat(actual.alarm().location().latitude()).isEqualTo(37.5)
-        );
+        assertAll(() -> {
+            assertThat(actual.id()).isEqualTo(bottari.getId());
+            assertThat(actual.items()).hasSize(1);
+            assertThat(actual.alarm()).isNotNull();
+            assertThat(actual.alarm().id()).isEqualTo(alarm.getId());
+            assertThat(actual.alarm().routine().type()).isEqualTo(RepeatType.EVERY_WEEK_REPEAT);
+            assertThat(actual.alarm().location().latitude()).isEqualTo(37.5);
+        });
     }
 
     @DisplayName("본인의 보따리가 아닌 보따리를 조회할 경우, 예외를 던진다.")
@@ -140,15 +141,16 @@ class BottariServiceTest {
         final List<ReadBottariPreviewResponse> actual = bottariService.getAllBySsaid(ssaid);
 
         // then
-        assertAll(
-                () -> assertThat(actual).hasSize(2),
-                () -> assertThat(actual.get(0).totalItemsCount()).isEqualTo(2),
-                () -> assertThat(actual.get(0).checkedItemsCount()).isEqualTo(1),
-                () -> assertThat(actual.get(0).alarm()).isNotNull(),
-                () -> assertThat(actual.get(1).totalItemsCount()).isEqualTo(1),
-                () -> assertThat(actual.get(1).checkedItemsCount()).isEqualTo(0),
-                () -> assertThat(actual.get(1).alarm()).isNull()
-        );
+        assertAll(() -> {
+            assertThat(actual).hasSize(2);
+            assertThat(actual.getFirst().totalItemsCount()).isEqualTo(2);
+            assertThat(actual.getFirst().checkedItemsCount()).isEqualTo(1);
+            assertThat(actual.getFirst().alarm()).isNotNull();
+            assertThat(actual.getFirst().alarm().id()).isEqualTo(alarm.getId());
+            assertThat(actual.get(1).totalItemsCount()).isEqualTo(1);
+            assertThat(actual.get(1).checkedItemsCount()).isEqualTo(0);
+            assertThat(actual.get(1).alarm()).isNull();
+        });
     }
 
     @DisplayName("존재하지 않는 사용자의 모든 보따리를 조회할 경우, 예외를 던진다.")


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 보따리 조회 시, 알람 ID 추가

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #80 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 보따리 상세 조회 시, 알람 ID 추가
- 보따리 목록 조회 시, 알람 ID 추가
- 테스트 변경

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- 훌라 & 코기 페어 진행
<br>
