### PR TITLE
[BE] SSAID로 회원가입 여부 및 사용자 이름 조회 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/controller/MemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/MemberController.java
@@ -1,11 +1,14 @@
 package com.bottari.controller;
 
 import com.bottari.controller.docs.MemberApiDocs;
+import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
 import com.bottari.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +29,16 @@ public class MemberController implements MemberApiDocs {
         final Long id = memberService.create(request);
 
         return ResponseEntity.created(URI.create("/members/" + id)).build();
+    }
+
+    @GetMapping("/check")
+    @Override
+    public ResponseEntity<CheckRegistrationResponse> checkRegistration(
+            final HttpServletRequest httpServletRequest
+    ) {
+        final String ssaid = httpServletRequest.getHeader("ssaid");
+        final CheckRegistrationResponse response = memberService.checkRegistration(ssaid);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/controller/docs/MemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/docs/MemberApiDocs.java
@@ -1,12 +1,13 @@
 package com.bottari.controller.docs;
 
+import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Member", description = "사용자 API")
 public interface MemberApiDocs {
@@ -16,6 +17,14 @@ public interface MemberApiDocs {
             @ApiResponse(responseCode = "201", description = "사용자 등록 성공"),
     })
     ResponseEntity<Void> register(
-            @RequestBody final CreateMemberRequest request
+            final CreateMemberRequest request
+    );
+
+    @Operation(summary = "사용자 회원가입 여부 확인")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 회원가입 여부 확인 성공"),
+    })
+    ResponseEntity<CheckRegistrationResponse> checkRegistration(
+            final HttpServletRequest httpServletRequest
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/dto/CheckRegistrationResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/CheckRegistrationResponse.java
@@ -1,0 +1,7 @@
+package com.bottari.dto;
+
+public record CheckRegistrationResponse(
+        boolean isRegistered,
+        String name
+) {
+}

--- a/backend/bottari/src/main/java/com/bottari/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/MemberService.java
@@ -1,8 +1,10 @@
 package com.bottari.service;
 
 import com.bottari.domain.Member;
+import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
 import com.bottari.repository.MemberRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,5 +28,16 @@ public class MemberService {
         if (memberRepository.existsBySsaid(ssaid)) {
             throw new IllegalArgumentException("중복된 ssaid입니다.");
         }
+    }
+
+    public CheckRegistrationResponse checkRegistration(final String ssaid) {
+        final Optional<Member> optionalMember = memberRepository.findBySsaid(ssaid);
+        if (optionalMember.isPresent()) {
+            final Member member = optionalMember.get();
+
+            return new CheckRegistrationResponse(true, member.getName());
+        }
+
+        return new CheckRegistrationResponse(false, null);
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
@@ -1,10 +1,13 @@
 package com.bottari.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
 import com.bottari.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,5 +46,24 @@ class MemberControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/members/1"));
+    }
+
+    @DisplayName("사용자의 회원가입 여부를 확인한다.")
+    @Test
+    void checkRegistration() throws Exception {
+        // given
+        final String ssaid = "ssaid";
+        final CheckRegistrationResponse response = new CheckRegistrationResponse(
+                true,
+                "name"
+        );
+        given(memberService.checkRegistration(ssaid))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/members/check")
+                        .header("ssaid", ssaid))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(response)));
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
@@ -2,8 +2,10 @@ package com.bottari.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.bottari.domain.Member;
+import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -47,5 +49,39 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.create(request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("중복된 ssaid입니다.");
+    }
+
+    @DisplayName("사용자 회원가입 여부를 확인할 때 가입된 ssaid라면, true와 사용자 이름을 반환한다.")
+    @Test
+    void checkRegistration() {
+        // given
+        final String ssaid = "ssaid";
+        final String name = "name";
+        entityManager.persist(new Member(ssaid, name));
+
+        // when
+        final CheckRegistrationResponse actual = memberService.checkRegistration(ssaid);
+
+        // then
+        assertAll(() -> {
+            assertThat(actual.isRegistered()).isTrue();
+            assertThat(actual.name()).isEqualTo(name);
+        });
+    }
+
+    @DisplayName("사용자 회원가입 여부를 확인할 때 가입되지 않은 ssaid라면, false와 null을 반환한다.")
+    @Test
+    void checkRegistration_unregister() {
+        // given
+        final String unregisteredSsaid = "ssaid";
+
+        // when
+        final CheckRegistrationResponse actual = memberService.checkRegistration(unregisteredSsaid);
+
+        // then
+        assertAll(() -> {
+            assertThat(actual.isRegistered()).isFalse();
+            assertThat(actual.name()).isNull();
+        });
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- SSAID로 회원가입 여부 및 사용자 이름 조회 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #74

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- SSAID로 회원가입 여부 및 사용자 이름 조회 기능 구현
  - 가입된 SSAID 일 시, true / name
  - 미가입된 SSAID 일 시, false / null

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- 벨로 호떡 2인 페어 진행