### PR TITLE
[AN] PermissionUtil 구현

### DIFF
--- a/android/Bottari/presentation/src/main/AndroidManifest.xml
+++ b/android/Bottari/presentation/src/main/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <application>
         <activity
             android:name=".view.home.HomeActivity"

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/permission/PermissionUtil.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/permission/PermissionUtil.kt
@@ -36,20 +36,12 @@ object PermissionUtil {
 
     fun requestExactAlarmPermission(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val intent =
-                Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
-                    data = "package:${context.packageName}".toUri()
-                }
-            context.startActivity(intent)
+            navigateToSettings(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, context)
         }
     }
 
     fun openAppSettings(context: Context) {
-        val intent =
-            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                data = "package:${context.packageName}".toUri()
-            }
-        context.startActivity(intent)
+        navigateToSettings(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, context)
     }
 
     fun isPermanentlyDenied(fragment: Fragment): Boolean =
@@ -60,4 +52,16 @@ object PermissionUtil {
             ) != PackageManager.PERMISSION_GRANTED &&
                 !fragment.shouldShowRequestPermissionRationale(permission)
         }
+
+    private fun navigateToSettings(
+        settingFlag: String,
+        context: Context,
+    ) {
+        val intent =
+            Intent(settingFlag).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                data = "package:${context.packageName}".toUri()
+            }
+        context.startActivity(intent)
+    }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/permission/PermissionUtil.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/permission/PermissionUtil.kt
@@ -1,0 +1,63 @@
+package com.bottari.presentation.util.permission
+
+import android.app.AlarmManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
+import androidx.fragment.app.Fragment
+
+object PermissionUtil {
+    fun getRequiredPermissions(): Array<String> {
+        val permissions = mutableListOf<String>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            permissions += android.Manifest.permission.POST_NOTIFICATIONS
+        }
+        permissions += android.Manifest.permission.ACCESS_FINE_LOCATION
+        permissions += android.Manifest.permission.ACCESS_COARSE_LOCATION
+        return permissions.toTypedArray()
+    }
+
+    fun hasAllRuntimePermissions(context: Context): Boolean =
+        getRequiredPermissions().all {
+            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+        }
+
+    fun hasExactAlarmPermission(context: Context): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val alarmManager = context.getSystemService(AlarmManager::class.java)
+            alarmManager.canScheduleExactAlarms()
+        } else {
+            true
+        }
+
+    fun requestExactAlarmPermission(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val intent =
+                Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                    data = "package:${context.packageName}".toUri()
+                }
+            context.startActivity(intent)
+        }
+    }
+
+    fun openAppSettings(context: Context) {
+        val intent =
+            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = "package:${context.packageName}".toUri()
+            }
+        context.startActivity(intent)
+    }
+
+    fun isPermanentlyDenied(fragment: Fragment): Boolean =
+        getRequiredPermissions().any { permission ->
+            ContextCompat.checkSelfPermission(
+                fragment.requireContext(),
+                permission,
+            ) != PackageManager.PERMISSION_GRANTED &&
+                !fragment.shouldShowRequestPermissionRationale(permission)
+        }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/permission/PermissionUtil.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/permission/PermissionUtil.kt
@@ -1,5 +1,6 @@
 package com.bottari.presentation.util.permission
 
+import android.Manifest
 import android.app.AlarmManager
 import android.content.Context
 import android.content.Intent
@@ -11,18 +12,17 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 
 object PermissionUtil {
-    fun getRequiredPermissions(): Array<String> {
-        val permissions = mutableListOf<String>()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            permissions += android.Manifest.permission.POST_NOTIFICATIONS
-        }
-        permissions += android.Manifest.permission.ACCESS_FINE_LOCATION
-        permissions += android.Manifest.permission.ACCESS_COARSE_LOCATION
-        return permissions.toTypedArray()
+    val requiredPermissions: Array<String> by lazy {
+        buildList {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+            add(Manifest.permission.ACCESS_FINE_LOCATION)
+        }.toTypedArray()
     }
 
     fun hasAllRuntimePermissions(context: Context): Boolean =
-        getRequiredPermissions().all {
+        requiredPermissions.all {
             ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
         }
 
@@ -45,7 +45,7 @@ object PermissionUtil {
     }
 
     fun isPermanentlyDenied(fragment: Fragment): Boolean =
-        getRequiredPermissions().any { permission ->
+        requiredPermissions.any { permission ->
             ContextCompat.checkSelfPermission(
                 fragment.requireContext(),
                 permission,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
@@ -24,7 +24,6 @@ import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
-import com.google.android.material.snackbar.Snackbar
 
 class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBinding>(FragmentPersonalBottariEditBinding::inflate) {
     private val viewModel: PersonalBottariEditViewModel by viewModels {
@@ -44,7 +43,7 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
                 if (PermissionUtil.isPermanentlyDenied(this)) {
                     showSettingsDialog()
                 } else {
-                    Snackbar.make(binding.root, "권한 요청에 실패했어요.", Snackbar.LENGTH_SHORT).show()
+                    showSnackbar(R.string.alarm_edit_permission_failure_text)
                 }
             }
         }
@@ -173,17 +172,30 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
             navigateToScreen(AlarmEditFragment::class.java, AlarmEditFragment.newBundle())
             return
         }
-        PermissionUtil.requestExactAlarmPermission(requireContext())
+        showExactAlarmSettingsDialog()
     }
 
     private fun showSettingsDialog() {
         AlertDialog
             .Builder(requireContext())
-            .setTitle("권한이 필요합니다")
-            .setMessage("앱 기능을 사용하려면 권한을 허용해야 합니다. 설정 화면으로 이동하시겠습니까?")
-            .setPositiveButton("설정으로 이동") { _, _ ->
+            .setTitle(R.string.alarm_edit_permission_dialog_title_text)
+            .setMessage(R.string.alarm_edit_permission_dialog_message_text)
+            .setPositiveButton(R.string.alarm_edit_permission_dialog_positive_btn_text) { _, _ ->
                 PermissionUtil.openAppSettings(requireContext())
-            }.setNegativeButton("취소", null)
+            }.setNegativeButton(R.string.alarm_edit_permission_dialog_negative_btn_text, null)
+            .show()
+    }
+
+    private fun showExactAlarmSettingsDialog() {
+        AlertDialog
+            .Builder(requireContext())
+            .setTitle(R.string.alarm_edit_permission_dialog_title_text)
+            .setMessage(R.string.alarm_edit_exact_alarm_permission_dialog_message_text)
+            .setPositiveButton(R.string.alarm_edit_permission_dialog_positive_btn_text) { _, _ ->
+                PermissionUtil.requestExactAlarmPermission(
+                    requireContext(),
+                )
+            }.setNegativeButton(R.string.alarm_edit_permission_dialog_negative_btn_text, null)
             .show()
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
@@ -16,6 +16,7 @@ import com.bottari.presentation.model.AlarmUiModel
 import com.bottari.presentation.model.BottariItemUiModel
 import com.bottari.presentation.model.BottariUiModel
 import com.bottari.presentation.util.permission.PermissionUtil
+import com.bottari.presentation.util.permission.PermissionUtil.requiredPermissions
 import com.bottari.presentation.view.edit.alarm.AlarmEditFragment
 import com.bottari.presentation.view.edit.personal.item.PersonalItemEditFragment
 import com.bottari.presentation.view.edit.personal.main.adapter.PersonalBottariEditAlarmAdapter
@@ -31,7 +32,6 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
     }
     private val itemAdapter: PersonalBottariEditItemAdapter by lazy { PersonalBottariEditItemAdapter() }
     private val alarmAdapter: PersonalBottariEditAlarmAdapter by lazy { PersonalBottariEditAlarmAdapter() }
-
     private val permissionLauncher =
         registerForActivityResult(
             ActivityResultContracts.RequestMultiplePermissions(),
@@ -84,7 +84,7 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
                 checkAndRequestSpecialPermission()
                 return@setOnClickListener
             }
-            permissionLauncher.launch(PermissionUtil.getRequiredPermissions())
+            permissionLauncher.launch(requiredPermissions)
         }
     }
 

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -49,6 +49,12 @@
     <string name="bottari_edit_add_alarm_title">알람 설정</string>
     <string name="current_location_button_description">현재 위치 버튼</string>
     <string name="alarm_edit_close_button_description">편집 종료 버튼</string>
+    <string name="alarm_edit_permission_dialog_title_text">권한 알림</string>
+    <string name="alarm_edit_permission_dialog_message_text">"앱 기능을 사용하려면 권한이 필요해요.\n설정 화면으로 이동하시겠어요?"</string>
+    <string name="alarm_edit_exact_alarm_permission_dialog_message_text">보따리 알림을 받으려면 권한이 필요해요.\n설정 화면으로 이동하시겠어요?</string>
+    <string name="alarm_edit_permission_dialog_positive_btn_text">이동</string>
+    <string name="alarm_edit_permission_dialog_negative_btn_text">취소</string>
+    <string name="alarm_edit_permission_failure_text">권한 요청에 실패했어요.</string>
 
     <!--  Description  -->
     <string name="bottari_item_more_button_description">보따리 옵션 버튼</string>


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 권한 관리 클래스 PermissionUtil 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #50 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 권한 관리 로직을 담당하는 PermissionUtil 구현
- 위치 권한 추가 (`ACCESS_COARSE_LOCATION`, `ACCESS_FINE_LOCATION`)
- 알람 권한 추가 (`SCHEDULE_EXACT_ALARM`, `POST_NOTIFICATIONS`)
 
### 권한 요청 플로우
1. 알람 클릭 시 위치 및 알람 권한 요청 (모든 권한 허용 시 알람 편집 화면으로 이동)
2. 권한 거절 시 스낵바 출력
3. 권한 요청 2회 이상 실패할 경우 설정 화면 이동 여부를 묻는 다이얼로그 출력
4. 영구적으로 권한 거절 시 알람 편집 화면으로 이동하지 않음

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
| 권한 요청 | 권한 거절 | 설정 이동 (런타임 권한) | 설정 이동 (특별 권한) |
|--------|-------|-------|-------|
| <img width="160" height="356" alt="image" src="https://github.com/user-attachments/assets/de8f46cc-d0f6-4ed4-8640-94cba5e4c48b" />| <img width="160" height="356" alt="image" src="https://github.com/user-attachments/assets/35c1b98b-e67d-4818-b73f-e69b908c638e" /> | <img width="160" height="356" alt="image" src="https://github.com/user-attachments/assets/7e7edc4a-3bb1-4522-9c4c-79fc9dd22d2a" /> | <img width="160" height="356" alt="image" src="https://github.com/user-attachments/assets/13122108-31c2-4ede-bda3-89dbd088dea5" /> |

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

### 고려할 점
- [구글에서 권장하는 권한 요청 플로우](https://developer.android.com/training/permissions/requesting?hl=ko) 준수 (영구적으로 권한 거절 시 알람 기능 제한 등)
- 설정 이동 다이얼로그 UI 개선
- 권한 관리 기능 추상화
- 정확한 위치 / 대략적인 위치 권한 구별

<br>
