### PR TITLE
[BE] 전역 예외 핸들링 추가 및 예외 응답 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/GlobalExceptionHandler.java
+++ b/backend/bottari/src/main/java/com/bottari/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.bottari;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({
+            IllegalArgumentException.class,
+            IllegalStateException.class
+    })
+    public ProblemDetail handleIllegalException(
+            final RuntimeException exception,
+            final HttpServletRequest request
+    ) {
+        log.warn("Request URL: {} | Exception: {}", request.getRequestURI(), exception.getMessage());
+
+        return ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                exception.getMessage()
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleException(
+            final Exception exception,
+            final HttpServletRequest request
+    ) {
+        log.error("Request URL: {} | Exception: {}", request.getRequestURI(), exception.getMessage());
+
+        return ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "예상치 못한 서버 에러입니다. 관리자(코기)를 찾아가세요."
+        );
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 전역 예외 핸들링 추가하고 및 예외 응답을 하도록 한다.

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #72 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- `@ControllerAdvice`와 `@ExceptionHandler` 전역 예외를 핸들링 하도록 구현
- 전역 예외 핸들러에서 예외 메시지를 담은 ProblemDetails를 응답하도록 구현
- 에러를 핸들링하여 stack trace가 콘솔 로그에 안뜨므로, 예외 상황을 간단한 로깅하는 기능 구현

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- 호떡, 코기, 벨로 3인 페어 진행
<br>
