### PR TITLE
[AN] 개인 보따리 물건 편집 화면 API 연동

### DIFF
--- a/android/Bottari/data/src/main/java/com/bottari/data/model/item/SaveBottariItemsRequest.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/item/SaveBottariItemsRequest.kt
@@ -1,0 +1,12 @@
+package com.bottari.data.model.item
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SaveBottariItemsRequest(
+    @SerialName("createItemNames")
+    val createItemNames: List<String>,
+    @SerialName("deleteItemIds")
+    val deleteItemIds: List<Int>,
+)

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/item/SaveBottariItemsRequest.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/item/SaveBottariItemsRequest.kt
@@ -8,5 +8,5 @@ data class SaveBottariItemsRequest(
     @SerialName("createItemNames")
     val createItemNames: List<String>,
     @SerialName("deleteItemIds")
-    val deleteItemIds: List<Int>,
+    val deleteItemIds: List<Long>,
 )

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/BottariItemRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/BottariItemRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.bottari.data.repository
 
 import com.bottari.data.mapper.BottariItemMapper.toDomain
+import com.bottari.data.model.item.SaveBottariItemsRequest
 import com.bottari.data.source.remote.BottariItemRemoteDataSource
 import com.bottari.domain.model.bottari.BottariItem
 import com.bottari.domain.repository.BottariItemRepository
@@ -25,4 +26,19 @@ class BottariItemRepositoryImpl(
         ssaid: String,
         bottariItemId: Long,
     ): Result<Unit> = bottariItemRemoteDataSource.checkBottariItem(ssaid, bottariItemId)
+
+    override suspend fun saveBottariItems(
+        ssaid: String,
+        bottariId: Long,
+        deleteItemIds: List<Long>,
+        createItemNames: List<String>,
+    ): Result<Unit> =
+        bottariItemRemoteDataSource.saveBottariItems(
+            ssaid,
+            bottariId,
+            SaveBottariItemsRequest(
+                deleteItemIds = deleteItemIds,
+                createItemNames = createItemNames,
+            ),
+        )
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/service/BottariItemService.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/service/BottariItemService.kt
@@ -1,7 +1,9 @@
 package com.bottari.data.service
 
 import com.bottari.data.model.item.FetchChecklistResponse
+import com.bottari.data.model.item.SaveBottariItemsRequest
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.PATCH
@@ -24,5 +26,12 @@ interface BottariItemService {
     suspend fun checkBottariItem(
         @Header("ssaid") ssaid: String,
         @Path("id") bottariItemId: Long,
+    ): Response<Unit>
+
+    @PATCH("/bottaries/{bottariId}/bottari-items")
+    suspend fun saveBottariItems(
+        @Header("ssaid") ssaid: String,
+        @Path("bottariId") bottariId: Long,
+        @Body request: SaveBottariItemsRequest,
     ): Response<Unit>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/service/BottariService.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/service/BottariService.kt
@@ -25,6 +25,6 @@ interface BottariService {
     @POST("/bottaries")
     suspend fun createBottari(
         @Header("ssaid") ssaid: String,
-        @Body body: CreateBottariRequest,
+        @Body request: CreateBottariRequest,
     ): Response<Unit>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/BottariItemRemoteDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/BottariItemRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.bottari.data.source.remote
 
 import com.bottari.data.model.item.FetchChecklistResponse
+import com.bottari.data.model.item.SaveBottariItemsRequest
 
 interface BottariItemRemoteDataSource {
     suspend fun fetchChecklist(
@@ -16,5 +17,11 @@ interface BottariItemRemoteDataSource {
     suspend fun checkBottariItem(
         ssaid: String,
         bottariItemId: Long,
+    ): Result<Unit>
+
+    suspend fun saveBottariItems(
+        ssaid: String,
+        bottariId: Long,
+        request: SaveBottariItemsRequest,
     ): Result<Unit>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/BottariItemRemoteDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/BottariItemRemoteDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.bottari.data.source.remote
 
 import com.bottari.data.model.item.FetchChecklistResponse
+import com.bottari.data.model.item.SaveBottariItemsRequest
 import com.bottari.data.service.BottariItemService
 import com.bottari.data.util.safeApiCall
 
@@ -29,5 +30,14 @@ class BottariItemRemoteDataSourceImpl(
     ): Result<Unit> =
         safeApiCall {
             bottariItemService.checkBottariItem(ssaid, bottariItemId)
+        }
+
+    override suspend fun saveBottariItems(
+        ssaid: String,
+        bottariId: Long,
+        request: SaveBottariItemsRequest,
+    ): Result<Unit> =
+        safeApiCall {
+            bottariItemService.saveBottariItems(ssaid, bottariId, request)
         }
 }

--- a/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
@@ -6,6 +6,7 @@ import com.bottari.domain.usecase.bottari.FetchBottariesUseCase
 import com.bottari.domain.usecase.bottariDetail.FindBottariDetailUseCase
 import com.bottari.domain.usecase.item.CheckBottariItemUseCase
 import com.bottari.domain.usecase.item.FetchChecklistUseCase
+import com.bottari.domain.usecase.item.SaveBottariItemsUseCase
 import com.bottari.domain.usecase.item.UnCheckBottariItemUseCase
 import com.bottari.domain.usecase.member.RegisterMemberUseCase
 import com.bottari.domain.usecase.template.FetchBottariTemplatesUseCase
@@ -59,6 +60,11 @@ object UseCaseProvider {
     val searchBottariTemplatesUseCase by lazy {
         SearchBottariTemplatesUseCase(
             RepositoryProvider.bottariTemplateRepository,
+        )
+    }
+    val saveBottariItemsUseCase by lazy {
+        SaveBottariItemsUseCase(
+            RepositoryProvider.bottariItemRepository,
         )
     }
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/BottariItemRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/BottariItemRepository.kt
@@ -17,4 +17,11 @@ interface BottariItemRepository {
         ssaid: String,
         bottariItemId: Long,
     ): Result<Unit>
+
+    suspend fun saveBottariItems(
+        ssaid: String,
+        bottariId: Long,
+        deleteItemIds: List<Long>,
+        createItemNames: List<String>,
+    ): Result<Unit>
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/item/SaveBottariItemsUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/item/SaveBottariItemsUseCase.kt
@@ -1,0 +1,14 @@
+package com.bottari.domain.usecase.item
+
+import com.bottari.domain.repository.BottariItemRepository
+
+class SaveBottariItemsUseCase(
+    private val bottariItemRepository: BottariItemRepository,
+) {
+    suspend operator fun invoke(
+        ssaid: String,
+        bottariId: Long,
+        deleteItemIds: List<Long>,
+        createItemNames: List<String>,
+    ): Result<Unit> = bottariItemRepository.saveBottariItems(ssaid, bottariId, deleteItemIds, createItemNames)
+}

--- a/android/Bottari/presentation/build.gradle.kts
+++ b/android/Bottari/presentation/build.gradle.kts
@@ -3,6 +3,7 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("kotlin-parcelize")
 }
 
 android {
@@ -18,7 +19,8 @@ android {
         val devId = gradleLocalProperties(rootDir, providers).getProperty("DEV_ID") ?: ""
         buildConfigField("String", "DEV_ID", "\"$devId\"")
 
-        val privacyPolicyUrl = gradleLocalProperties(rootDir, providers).getProperty("PRIVACY_POLICY_URL") ?: ""
+        val privacyPolicyUrl =
+            gradleLocalProperties(rootDir, providers).getProperty("PRIVACY_POLICY_URL") ?: ""
         buildConfigField("String", "PRIVACY_POLICY_URL", "\"$privacyPolicyUrl\"")
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/extension/ParcelableExtension.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/extension/ParcelableExtension.kt
@@ -1,0 +1,26 @@
+package com.bottari.presentation.extension
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
+
+inline fun <reified T : Parcelable> Intent?.getParcelableCompat(key: String): T {
+    val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        this?.getParcelableExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        this?.getParcelableExtra(key) as? T
+    }
+    return result ?: error("Parcelable extra '$key' not found in intent")
+}
+
+inline fun <reified T : Parcelable> Bundle?.getParcelableCompat(key: String): T {
+    val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        this?.getParcelable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        this?.getParcelable(key) as? T
+    }
+    return result ?: error("Parcelable extra '$key' not found in bundle")
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/extension/ParcelableExtension.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/extension/ParcelableExtension.kt
@@ -6,21 +6,23 @@ import android.os.Bundle
 import android.os.Parcelable
 
 inline fun <reified T : Parcelable> Intent?.getParcelableCompat(key: String): T {
-    val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        this?.getParcelableExtra(key, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        this?.getParcelableExtra(key) as? T
-    }
+    val result =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            this?.getParcelableExtra(key, T::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            this?.getParcelableExtra(key) as? T
+        }
     return result ?: error("Parcelable extra '$key' not found in intent")
 }
 
 inline fun <reified T : Parcelable> Bundle?.getParcelableCompat(key: String): T {
-    val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        this?.getParcelable(key, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        this?.getParcelable(key) as? T
-    }
+    val result =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            this?.getParcelable(key, T::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            this?.getParcelable(key) as? T
+        }
     return result ?: error("Parcelable extra '$key' not found in bundle")
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/AlarmUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/AlarmUiModel.kt
@@ -1,9 +1,12 @@
 package com.bottari.presentation.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
 
+@Parcelize
 data class AlarmUiModel(
     val id: Long? = null,
     val isActive: Boolean,
@@ -12,7 +15,7 @@ data class AlarmUiModel(
     val date: LocalDate,
     val daysOfWeek: List<DayOfWeekUiModel>,
     val locationAlarm: LocationAlarmUiModel? = null,
-) {
+) : Parcelable {
     companion object {
         val DEFAULT_ALARM_UI_MODEL =
             AlarmUiModel(

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/BottariDetailUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/BottariDetailUiModel.kt
@@ -1,8 +1,12 @@
 package com.bottari.presentation.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class BottariDetailUiModel(
     val id: Long,
     val title: String,
     val alarm: AlarmUiModel?,
     val items: List<BottariItemUiModel> = emptyList(),
-)
+) : Parcelable

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/BottariItemUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/BottariItemUiModel.kt
@@ -1,7 +1,11 @@
 package com.bottari.presentation.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class BottariItemUiModel(
     val id: Long,
     val name: String,
     val isChecked: Boolean,
-)
+) : Parcelable

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/DayOfWeekUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/DayOfWeekUiModel.kt
@@ -1,8 +1,11 @@
 package com.bottari.presentation.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import java.time.DayOfWeek
 
+@Parcelize
 data class DayOfWeekUiModel(
     val dayOfWeek: DayOfWeek,
     val isChecked: Boolean,
-)
+) : Parcelable

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/LocationAlarmUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/LocationAlarmUiModel.kt
@@ -1,8 +1,12 @@
 package com.bottari.presentation.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class LocationAlarmUiModel(
     val latitude: Double,
     val longitude: Double,
     val radius: Int,
     val isActive: Boolean,
-)
+) : Parcelable

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
@@ -17,6 +17,8 @@ import com.bottari.presentation.base.BaseFragment
 import com.bottari.presentation.base.UiState
 import com.bottari.presentation.databinding.FragmentPersonalItemEditBinding
 import com.bottari.presentation.extension.dpToPx
+import com.bottari.presentation.extension.getParcelableCompat
+import com.bottari.presentation.model.BottariDetailUiModel
 import com.bottari.presentation.model.BottariItemUiModel
 import com.bottari.presentation.view.edit.personal.item.adapter.PersonalItemEditAdapter
 
@@ -24,7 +26,9 @@ class PersonalItemEditFragment :
     BaseFragment<FragmentPersonalItemEditBinding>(FragmentPersonalItemEditBinding::inflate),
     TextWatcher {
     private val viewModel: PersonalItemEditViewModel by viewModels {
-        PersonalItemEditViewModel.Factory(getBottariId())
+        val bottariDetail =
+            arguments.getParcelableCompat<BottariDetailUiModel>(EXTRA_BOTTARI_DETAIL)
+        PersonalItemEditViewModel.Factory(bottariDetail)
     }
 
     private val adapter by lazy {
@@ -90,8 +94,6 @@ class PersonalItemEditFragment :
         }
     }
 
-    private fun getBottariId(): Long = arguments?.getLong(EXTRA_BOTTARI_ID) ?: INVALID_BOTTARI_ID
-
     private fun setupInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
             val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
@@ -140,12 +142,8 @@ class PersonalItemEditFragment :
         }
     }
 
-    private fun handleBottariNameState(uiState: UiState<String>) {
-        when (uiState) {
-            is UiState.Loading -> Unit
-            is UiState.Success -> binding.tvBottariTitle.text = uiState.data
-            is UiState.Failure -> Unit
-        }
+    private fun handleBottariNameState(title: String) {
+        binding.tvBottariTitle.text = title
     }
 
     private fun handleItemState(uiState: UiState<List<BottariItemUiModel>>) {
@@ -157,17 +155,16 @@ class PersonalItemEditFragment :
     }
 
     companion object {
-        private const val INVALID_BOTTARI_ID = -1L
-        private const val EXTRA_BOTTARI_ID = "EXTRA_BOTTARI_ID"
+        private const val EXTRA_BOTTARI_DETAIL = "EXTRA_BOTTARI_DETAIL"
 
         private const val DUPLICATE_BORDER_WIDTH_DP = 2
         private const val DISABLED_ALPHA = 0.3f
         private const val ENABLED_ALPHA = 1f
         private const val DEFAULT_BOTTOM_INSET = 0
 
-        fun newBundle(bottariId: Long) =
+        fun newBundle(bottariDetail: BottariDetailUiModel) =
             Bundle().apply {
-                putLong(EXTRA_BOTTARI_ID, bottariId)
+                putParcelable(EXTRA_BOTTARI_DETAIL, bottariDetail)
             }
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
@@ -6,67 +6,105 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.bottari.di.UseCaseProvider
+import com.bottari.domain.usecase.item.SaveBottariItemsUseCase
 import com.bottari.presentation.base.UiState
-import com.bottari.presentation.extension.takeSuccess
 import com.bottari.presentation.model.BottariDetailUiModel
 import com.bottari.presentation.model.BottariItemUiModel
+import kotlinx.coroutines.launch
 
 class PersonalItemEditViewModel(
     stateHandle: SavedStateHandle,
+    private val saveBottariItemsUseCase: SaveBottariItemsUseCase,
 ) : ViewModel() {
-    private var bottariId: Long? = null
+    private val ssaid: String =
+        stateHandle.get<String>(EXTRA_BOTTARI_ID) ?: error(ERROR_REQUIRE_SSAID)
+    private val bottariDetail: BottariDetailUiModel =
+        stateHandle.get(EXTRA_BOTTARI_DETAIL) ?: error(ERROR_REQUIRE_BOTTARI_DATA)
 
-    private val _bottariName: MutableLiveData<String> = MutableLiveData<String>()
+    private val bottariId: Long = bottariDetail.id
+    private val createItemNames = mutableSetOf<String>()
+    private val deleteItems = mutableSetOf<BottariItemUiModel>()
+
+    private val _saveState = MutableLiveData<UiState<Unit>>()
+    val saveState: LiveData<UiState<Unit>> get() = _saveState
+
+    private val _bottariName = MutableLiveData(bottariDetail.title)
     val bottariName: LiveData<String> get() = _bottariName
 
-    private val _items = MutableLiveData<UiState<List<BottariItemUiModel>>>(UiState.Loading)
-    val items: LiveData<UiState<List<BottariItemUiModel>>> = _items
+    private val _items = MutableLiveData<List<BottariItemUiModel>>(bottariDetail.items)
+    val items: LiveData<List<BottariItemUiModel>> get() = _items
 
-    init {
-        val bottariDetail = stateHandle.get<BottariDetailUiModel>(EXTRA_BOTTARI_DETAIL) ?: error("")
-        setupData(bottariDetail)
-    }
+    private val currentList: List<BottariItemUiModel> get() = _items.value ?: emptyList()
 
     fun addItem(itemName: String) {
-        if (itemName.isBlank()) return
+        if (itemName.isBlank() || isAlreadyExistItem(itemName)) return
 
-        val currentList = _items.value?.takeSuccess() ?: return
-        if (currentList.any { item -> item.name == itemName }) return
+        val restored = deleteItems.find { it.name == itemName }
+        if (restored != null) {
+            deleteItems.remove(restored)
+            _items.value = currentList + restored
+            return
+        }
 
-        val updatedList = currentList + createItem(itemName)
-        _items.value = UiState.Success(updatedList)
+        _items.value = currentList + createNewItem(itemName)
+        createItemNames.add(itemName)
     }
 
     fun deleteItem(itemId: Long) {
-        val currentList = _items.value?.takeSuccess() ?: return
-        val updatedList = currentList.filterNot { it.id == itemId }
-        _items.value = UiState.Success(updatedList)
+        val updated = currentList.filterNot { it.id == itemId }
+        val deleted = currentList.find { it.id == itemId } ?: return
+
+        _items.value = updated
+        deleteItems.add(deleted)
     }
 
-    private fun setupData(bottariDetail: BottariDetailUiModel) {
-        bottariId = bottariDetail.id
-        _bottariName.value = bottariDetail.title
-        _items.value = UiState.Success(bottariDetail.items)
+    fun saveItems() {
+        _saveState.value = UiState.Loading
+
+        viewModelScope.launch {
+            val deleteItemIds = deleteItems.map { it.id }
+            saveBottariItemsUseCase(ssaid, bottariId, deleteItemIds, createItemNames.toList())
+                .onSuccess { _saveState.value = UiState.Success(Unit) }
+                .onFailure { _saveState.value = UiState.Failure(it.message) }
+        }
     }
 
-    private fun createItem(name: String): BottariItemUiModel {
-        val currentList = _items.value?.takeSuccess().orEmpty()
-        val maxId = currentList.maxOfOrNull { it.id } ?: 0L
-        return BottariItemUiModel(id = maxId + 1, isChecked = false, name = name)
-    }
+    private fun isAlreadyExistItem(name: String): Boolean = currentList.any { it.name == name }
+
+    private fun createNewItem(name: String): BottariItemUiModel =
+        BottariItemUiModel(
+            id = (currentList.maxOfOrNull { it.id } ?: DEFAULT_ITEM_ID) + ITEM_ID_INCREMENT,
+            isChecked = false,
+            name = name,
+        )
 
     companion object {
+        private const val EXTRA_BOTTARI_ID = "EXTRA_BOTTARI_ID"
         private const val EXTRA_BOTTARI_DETAIL = "EXTRA_BOTTARI_DETAIL"
-        private const val ERROR_REQUIRE_BOTTARI_ID = "보따리 ID가 없습니다"
+        private const val ERROR_REQUIRE_SSAID = "SSAID 없습니다"
+        private const val ERROR_REQUIRE_BOTTARI_DATA = "보따리가 없습니다"
 
-        fun Factory(bottariDetail: BottariDetailUiModel): ViewModelProvider.Factory =
+        private const val DEFAULT_ITEM_ID = 0L
+        private const val ITEM_ID_INCREMENT = 1
+
+        fun Factory(
+            ssaid: String,
+            bottariDetail: BottariDetailUiModel,
+        ): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
                     val stateHandle = createSavedStateHandle()
+                    stateHandle[EXTRA_BOTTARI_ID] = ssaid
                     stateHandle[EXTRA_BOTTARI_DETAIL] = bottariDetail
-                    PersonalItemEditViewModel(stateHandle)
+
+                    PersonalItemEditViewModel(
+                        stateHandle,
+                        UseCaseProvider.saveBottariItemsUseCase,
+                    )
                 }
             }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
@@ -60,6 +60,12 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
         setupListener()
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        viewModel.fetchBottari()
+    }
+
     private fun setupObserver() {
         viewModel.bottari.observe(viewLifecycleOwner, ::handleBottariState)
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
@@ -27,8 +27,7 @@ import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
 
-class PersonalBottariEditFragment :
-    BaseFragment<FragmentPersonalBottariEditBinding>(FragmentPersonalBottariEditBinding::inflate) {
+class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBinding>(FragmentPersonalBottariEditBinding::inflate) {
     private val viewModel: PersonalBottariEditViewModel by viewModels {
         val bottariId = arguments?.getLong(EXTRA_BOTTARI_ID) ?: error(ERROR_REQUIRE_BOTTARI_ID)
         PersonalBottariEditViewModel.Factory(requireContext().getSSAID(), bottariId)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
@@ -14,6 +14,7 @@ import com.bottari.presentation.base.BaseFragment
 import com.bottari.presentation.base.UiState
 import com.bottari.presentation.databinding.FragmentPersonalBottariEditBinding
 import com.bottari.presentation.extension.getSSAID
+import com.bottari.presentation.extension.takeSuccess
 import com.bottari.presentation.model.BottariDetailUiModel
 import com.bottari.presentation.util.permission.PermissionUtil
 import com.bottari.presentation.util.permission.PermissionUtil.requiredPermissions
@@ -26,9 +27,11 @@ import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
 
-class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBinding>(FragmentPersonalBottariEditBinding::inflate) {
+class PersonalBottariEditFragment :
+    BaseFragment<FragmentPersonalBottariEditBinding>(FragmentPersonalBottariEditBinding::inflate) {
     private val viewModel: PersonalBottariEditViewModel by viewModels {
-        PersonalBottariEditViewModel.Factory(requireContext().getSSAID(), getBottariId())
+        val bottariId = arguments?.getLong(EXTRA_BOTTARI_ID) ?: error(ERROR_REQUIRE_BOTTARI_ID)
+        PersonalBottariEditViewModel.Factory(requireContext().getSSAID(), bottariId)
     }
     private val itemAdapter: PersonalBottariEditItemAdapter by lazy { PersonalBottariEditItemAdapter() }
     private val alarmAdapter: PersonalBottariEditAlarmAdapter by lazy { PersonalBottariEditAlarmAdapter() }
@@ -72,9 +75,10 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
             requireActivity().onBackPressedDispatcher.onBackPressed()
         }
         binding.clEditItem.setOnClickListener {
+            val bottariDetail = viewModel.bottari.value?.takeSuccess() ?: return@setOnClickListener
             navigateToScreen(
                 PersonalItemEditFragment::class.java,
-                PersonalItemEditFragment.newBundle(getBottariId()),
+                PersonalItemEditFragment.newBundle(bottariDetail),
             )
         }
         binding.clEditAlarm.setOnClickListener {
@@ -90,8 +94,6 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
         }
     }
 
-    private fun getBottariId(): Long = arguments?.getLong(EXTRA_BOTTARI_ID) ?: INVALID_BOTTARI_ID
-
     private fun handleBottariState(uiState: UiState<BottariDetailUiModel>) {
         when (uiState) {
             is UiState.Loading -> Unit
@@ -100,6 +102,7 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
                 setupItems(uiState.data)
                 setupAlarm(uiState.data)
             }
+
             is UiState.Failure -> Unit
         }
     }
@@ -195,7 +198,7 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
 
     companion object {
         private const val EXTRA_BOTTARI_ID = "EXTRAS_BOTTARI_ID"
-        private const val INVALID_BOTTARI_ID = -1L
+        private const val ERROR_REQUIRE_BOTTARI_ID = "보따리 ID가 없습니다"
 
         fun newBundle(bottariId: Long) =
             Bundle().apply {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditViewModel.kt
@@ -35,7 +35,7 @@ class PersonalBottariEditViewModel(
     private var toggleAlarmJob: Job? = null
 
     init {
-        fetchBottariById(bottariId)
+        fetchBottari()
     }
 
     fun toggleAlarmState(isActive: Boolean) {
@@ -49,11 +49,11 @@ class PersonalBottariEditViewModel(
             }
     }
 
-    private fun fetchBottariById(id: Long) {
+    fun fetchBottari() {
+        _bottari.value = UiState.Loading
+
         viewModelScope.launch {
-            _bottari.value = UiState.Loading
-            findBottariDetailUseCase
-                .invoke(id, ssaid)
+            findBottariDetailUseCase(bottariId, ssaid)
                 .onSuccess { _bottari.value = UiState.Success(it.toUiModel()) }
                 .onFailure { _bottari.value = UiState.Failure(it.message ?: ERROR_UNKNOWN) }
         }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 개인 보따리 물건 편집 화면 API 연동 작업

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #96

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
### 개인 보따리 물건 편집 화면 API 연동 작업
```kotlin
{
  "deleteItemIds": [
    0
  ],
  "createItemNames": [
    "string"
  ]
}
```
서버에서의 체크리스트 상태를 유지하기 위해
삭제 물품과 기존에 없던 새로운 상품으로 구분하여 요청을 진행

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
