### PR TITLE
[AN] 사용자 조회 API 연동

### DIFF
--- a/android/Bottari/app/src/main/java/com/bottari/bottari/view/MainActivity.kt
+++ b/android/Bottari/app/src/main/java/com/bottari/bottari/view/MainActivity.kt
@@ -32,5 +32,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     private fun navigateToHome() {
         val intent = HomeActivity.newIntent(this)
         startActivity(intent)
+        finish()
     }
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/mapper/MemberMapper.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/mapper/MemberMapper.kt
@@ -1,8 +1,12 @@
 package com.bottari.data.mapper
 
+import com.bottari.data.model.member.CheckRegisteredMemberResponse
 import com.bottari.data.model.member.RegisterMemberRequest
 import com.bottari.domain.model.member.Member
+import com.bottari.domain.model.member.RegisteredMember
 
 object MemberMapper {
     fun Member.toRequest(): RegisterMemberRequest = RegisterMemberRequest(name = nickname, ssaid = ssaid)
+
+    fun CheckRegisteredMemberResponse.toDomain(): RegisteredMember = RegisteredMember(name = name, isRegistered = isRegistered)
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/member/CheckRegisteredMemberResponse.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/member/CheckRegisteredMemberResponse.kt
@@ -1,0 +1,12 @@
+package com.bottari.data.model.member
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CheckRegisteredMemberResponse(
+    @SerialName("isRegistered")
+    val isRegistered: Boolean,
+    @SerialName("name")
+    val name: String?,
+)

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.bottari.data.repository
 
+import com.bottari.data.mapper.MemberMapper.toDomain
 import com.bottari.data.mapper.MemberMapper.toRequest
 import com.bottari.data.source.remote.MemberRemoteDataSource
 import com.bottari.domain.model.member.Member
+import com.bottari.domain.model.member.RegisteredMember
 import com.bottari.domain.repository.MemberRepository
 
 class MemberRepositoryImpl(
@@ -10,4 +12,7 @@ class MemberRepositoryImpl(
 ) : MemberRepository {
     override suspend fun registerMember(member: Member): Result<Boolean> =
         memberRemoteDataSource.registerMember(member.toRequest()).map { true }
+
+    override suspend fun checkRegisteredMember(ssaid: String): Result<RegisteredMember> =
+        memberRemoteDataSource.checkRegisteredMember(ssaid).mapCatching { it.toDomain() }
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/service/MemberService.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/service/MemberService.kt
@@ -1,8 +1,11 @@
 package com.bottari.data.service
 
+import com.bottari.data.model.member.CheckRegisteredMemberResponse
 import com.bottari.data.model.member.RegisterMemberRequest
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface MemberService {
@@ -10,4 +13,9 @@ interface MemberService {
     suspend fun registerMember(
         @Body request: RegisterMemberRequest,
     ): Response<Unit>
+
+    @GET("/members/check")
+    suspend fun checkRegisteredMember(
+        @Header("ssaid") ssaid: String,
+    ): Response<CheckRegisteredMemberResponse>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/MemberRemoteDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/MemberRemoteDataSource.kt
@@ -1,7 +1,10 @@
 package com.bottari.data.source.remote
 
+import com.bottari.data.model.member.CheckRegisteredMemberResponse
 import com.bottari.data.model.member.RegisterMemberRequest
 
 interface MemberRemoteDataSource {
     suspend fun registerMember(request: RegisterMemberRequest): Result<Unit>
+
+    suspend fun checkRegisteredMember(ssaid: String): Result<CheckRegisteredMemberResponse>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/MemberRemoteDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/MemberRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.bottari.data.source.remote
 
+import com.bottari.data.model.member.CheckRegisteredMemberResponse
 import com.bottari.data.model.member.RegisterMemberRequest
 import com.bottari.data.service.MemberService
 import com.bottari.data.util.safeApiCall
@@ -10,5 +11,10 @@ class MemberRemoteDataSourceImpl(
     override suspend fun registerMember(request: RegisterMemberRequest): Result<Unit> =
         safeApiCall {
             memberService.registerMember(request)
+        }
+
+    override suspend fun checkRegisteredMember(ssaid: String): Result<CheckRegisteredMemberResponse> =
+        safeApiCall {
+            memberService.checkRegisteredMember(ssaid)
         }
 }

--- a/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
@@ -10,6 +10,7 @@ import com.bottari.domain.usecase.item.CheckBottariItemUseCase
 import com.bottari.domain.usecase.item.FetchChecklistUseCase
 import com.bottari.domain.usecase.item.SaveBottariItemsUseCase
 import com.bottari.domain.usecase.item.UnCheckBottariItemUseCase
+import com.bottari.domain.usecase.member.CheckRegisteredMemberUseCase
 import com.bottari.domain.usecase.member.RegisterMemberUseCase
 import com.bottari.domain.usecase.template.CreateBottariTemplateUseCase
 import com.bottari.domain.usecase.template.FetchBottariTemplateDetailUseCase
@@ -90,6 +91,11 @@ object UseCaseProvider {
     val saveBottariItemsUseCase by lazy {
         SaveBottariItemsUseCase(
             RepositoryProvider.bottariItemRepository,
+        )
+    }
+    val checkRegisteredMemberUseCase by lazy {
+        CheckRegisteredMemberUseCase(
+            RepositoryProvider.memberRepository,
         )
     }
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/model/member/RegisteredMember.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/model/member/RegisteredMember.kt
@@ -1,0 +1,6 @@
+package com.bottari.domain.model.member
+
+data class RegisteredMember(
+    val name: String?,
+    val isRegistered: Boolean,
+)

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
@@ -1,7 +1,10 @@
 package com.bottari.domain.repository
 
 import com.bottari.domain.model.member.Member
+import com.bottari.domain.model.member.RegisteredMember
 
 interface MemberRepository {
     suspend fun registerMember(member: Member): Result<Boolean>
+
+    suspend fun checkRegisteredMember(ssaid: String): Result<RegisteredMember>
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/CheckRegisteredMemberUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/CheckRegisteredMemberUseCase.kt
@@ -1,0 +1,10 @@
+package com.bottari.domain.usecase.member
+
+import com.bottari.domain.model.member.RegisteredMember
+import com.bottari.domain.repository.MemberRepository
+
+class CheckRegisteredMemberUseCase(
+    private val memberRepository: MemberRepository,
+) {
+    suspend operator fun invoke(ssaid: String): Result<RegisteredMember> = memberRepository.checkRegisteredMember(ssaid)
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 사용자 조회 API 연동

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #118 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 사용자 회원 가입 여부를 체크 후 `사용자 등록` / `홈 화면 진입` 분기 처리

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
