### PR TITLE
[AN] 개인 보따리 편집 저장 기능 문제 해결

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
@@ -31,7 +31,7 @@ class PersonalItemEditFragment :
 
     private val adapter by lazy {
         PersonalItemEditAdapter {
-            viewModel.deleteItem(it)
+            viewModel.markItemAsDeleted(it)
         }
     }
 
@@ -67,7 +67,7 @@ class PersonalItemEditFragment :
 
     private fun setupObserver() {
         viewModel.bottariName.observe(viewLifecycleOwner, ::handleBottariNameState)
-        viewModel.items.observe(viewLifecycleOwner, ::handleItemState)
+        viewModel.bottariItems.observe(viewLifecycleOwner, ::handleItemState)
         viewModel.saveState.observe(viewLifecycleOwner, ::handleSaveState)
     }
 
@@ -83,7 +83,7 @@ class PersonalItemEditFragment :
 
         binding.etPersonalItem.addTextChangedListener(this)
 
-        binding.btnConfirm.setOnClickListener { viewModel.saveItems() }
+        binding.btnConfirm.setOnClickListener { viewModel.saveChanges() }
 
         binding.etPersonalItem.setOnEditorActionListener { _, actionId, _ ->
             if (actionId != EditorInfo.IME_ACTION_SEND) return@setOnEditorActionListener false
@@ -94,7 +94,7 @@ class PersonalItemEditFragment :
     }
 
     private fun addItemFromInput() {
-        viewModel.addItem(binding.etPersonalItem.text.toString())
+        viewModel.addNewItemIfNeeded(binding.etPersonalItem.text.toString())
         binding.etPersonalItem.text.clear()
     }
 


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 기존에 없던 물건을 추가한 뒤 바로 제거하면, 저장 API 호출 시 임시 ID를 가진 물건을 제거하려 해서 생기는 문제를 해결

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #130 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->

### 오류 해결
기존에 없던 물건을 추가한 뒤 바로 제거하면, 저장 API 호출 시 임시 ID를 가진 물건을 제거하려 해서 생기는 문제를 해결

### 코드 리팩터링
- `SavedStateHandle`에서 값을 가져올 때 `getOrThrow` 확장 함수 사용
- 아이템 추가 및 삭제 로직을 명확하게 분리
- 변수명 및 함수명을 더 직관적으로 변경
- 중복 아이템 검사 로직 개선
- 아이템 ID 생성 로직 개선

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
