### PR TITLE
[BE] 사용자 이름 변경 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/controller/MemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/MemberController.java
@@ -3,12 +3,14 @@ package com.bottari.controller;
 import com.bottari.controller.docs.MemberApiDocs;
 import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
+import com.bottari.dto.UpdateMemberRequest;
 import com.bottari.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,5 +42,17 @@ public class MemberController implements MemberApiDocs {
         final CheckRegistrationResponse response = memberService.checkRegistration(ssaid);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/me")
+    @Override
+    public ResponseEntity<Void> updateName(
+            @RequestBody final UpdateMemberRequest request,
+            final HttpServletRequest httpServletRequest
+    ) {
+        final String ssaid = httpServletRequest.getHeader("ssaid");
+        memberService.updateName(ssaid, request);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/controller/docs/MemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/docs/MemberApiDocs.java
@@ -2,6 +2,7 @@ package com.bottari.controller.docs;
 
 import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
+import com.bottari.dto.UpdateMemberRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -25,6 +26,15 @@ public interface MemberApiDocs {
             @ApiResponse(responseCode = "200", description = "사용자 회원가입 여부 확인 성공"),
     })
     ResponseEntity<CheckRegistrationResponse> checkRegistration(
+            final HttpServletRequest httpServletRequest
+    );
+
+    @Operation(summary = "사용자 이름 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "사용자 이름 수정 성공"),
+    })
+    ResponseEntity<Void> updateName(
+            final UpdateMemberRequest request,
             final HttpServletRequest httpServletRequest
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/domain/Member.java
+++ b/backend/bottari/src/main/java/com/bottari/domain/Member.java
@@ -1,5 +1,6 @@
 package com.bottari.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,6 +20,7 @@ public class Member {
 
     private String ssaid;
 
+    @Column(unique = true)
     private String name;
 
     public Member(

--- a/backend/bottari/src/main/java/com/bottari/domain/Member.java
+++ b/backend/bottari/src/main/java/com/bottari/domain/Member.java
@@ -34,6 +34,14 @@ public class Member {
         return this.ssaid.equals(ssaid);
     }
 
+    public void updateName(final String newName) {
+        if (name.equals(newName)) {
+            throw new IllegalArgumentException("기존 이름과 동일한 이름으로는 변경할 수 없습니다.");
+        }
+        validateName(newName);
+        this.name = newName;
+    }
+
     private void validateName(final String name) {
         if (name.length() < 3 || name.length() > 10) {
             throw new IllegalArgumentException("사용자 이름은 3글자 이상 10글자 이하여야 합니다.");

--- a/backend/bottari/src/main/java/com/bottari/domain/Member.java
+++ b/backend/bottari/src/main/java/com/bottari/domain/Member.java
@@ -18,6 +18,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String ssaid;
 
     @Column(unique = true)

--- a/backend/bottari/src/main/java/com/bottari/dto/UpdateMemberRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/UpdateMemberRequest.java
@@ -1,0 +1,6 @@
+package com.bottari.dto;
+
+public record UpdateMemberRequest(
+        String name
+) {
+}

--- a/backend/bottari/src/main/java/com/bottari/repository/MemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsBySsaid(final String ssaid);
 
     Optional<Member> findBySsaid(final String ssaid);
+
+    boolean existsByName(final String name);
 }

--- a/backend/bottari/src/main/java/com/bottari/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/MemberService.java
@@ -49,6 +49,13 @@ public class MemberService {
     ) {
         final Member member = memberRepository.findBySsaid(ssaid)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ssaid로 가입된 사용자가 없습니다."));
+        validateDuplicateName(request);
         member.updateName(request.name());
+    }
+
+    private void validateDuplicateName(final UpdateMemberRequest request) {
+        if (memberRepository.existsByName(request.name())) {
+            throw new IllegalArgumentException("이미 사용 중인 이름입니다.");
+        }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/MemberService.java
@@ -3,6 +3,7 @@ package com.bottari.service;
 import com.bottari.domain.Member;
 import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
+import com.bottari.dto.UpdateMemberRequest;
 import com.bottari.repository.MemberRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -39,5 +40,15 @@ public class MemberService {
         }
 
         return new CheckRegistrationResponse(false, null);
+    }
+
+    @Transactional
+    public void updateName(
+            final String ssaid,
+            final UpdateMemberRequest request
+    ) {
+        final Member member = memberRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ssaid로 가입된 사용자가 없습니다."));
+        member.updateName(request.name());
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.bottari.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
+import com.bottari.dto.UpdateMemberRequest;
 import com.bottari.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -65,5 +67,20 @@ class MemberControllerTest {
                         .header("ssaid", ssaid))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(response)));
+    }
+
+    @DisplayName("사용자의 이름을 수정한다.")
+    @Test
+    void updateName() throws Exception {
+        // given
+        final String ssaid = "ssaid";
+        final UpdateMemberRequest request = new UpdateMemberRequest("new_name");
+
+        // when & then
+        mockMvc.perform(patch("/members/me")
+                        .header("ssaid", ssaid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/domain/MemberTest.java
+++ b/backend/bottari/src/test/java/com/bottari/domain/MemberTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -38,5 +39,30 @@ class MemberTest {
 
         // then
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("이름을 수정한다.")
+    @Test
+    void updateName() {
+        // given
+        final Member member = new Member("ssaid", "name");
+
+        // when
+        member.updateName("new_name");
+
+        // then
+        assertThat(member.getName()).isEqualTo("new_name");
+    }
+
+    @DisplayName("기존 이름과 동일한 이름으로는 수정할 수 없다.")
+    @Test
+    void updateName_Exception_SameName() {
+        // given
+        final Member member = new Member("ssaid", "name");
+
+        // when & then
+        assertThatThrownBy(() -> member.updateName("name"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("기존 이름과 동일한 이름으로는 변경할 수 없습니다.");
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
@@ -117,4 +117,24 @@ class MemberServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 ssaid로 가입된 사용자가 없습니다.");
     }
+
+    @DisplayName("이미 사용 중인 이름으로 사용자의 이름을 수정할 경우, 예외를 던진다.")
+    @Test
+    void updateName_Exception_DuplicateName() {
+        // given
+        final String duplicatedName = "중복_이름";
+        final Member memberWithDuplicatedName = new Member("ssaid_1", duplicatedName);
+        entityManager.persist(memberWithDuplicatedName);
+
+        final String requesterSsaid = "ssaid_2";
+        final Member memberToUpdate = new Member(requesterSsaid, "기존_이름");
+        entityManager.persist(memberToUpdate);
+
+        final UpdateMemberRequest updateRequest = new UpdateMemberRequest(duplicatedName);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateName(requesterSsaid, updateRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 사용 중인 이름입니다.");
+    }
 }

--- a/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.bottari.domain.Member;
 import com.bottari.dto.CheckRegistrationResponse;
 import com.bottari.dto.CreateMemberRequest;
+import com.bottari.dto.UpdateMemberRequest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,5 +84,37 @@ class MemberServiceTest {
             assertThat(actual.isRegistered()).isFalse();
             assertThat(actual.name()).isNull();
         });
+    }
+
+    @DisplayName("사용자의 이름을 수정한다.")
+    @Test
+    void updateName() {
+        // given
+        final String ssaid = "ssaid";
+        final Member member = new Member(ssaid, "name");
+        entityManager.persist(member);
+
+        final UpdateMemberRequest request = new UpdateMemberRequest("new_name");
+
+        // when
+        memberService.updateName(ssaid, request);
+
+        // then
+        final Member updatedMember = entityManager.find(Member.class, member.getId());
+        final String actual = updatedMember.getName();
+        assertThat(actual).isEqualTo("new_name");
+    }
+
+    @DisplayName("존재하지 않는 ssaid로 사용자의 이름을 수정할 경우, 예외를 던진다.")
+    @Test
+    void updateName_Exception_NotExistsSsaid() {
+        // given
+        final String ssaid = "invalid_ssaid";
+        final UpdateMemberRequest request = new UpdateMemberRequest("new_name");
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateName(ssaid, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 ssaid로 가입된 사용자가 없습니다.");
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 사용자 이름을 수정하는 API를 구현합니다.

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #143

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 사용자 이름을 수정하는 API 구현
    - 이미 사용하는 이름으로 수정할 경우 예외 발생
    - 현재 이름과 똑같은 이름인 경우 예외 발생 (따라서 같은 이름으로 수정할 경우 안드로이드에서 API 호출 X)
- 사용자 이름 엔티티에 유니크 제약 조건 추가
  - 추후 마켓 플레이스에 보따리 템플릿 공유자 이름을 보여주기 위함 (식별성)

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
