### PR TITLE
[BE] 보따리 삭제 기능

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/controller/BottariController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/BottariController.java
@@ -62,7 +62,7 @@ public class BottariController implements BottariApiDocs {
 
     @DeleteMapping("/{id}")
     @Override
-    public ResponseEntity<Void> deleteById(
+    public ResponseEntity<Void> delete(
             @PathVariable final Long id,
             final HttpServletRequest httpServletRequest
     ) {

--- a/backend/bottari/src/main/java/com/bottari/controller/BottariController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/BottariController.java
@@ -63,7 +63,7 @@ public class BottariController implements BottariApiDocs {
     @DeleteMapping("/{id}")
     @Override
     public ResponseEntity<Void> deleteById(
-            @PathVariable Long id,
+            @PathVariable final Long id,
             final HttpServletRequest httpServletRequest
     ) {
         final String ssaid = httpServletRequest.getHeader("ssaid");

--- a/backend/bottari/src/main/java/com/bottari/controller/BottariController.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/BottariController.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,5 +58,17 @@ public class BottariController implements BottariApiDocs {
         final Long id = bottariService.create(ssaid, request);
 
         return ResponseEntity.created(URI.create("/bottaries/" + id)).build();
+    }
+
+    @DeleteMapping("/{id}")
+    @Override
+    public ResponseEntity<Void> deleteById(
+            @PathVariable Long id,
+            final HttpServletRequest httpServletRequest
+    ) {
+        final String ssaid = httpServletRequest.getHeader("ssaid");
+        bottariService.deleteById(id, ssaid);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/controller/docs/BottariApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/docs/BottariApiDocs.java
@@ -44,7 +44,7 @@ public interface BottariApiDocs {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "보따리 삭제 성공"),
     })
-    ResponseEntity<Void> deleteById(
+    ResponseEntity<Void> delete(
             final Long id,
             final HttpServletRequest httpServletRequest
     );

--- a/backend/bottari/src/main/java/com/bottari/controller/docs/BottariApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/controller/docs/BottariApiDocs.java
@@ -10,8 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Bottari", description = "보따리 API")
 public interface BottariApiDocs {
@@ -21,7 +19,7 @@ public interface BottariApiDocs {
             @ApiResponse(responseCode = "200", description = "보따리 상세 조회 성공"),
     })
     ResponseEntity<ReadBottariResponse> read(
-            @PathVariable final Long id,
+            final Long id,
             final HttpServletRequest httpServletRequest
     );
 
@@ -38,7 +36,16 @@ public interface BottariApiDocs {
             @ApiResponse(responseCode = "201", description = "보따리 생성 성공"),
     })
     ResponseEntity<Void> create(
-            @RequestBody final CreateBottariRequest request,
+            final CreateBottariRequest request,
+            final HttpServletRequest httpServletRequest
+    );
+
+    @Operation(summary = "보따리 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "보따리 삭제 성공"),
+    })
+    ResponseEntity<Void> deleteById(
+            final Long id,
             final HttpServletRequest httpServletRequest
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
@@ -14,7 +14,7 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     List<Alarm> findAllByBottariIn(final List<Bottari> bottaries);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
             DELETE FROM Alarm a
             WHERE a.bottari.id = :bottariId

--- a/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
@@ -5,10 +5,16 @@ import com.bottari.domain.Bottari;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     Optional<Alarm> findByBottariId(final Long id);
 
     List<Alarm> findAllByBottariIn(final List<Bottari> bottaries);
+
+    @Modifying
+    @Query("DELETE FROM Alarm a WHERE a.bottari.id = :bottariId")
+    void deleteByBottariId(Long bottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
@@ -16,8 +16,8 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     @Modifying
     @Query("""
-            DELETE FROM Alarm a 
+            DELETE FROM Alarm a
             WHERE a.bottari.id = :bottariId
             """)
-    void deleteByBottariId(Long bottariId);
+    void deleteByBottariId(final Long bottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
@@ -15,6 +15,9 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     List<Alarm> findAllByBottariIn(final List<Bottari> bottaries);
 
     @Modifying
-    @Query("DELETE FROM Alarm a WHERE a.bottari.id = :bottariId")
+    @Query("""
+            DELETE FROM Alarm a 
+            WHERE a.bottari.id = :bottariId
+            """)
     void deleteByBottariId(Long bottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
@@ -4,6 +4,8 @@ import com.bottari.domain.Bottari;
 import com.bottari.domain.BottariItem;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BottariItemRepository extends JpaRepository<BottariItem, Long> {
 
@@ -29,4 +31,8 @@ public interface BottariItemRepository extends JpaRepository<BottariItem, Long> 
     int countAllByBottariId(final Long bottariId);
 
     void deleteByIdIn(final List<Long> ids);
+
+    @Modifying
+    @Query("DELETE FROM BottariItem bt WHERE bt.bottari.id = :bottariId")
+    void deleteByBottariId(Long bottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
@@ -30,7 +30,7 @@ public interface BottariItemRepository extends JpaRepository<BottariItem, Long> 
 
     int countAllByBottariId(final Long bottariId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
             DELETE FROM BottariItem bt
             WHERE bt.bottari.id = :bottariId

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
@@ -30,12 +30,12 @@ public interface BottariItemRepository extends JpaRepository<BottariItem, Long> 
 
     int countAllByBottariId(final Long bottariId);
 
-    void deleteByIdIn(final List<Long> ids);
-
     @Modifying
     @Query("""
-            DELETE FROM BottariItem bt 
+            DELETE FROM BottariItem bt
             WHERE bt.bottari.id = :bottariId
             """)
-    void deleteByBottariId(Long bottariId);
+    void deleteByBottariId(final Long bottariId);
+
+    void deleteByIdIn(final List<Long> ids);
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
@@ -33,6 +33,9 @@ public interface BottariItemRepository extends JpaRepository<BottariItem, Long> 
     void deleteByIdIn(final List<Long> ids);
 
     @Modifying
-    @Query("DELETE FROM BottariItem bt WHERE bt.bottari.id = :bottariId")
+    @Query("""
+            DELETE FROM BottariItem bt 
+            WHERE bt.bottari.id = :bottariId
+            """)
     void deleteByBottariId(Long bottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariRepository.java
@@ -2,9 +2,19 @@ package com.bottari.repository;
 
 import com.bottari.domain.Bottari;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BottariRepository extends JpaRepository<Bottari, Long> {
+
+    @Query("""
+            SELECT b
+            FROM Bottari b
+            JOIN FETCH b.member
+            WHERE b.id = :id
+            """)
+    Optional<Bottari> findByIdWithMember(Long id);
 
     List<Bottari> findAllByMemberIdOrderByCreatedAtDesc(final Long memberId);
 }

--- a/backend/bottari/src/main/java/com/bottari/service/BottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/BottariService.java
@@ -35,7 +35,7 @@ public class BottariService {
             final String ssaid,
             final Long id
     ) {
-        final Bottari bottari = bottariRepository.findById(id)
+        final Bottari bottari = bottariRepository.findByIdWithMember(id)
                 .orElseThrow(() -> new IllegalArgumentException("보따리를 찾을 수 없습니다."));
         validateOwner(ssaid, bottari);
         final List<BottariItem> bottariItems = bottariItemRepository.findAllByBottariId(id);
@@ -71,7 +71,7 @@ public class BottariService {
             final Long id,
             final String ssaid
     ) {
-        final Bottari bottari = bottariRepository.findById(id)
+        final Bottari bottari = bottariRepository.findByIdWithMember(id)
                 .orElseThrow(() -> new IllegalArgumentException("보따리를 찾을 수 없습니다."));
         validateOwner(ssaid, bottari);
         bottariItemRepository.deleteByBottariId(id);

--- a/backend/bottari/src/main/java/com/bottari/service/BottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/BottariService.java
@@ -66,6 +66,13 @@ public class BottariService {
         return savedBottari.getId();
     }
 
+    @Transactional
+    public void deleteById(final Long id) {
+        bottariItemRepository.deleteByBottariId(id);
+        alarmRepository.deleteByBottariId(id);
+        bottariRepository.deleteById(id);
+    }
+
     private List<ReadBottariPreviewResponse> buildReadBottariPreviewResponses(final List<Bottari> bottaries) {
         final Map<Bottari, List<BottariItem>> bottariItemsGroupByBottari = groupingBottariItmesById(bottaries);
         final Map<Bottari, Alarm> alarmMap = groupingAlarmByBottari(bottaries);

--- a/backend/bottari/src/main/java/com/bottari/service/BottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/BottariService.java
@@ -67,7 +67,13 @@ public class BottariService {
     }
 
     @Transactional
-    public void deleteById(final Long id) {
+    public void deleteById(
+            final Long id,
+            final String ssaid
+    ) {
+        final Bottari bottari = bottariRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("보따리를 찾을 수 없습니다."));
+        validateOwner(ssaid, bottari);
         bottariItemRepository.deleteByBottariId(id);
         alarmRepository.deleteByBottariId(id);
         bottariRepository.deleteById(id);

--- a/backend/bottari/src/test/java/com/bottari/controller/BottariControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/BottariControllerTest.java
@@ -1,6 +1,8 @@
 package com.bottari.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -85,5 +87,20 @@ class BottariControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/bottaries/1"));
+    }
+
+    @DisplayName("보따리를 생성한다.")
+    @Test
+    void deleteById() throws Exception {
+        // given
+        final Long bottariId = 1L;
+        final String ssaid = "ssaid";
+        willDoNothing().given(bottariService)
+                .deleteById(bottariId, ssaid);
+
+        // when & then
+        mockMvc.perform(delete("/bottaries/" + bottariId)
+                        .header("ssaid", ssaid))
+                .andExpect(status().isNoContent());
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/controller/BottariControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/BottariControllerTest.java
@@ -2,7 +2,6 @@ package com.bottari.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -23,6 +22,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @WebMvcTest(BottariController.class)
 class BottariControllerTest {
@@ -89,9 +89,9 @@ class BottariControllerTest {
                 .andExpect(header().string(HttpHeaders.LOCATION, "/bottaries/1"));
     }
 
-    @DisplayName("보따리를 생성한다.")
+    @DisplayName("보따리를 삭제한다.")
     @Test
-    void deleteById() throws Exception {
+    void delete() throws Exception {
         // given
         final Long bottariId = 1L;
         final String ssaid = "ssaid";
@@ -99,7 +99,7 @@ class BottariControllerTest {
                 .deleteById(bottariId, ssaid);
 
         // when & then
-        mockMvc.perform(delete("/bottaries/" + bottariId)
+        mockMvc.perform(MockMvcRequestBuilders.delete("/bottaries/" + bottariId)
                         .header("ssaid", ssaid))
                 .andExpect(status().isNoContent());
     }

--- a/backend/bottari/src/test/java/com/bottari/service/BottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/BottariServiceTest.java
@@ -244,8 +244,10 @@ class BottariServiceTest {
                         "SELECT COUNT(b) FROM Bottari b WHERE b.member.ssaid = :ssaid", Long.class)
                 .setParameter("ssaid", ssaid)
                 .getSingleResult());
-        assertThat(countBottariFromSsaid_Before).isEqualTo(1);
-        assertThat(countBottariFromSsaid_After).isEqualTo(0);
+        assertAll(() -> {
+            assertThat(countBottariFromSsaid_Before).isEqualTo(1);
+            assertThat(countBottariFromSsaid_After).isEqualTo(0);
+        });
     }
 
     @DisplayName("존재하지 않는 보따리를 삭제할 경우, 예외를 던진다.")
@@ -268,7 +270,7 @@ class BottariServiceTest {
         final Member member = new Member(ssaid, "name");
         entityManager.persist(member);
 
-        final Member anotherMember = new Member("another_ssaid", "name");
+        final Member anotherMember = new Member("another_ssaid", "name_2");
         entityManager.persist(anotherMember);
 
         final Bottari anotherMemberBottari = new Bottari("title1", anotherMember);

--- a/backend/bottari/src/test/java/com/bottari/service/BottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/BottariServiceTest.java
@@ -231,15 +231,11 @@ class BottariServiceTest {
         );
         final Alarm alarm = new Alarm(true, routineAlarm, locationAlarm, delete_bottari);
         entityManager.persist(alarm);
-        entityManager.flush();
-        entityManager.clear();
 
         // when
         bottariService.deleteById(delete_bottari.getId(), ssaid);
 
         // then
-        entityManager.flush();
-        entityManager.clear();
         final Bottari remainingBottari = entityManager.find(Bottari.class, remain_bottari.getId());
         final Bottari deletedBottari = entityManager.find(Bottari.class, delete_bottari.getId());
 
@@ -275,8 +271,6 @@ class BottariServiceTest {
 
         final Bottari anotherMemberBottari = new Bottari("title1", anotherMember);
         entityManager.persist(anotherMemberBottari);
-        entityManager.flush();
-        entityManager.clear();
 
         // when & then
         assertThatThrownBy(() -> bottariService.deleteById(anotherMemberBottari.getId(), "ssaid"))

--- a/backend/bottari/src/test/java/com/bottari/service/BottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/BottariServiceTest.java
@@ -68,15 +68,15 @@ class BottariServiceTest {
         final ReadBottariResponse actual = bottariService.getById(ssaid, bottari.getId());
 
         // then
-        assertAll(() -> {
-            assertThat(actual.id()).isEqualTo(bottari.getId());
-            assertThat(actual.items()).hasSize(1);
-            assertThat(actual.alarm()).isNotNull();
-            assertThat(actual.alarm().id()).isEqualTo(alarm.getId());
-            assertThat(actual.alarm().isActive()).isTrue();
-            assertThat(actual.alarm().routine().type()).isEqualTo(RepeatType.EVERY_WEEK_REPEAT);
-            assertThat(actual.alarm().location().latitude()).isEqualTo(37.5);
-        });
+        assertAll(
+                () -> assertThat(actual.id()).isEqualTo(bottari.getId()),
+                () -> assertThat(actual.items()).hasSize(1),
+                () -> assertThat(actual.alarm()).isNotNull(),
+                () -> assertThat(actual.alarm().id()).isEqualTo(alarm.getId()),
+                () -> assertThat(actual.alarm().isActive()).isTrue(),
+                () -> assertThat(actual.alarm().routine().type()).isEqualTo(RepeatType.EVERY_WEEK_REPEAT),
+                () -> assertThat(actual.alarm().location().latitude()).isEqualTo(37.5)
+        );
     }
 
     @DisplayName("본인의 보따리가 아닌 보따리를 조회할 경우, 예외를 던진다.")
@@ -143,18 +143,18 @@ class BottariServiceTest {
         final List<ReadBottariPreviewResponse> actual = bottariService.getAllBySsaidSortedByLatest(ssaid);
 
         // then
-        assertAll(() -> {
-            assertThat(actual).extracting("title").containsExactly("title2", "title1");
-            assertThat(actual).hasSize(2);
-            assertThat(actual.getFirst().totalItemsCount()).isEqualTo(1);
-            assertThat(actual.getFirst().checkedItemsCount()).isEqualTo(0);
-            assertThat(actual.getFirst().alarm()).isNull();
-            assertThat(actual.get(1).totalItemsCount()).isEqualTo(2);
-            assertThat(actual.get(1).checkedItemsCount()).isEqualTo(1);
-            assertThat(actual.get(1).alarm()).isNotNull();
-            assertThat(actual.get(1).alarm().id()).isEqualTo(alarm.getId());
-            assertThat(actual.get(1).alarm().isActive()).isTrue();
-        });
+        assertAll(
+                () -> assertThat(actual).extracting("title").containsExactly("title2", "title1"),
+                () -> assertThat(actual).hasSize(2),
+                () -> assertThat(actual.getFirst().totalItemsCount()).isEqualTo(1),
+                () -> assertThat(actual.getFirst().checkedItemsCount()).isEqualTo(0),
+                () -> assertThat(actual.getFirst().alarm()).isNull(),
+                () -> assertThat(actual.get(1).totalItemsCount()).isEqualTo(2),
+                () -> assertThat(actual.get(1).checkedItemsCount()).isEqualTo(1),
+                () -> assertThat(actual.get(1).alarm()).isNotNull(),
+                () -> assertThat(actual.get(1).alarm().id()).isEqualTo(alarm.getId()),
+                () -> assertThat(actual.get(1).alarm().isActive()).isTrue()
+        );
     }
 
     @DisplayName("존재하지 않는 사용자의 모든 보따리를 조회할 경우, 예외를 던진다.")
@@ -243,11 +243,11 @@ class BottariServiceTest {
         final Bottari remainingBottari = entityManager.find(Bottari.class, remain_bottari.getId());
         final Bottari deletedBottari = entityManager.find(Bottari.class, delete_bottari.getId());
 
-        assertAll(() -> {
-            assertThat(deletedBottari).isNull();
-            assertThat(remainingBottari).isNotNull();
-            assertThat(remainingBottari.getTitle()).isEqualTo("remain_bottari");
-        });
+        assertAll(
+                () -> assertThat(deletedBottari).isNull(),
+                () -> assertThat(remainingBottari).isNotNull(),
+                () -> assertThat(remainingBottari.getTitle()).isEqualTo("remain_bottari")
+        );
     }
 
     @DisplayName("존재하지 않는 보따리를 삭제할 경우, 예외를 던진다.")


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 보따리 삭제 기능

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #141 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 보따리 삭제 기능 구현
- 본인 보따리만 삭제 가능하도록 검증

```java
    @Transactional
    public void deleteById(
            final Long id,
            final String ssaid
    ) {
        final Bottari bottari = bottariRepository.findById(id)
                .orElseThrow(() -> new IllegalArgumentException("보따리를 찾을 수 없습니다."));
        validateOwner(ssaid, bottari);
        bottariItemRepository.deleteByBottariId(id);
        alarmRepository.deleteByBottariId(id);
        bottariRepository.deleteById(id);
    }
```
`cascade` 설정을 통해 삭제를 하려고 했으나, 그 경우 delete 쿼리가 item의 갯수 만큼 실행됨

```java
    @Modifying
    @Query("DELETE FROM BottariItem bt WHERE bt.bottari.id = :bottariId")
    void deleteByBottariId(Long bottariId);
```
기존의 `deleteByBottariId` 또한 select 쿼리 이후, item 갯수 만큼 delete 쿼리가 실행되므로 직접 쿼리 작성

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
