### PR TITLE
[BE] 사용자 등록 흐름 변경

### DIFF
--- a/backend/bottari/build.gradle
+++ b/backend/bottari/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/backend/bottari/src/main/java/com/bottari/config/RetryConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.bottari.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/backend/bottari/src/main/java/com/bottari/dto/CreateMemberRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/dto/CreateMemberRequest.java
@@ -1,13 +1,6 @@
 package com.bottari.dto;
 
-import com.bottari.domain.Member;
-
 public record CreateMemberRequest(
-        String ssaid,
-        String name
+        String ssaid
 ) {
-
-    public Member toMember() {
-        return new Member(ssaid, name);
-    }
 }

--- a/backend/bottari/src/main/java/com/bottari/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/MemberService.java
@@ -34,8 +34,8 @@ public class MemberService {
     )
     public Long create(final CreateMemberRequest request) {
         validateDuplicateSsaid(request.ssaid());
-        final String tempName = createRandomNameCandidate();
-        final Member member = new Member(request.ssaid(), tempName);
+        final String generatedName = generatedRandomNameCandidate();
+        final Member member = new Member(request.ssaid(), generatedName);
         final Member savedMember = memberRepository.save(member);
 
         return savedMember.getId();
@@ -77,7 +77,7 @@ public class MemberService {
         }
     }
 
-    private String createRandomNameCandidate() {
+    private String generatedRandomNameCandidate() {
         String word = NAME_POOL[ThreadLocalRandom.current().nextInt(NAME_POOL.length)];
         int suffix = ThreadLocalRandom.current().nextInt(10_000);
         return "%s-%04d".formatted(word, suffix);

--- a/backend/bottari/src/main/java/com/bottari/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
     )
     public Long create(final CreateMemberRequest request) {
         validateDuplicateSsaid(request.ssaid());
-        final String generatedName = generatedRandomNameCandidate();
+        final String generatedName = generatedRandomCandidateName();
         final Member member = new Member(request.ssaid(), generatedName);
         final Member savedMember = memberRepository.save(member);
 
@@ -77,7 +77,7 @@ public class MemberService {
         }
     }
 
-    private String generatedRandomNameCandidate() {
+    private String generatedRandomCandidateName() {
         String word = NAME_POOL[ThreadLocalRandom.current().nextInt(NAME_POOL.length)];
         int suffix = ThreadLocalRandom.current().nextInt(10_000);
         return "%s-%04d".formatted(word, suffix);

--- a/backend/bottari/src/main/java/com/bottari/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/service/MemberService.java
@@ -6,7 +6,9 @@ import com.bottari.dto.CreateMemberRequest;
 import com.bottari.dto.UpdateMemberRequest;
 import com.bottari.repository.MemberRepository;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,21 +16,20 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private static final String[] NAME_POOL = {
+            "체커", "잊꾸", "짐장인", "출근러", "여행러",
+            "물건러", "챙김러", "잊꾸러기", "보따리꾼", "가방요정"
+    };
+    private static final double MAX_TEMP_NAME_GENERATION_ATTEMPTS = 3;
+
     private final MemberRepository memberRepository;
 
     @Transactional
     public Long create(final CreateMemberRequest request) {
         validateDuplicateSsaid(request.ssaid());
-        final Member member = request.toMember();
-        final Member savedMember = memberRepository.save(member);
+        final Member savedMember = saveWithUniqueTempName(request.ssaid());
 
         return savedMember.getId();
-    }
-
-    private void validateDuplicateSsaid(final String ssaid) {
-        if (memberRepository.existsBySsaid(ssaid)) {
-            throw new IllegalArgumentException("중복된 ssaid입니다.");
-        }
     }
 
     public CheckRegistrationResponse checkRegistration(final String ssaid) {
@@ -53,9 +54,36 @@ public class MemberService {
         member.updateName(request.name());
     }
 
+    private void validateDuplicateSsaid(final String ssaid) {
+        if (memberRepository.existsBySsaid(ssaid)) {
+            throw new IllegalArgumentException("중복된 ssaid입니다.");
+        }
+    }
+
     private void validateDuplicateName(final UpdateMemberRequest request) {
         if (memberRepository.existsByName(request.name())) {
             throw new IllegalArgumentException("이미 사용 중인 이름입니다.");
         }
+    }
+
+    private Member saveWithUniqueTempName(final String ssaid) {
+        for (int i = 0; i < MAX_TEMP_NAME_GENERATION_ATTEMPTS; i++) {
+            try {
+                final String tempName = createRandomNameCandidate();
+                final Member member = new Member(ssaid, tempName);
+                return memberRepository.save(member);
+            } catch (DataIntegrityViolationException e) {
+                if (i == MAX_TEMP_NAME_GENERATION_ATTEMPTS - 1) {
+                    throw new IllegalStateException("고유한 임시 닉네임을 생성하고 저장하는 데 실패했습니다. (관리자 문의 필요)");
+                }
+            }
+        }
+        throw new IllegalStateException("알 수 없는 이유로 닉네임 생성에 실패했습니다.");
+    }
+
+    private String createRandomNameCandidate() {
+        String word = NAME_POOL[ThreadLocalRandom.current().nextInt(NAME_POOL.length)];
+        int suffix = ThreadLocalRandom.current().nextInt(10_000);
+        return "%s-%04d".formatted(word, suffix);
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/controller/MemberControllerTest.java
@@ -38,7 +38,7 @@ class MemberControllerTest {
     @Test
     void register() throws Exception {
         // given
-        final CreateMemberRequest request = new CreateMemberRequest("ssaid", "name");
+        final CreateMemberRequest request = new CreateMemberRequest("ssaid");
         given(memberService.create(request))
                 .willReturn(1L);
 

--- a/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/service/MemberServiceTest.java
@@ -29,7 +29,7 @@ class MemberServiceTest {
     @Test
     void create() {
         // given
-        final CreateMemberRequest request = new CreateMemberRequest("ssaid", "name");
+        final CreateMemberRequest request = new CreateMemberRequest("ssaid");
 
         // when
         final Long actual = memberService.create(request);
@@ -38,13 +38,31 @@ class MemberServiceTest {
         assertThat(actual).isNotNull();
     }
 
+    @DisplayName("사용자를 생성하면 고유한 임시 이름이 부여된다.")
+    @Test
+    void create_AssignTemporaryName() {
+        // given
+        final String ssaid = "ssaid";
+        final CreateMemberRequest request = new CreateMemberRequest(ssaid);
+
+        // when
+        final Long memberId = memberService.create(request);
+
+        // then
+        final Member createdMember = entityManager.find(Member.class, memberId);
+        assertAll(
+                () -> assertThat(createdMember).isNotNull(),
+                () -> assertThat(createdMember.getName()).isNotBlank()
+        );
+    }
+
     @DisplayName("중복된 ssaid로 사용자를 생성할 경우, 예외를 던진다.")
     @Test
     void create_Exception_DuplicateSsaid() {
         // given
         final String duplicateSsaid = "duplicateSsaid";
         entityManager.persist(new Member(duplicateSsaid, "name"));
-        final CreateMemberRequest request = new CreateMemberRequest(duplicateSsaid, "name");
+        final CreateMemberRequest request = new CreateMemberRequest(duplicateSsaid);
 
         // when & then
         assertThatThrownBy(() -> memberService.create(request))


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 사용자 등록 시 사용자 이름을 받던 방식에서 서버에서 무작위로 생성하는 방식으로 변경

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #157 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 고유한 닉네임을 생성하는 과정이 어렵지 않기 때문에 별도 락이 아닌 재시도 방식으로 구현


## 재시도 구현 방법

`create()` 메서드는 회원 생성 시 랜덤한 임시 이름을 부여하고 저장하는 로직입니다.
- 사용자 이름(name)에는 `유니크 제약조건`이 설정되어 있어 중복 발생 시 `DataIntegrityViolationException`이 발생할 수 있으며, 이를 최대 `3회`까지 재시도합니다.
    - `@Retryable`의 maxAttempts 속성은 기본값이 3이지만, 명확히 나타내기 위해 작성했습니다.
- 재시도는 지수 백오프(exponential backoff) 정책을 적용했습니다. `300ms → 600ms → 1200ms`
- 모든 재시도 실패 시, `@Recover` 메서드가 호출되어 사용자에게 구체적인 예외 메시지를 전달합니다.
    - `@Recover`를 적용한 메서드에는 예외 타입과 예외가 발생한 메서드의 기본 파라미터를 받아야 합니다.

> ⚠️ 주의
> 
> `@Retryable`은 Spring AOP 기반으로 동작하므로,
> 같은 클래스 내부에서 호출되면 retry가 적용되지 않습니다.
> 따라서 외부에서 직접 호출되는 구조로 유지했습니다.

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->

<img width="188" height="111" alt="image" src="https://github.com/user-attachments/assets/e0df056b-7ae1-479e-9407-5f76235278a1" />

- 가입 시 받는 임시 이름 형태

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
