### PR TITLE
[BE] JPA open-in-view 비활성화

### DIFF
--- a/backend/bottari/src/main/resources/application.yml
+++ b/backend/bottari/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
     hibernate:
       ddl-auto: create
     defer-datasource-initialization: true
+    open-in-view: false
   sql:
     init:
       mode: always


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- JPA open-in-view 비활성화

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #217 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->

> ### WARN 로그 내용
>
> `spring.jpa.open-in-view`는 기본적으로 활성화됩니다. 따라서 뷰 렌더링 중에 데이터베이스 쿼리가 수행될 수 있습니다. 이 경고를 비활성화하려면 `spring.jpa.open-in-view`를 명시적으로 구성하십시오.

```yml
spring:
  jpa:
    open-in-view: true # or false
```

- `open-in-view` 옵션을 직접 명시하면 WARN 로그 자체는 출력되지 않습니다.

### 비활성화 이유

레이어드 아키텍쳐를 사용하고 있으며, 계층별 책임 분리가 명확해집니다.
OIV를 활성화하면 컨틀롤러 계층에서도 지연 로딩이 가능해져서 `컨틀롤러 계층에서도 데이터베이스에 접근`이 가능합니다.
즉, 활성화하는 경우 계층 간 책임이 모호해지는 문제를 야기할 수 있습니다.

서비스 계층에서 비즈니스 로직이 완료되면 데이터베이스 작업도 끝나는 것이 자연스럽습니다.
컨트롤러 계층은 단순히 응답을 만드는 역할만 하므로, 서비스 계층 트랜잭션 종료와 함께 커넥션을 반환하는 것이 리소스 관리 측면에서도 효율적입니다.

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<img width="211" height="30" alt="image" src="https://github.com/user-attachments/assets/6754bc15-8e54-46df-919e-c99097977579" />

- 기존 작성된 테스트 코드도 문제 없이 동작합니다.
  - 이 변경으로 인해 기존 코드에서 LazyInitializationException이 발생할 가능성은 없는 것 같아요!
- [참고 자료](https://velog.io/@hyeok_1212/osiv-%EC%84%A4%EC%A0%95%ED%95%98%EC%8B%9C%EB%82%98%EC%9A%94)

<br>
