### PR TITLE
[AN] Firebase Crashlytics 설정

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -8,6 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+      LOCAL_PROPERTIES_CONTENTS: ${{ secrets.LOCAL_PROPERTIES_CONTENTS }}
+
     defaults:
       run:
         shell: bash

--- a/android/Bottari/app/build.gradle.kts
+++ b/android/Bottari/app/build.gradle.kts
@@ -67,8 +67,4 @@ dependencies {
     testImplementation(libs.bundles.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
-
-    implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.crashlytics.ndk)
-    implementation(libs.firebase.analytics)
 }

--- a/android/Bottari/app/build.gradle.kts
+++ b/android/Bottari/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -15,13 +17,12 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
@@ -30,23 +31,29 @@ android {
 
         debug {
             isMinifyEnabled = false
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-dev"
+            resValue("string", "app_name", "보따리 (Dev)")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
 
-            applicationIdSuffix = ".debug"
-            versionNameSuffix = "-dev"
-            resValue("string", "app_name", "보따리 (Dev)")
+            configure<CrashlyticsExtension> {
+                mappingFileUploadEnabled = false
+            }
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
+
     kotlinOptions {
         jvmTarget = "21"
     }
+
     buildFeatures {
         viewBinding = true
         buildConfig = true
@@ -58,12 +65,13 @@ dependencies {
     implementation(project(":presentation"))
 
     implementation(libs.timber)
+    implementation(libs.material)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
-    implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.constraintlayout)
+
     testImplementation(libs.bundles.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/Bottari/app/build.gradle.kts
+++ b/android/Bottari/app/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.google.gms.google.services)
+    alias(libs.plugins.google.firebase.crashlytics)
 }
 
 android {
@@ -65,4 +67,8 @@ dependencies {
     testImplementation(libs.bundles.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics.ndk)
+    implementation(libs.firebase.analytics)
 }

--- a/android/Bottari/app/proguard-rules.pro
+++ b/android/Bottari/app/proguard-rules.pro
@@ -1,21 +1,41 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# ===== 기본 유지 설정 =====
+# 애플리케이션의 모든 클래스 및 메서드 이름은 난독화되더라도 앱의 진입점은 유지해야 함
+-keep class com.bottari.** { *; }
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# ===== Android 필수 =====
+-keepclassmembers class * extends android.app.Activity {
+    public void *(android.view.View);
+}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# ViewBinding 유지 (예: XxxBinding)
+-keep class **_ViewBinding { *; }
+-keep class **Binding { *; }
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# ===== Retrofit / OkHttp =====
+# Retrofit 인터페이스와 모델 클래스 보존
+-keepattributes Signature
+-keepattributes RuntimeVisibleAnnotations
+-keep class retrofit2.** { *; }
+-keep interface retrofit2.** { *; }
+-keep class kotlinx.serialization.** { *; }
+
+# ===== Firebase Crashlytics =====
+# stack trace 정확히 보고하기 위한 유지 설정
+-keepattributes SourceFile,LineNumberTable
+-keep public class * extends java.lang.Exception
+
+# ===== Kotlin =====
+-keepclassmembers class kotlin.Metadata { *; }
+-dontwarn kotlin.**
+-dontnote kotlin.**
+
+# ===== Timber (로그는 제거 가능) =====
+-assumenosideeffects class timber.log.Timber {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+}
+
+# ===== 기타 =====
+-dontwarn org.jetbrains.annotations.**

--- a/android/Bottari/build.gradle.kts
+++ b/android/Bottari/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.google.gms.google.services) apply false
+    alias(libs.plugins.google.firebase.crashlytics) apply false
 }
 
 allprojects {

--- a/android/Bottari/data/src/main/java/com/bottari/data/local/UserInfoDataStore.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/local/UserInfoDataStore.kt
@@ -1,0 +1,30 @@
+package com.bottari.data.local
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+
+class UserInfoDataStore(
+    private val context: Context,
+) {
+    private val Context.dataStore by preferencesDataStore(name = DATASTORE_NAME)
+    private val keyUserId = stringPreferencesKey(KEY_USER_ID)
+
+    suspend fun saveUserId(userId: String) {
+        context.dataStore.edit { prefs ->
+            prefs[keyUserId] = userId
+        }
+    }
+
+    suspend fun getUserId(): String {
+        val prefs = context.dataStore.data.first()
+        return prefs[keyUserId] ?: ""
+    }
+
+    companion object {
+        private const val DATASTORE_NAME = "user_info"
+        private const val KEY_USER_ID = "KEY_USER_ID"
+    }
+}

--- a/android/Bottari/data/src/main/java/com/bottari/data/mapper/MemberMapper.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/mapper/MemberMapper.kt
@@ -4,5 +4,5 @@ import com.bottari.data.model.member.CheckRegisteredMemberResponse
 import com.bottari.domain.model.member.RegisteredMember
 
 object MemberMapper {
-    fun CheckRegisteredMemberResponse.toDomain(): RegisteredMember = RegisteredMember(name = name, isRegistered = isRegistered)
+    fun CheckRegisteredMemberResponse.toDomain(): RegisteredMember = RegisteredMember(name = name, id = id, isRegistered = isRegistered)
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/member/CheckRegisteredMemberResponse.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/member/CheckRegisteredMemberResponse.kt
@@ -7,6 +7,8 @@ import kotlinx.serialization.Serializable
 data class CheckRegisteredMemberResponse(
     @SerialName("isRegistered")
     val isRegistered: Boolean,
+    @SerialName("id")
+    val id: Long?,
     @SerialName("name")
     val name: String?,
 )

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -3,18 +3,21 @@ package com.bottari.data.repository
 import com.bottari.data.mapper.MemberMapper.toDomain
 import com.bottari.data.model.member.RegisterMemberRequest
 import com.bottari.data.model.member.SaveMemberNicknameRequest
+import com.bottari.data.source.local.UserInfoLocalDataSource
 import com.bottari.data.source.remote.MemberRemoteDataSource
 import com.bottari.domain.model.member.Member
 import com.bottari.domain.model.member.RegisteredMember
 import com.bottari.domain.repository.MemberRepository
+import timber.log.Timber
 
 class MemberRepositoryImpl(
     private val memberRemoteDataSource: MemberRemoteDataSource,
+    private val userInfoLocalDataSource: UserInfoLocalDataSource,
 ) : MemberRepository {
-    override suspend fun registerMember(ssaid: String): Result<Unit> =
-        memberRemoteDataSource.registerMember(
-            RegisterMemberRequest(ssaid),
-        )
+    override suspend fun registerMember(ssaid: String): Result<Long?> =
+        memberRemoteDataSource
+            .registerMember(RegisterMemberRequest(ssaid))
+            .onSuccess { safeSaveUserId(it.toString()) }
 
     override suspend fun saveMemberNickname(member: Member): Result<Unit> =
         memberRemoteDataSource.saveMemberNickname(
@@ -23,5 +26,17 @@ class MemberRepositoryImpl(
         )
 
     override suspend fun checkRegisteredMember(ssaid: String): Result<RegisteredMember> =
-        memberRemoteDataSource.checkRegisteredMember(ssaid).mapCatching { it.toDomain() }
+        memberRemoteDataSource
+            .checkRegisteredMember(ssaid)
+            .mapCatching { it.toDomain() }
+            .onSuccess { safeSaveUserId(it.id.toString()) }
+
+    private suspend fun safeSaveUserId(userId: String) {
+        runCatching { userInfoLocalDataSource.saveUserId(userId) }
+            .onFailure { Timber.e(it, ERROR_SAVE_USER_ID_MESSAGE) }
+    }
+
+    companion object {
+        private const val ERROR_SAVE_USER_ID_MESSAGE = "[ERROR] UserId 저장 실패"
+    }
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/UserInfoLocalDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/UserInfoLocalDataSource.kt
@@ -1,0 +1,7 @@
+package com.bottari.data.source.local
+
+interface UserInfoLocalDataSource {
+    suspend fun saveUserId(userId: String): Result<Unit>
+
+    suspend fun getUserId(): Result<String>
+}

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/UserInfoLocalDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/UserInfoLocalDataSourceImpl.kt
@@ -1,0 +1,17 @@
+package com.bottari.data.source.local
+
+import com.bottari.data.local.UserInfoDataStore
+
+class UserInfoLocalDataSourceImpl(
+    private val dataStore: UserInfoDataStore,
+) : UserInfoLocalDataSource {
+    override suspend fun saveUserId(userId: String): Result<Unit> =
+        runCatching {
+            dataStore.saveUserId(userId)
+        }
+
+    override suspend fun getUserId(): Result<String> =
+        runCatching {
+            dataStore.getUserId()
+        }
+}

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/MemberRemoteDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/MemberRemoteDataSource.kt
@@ -5,7 +5,7 @@ import com.bottari.data.model.member.RegisterMemberRequest
 import com.bottari.data.model.member.SaveMemberNicknameRequest
 
 interface MemberRemoteDataSource {
-    suspend fun registerMember(request: RegisterMemberRequest): Result<Unit>
+    suspend fun registerMember(request: RegisterMemberRequest): Result<Long?>
 
     suspend fun saveMemberNickname(
         ssaid: String,

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/MemberRemoteDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/MemberRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.bottari.data.source.remote
 
+import com.bottari.data.common.extension.extractIdFromHeader
 import com.bottari.data.common.util.safeApiCall
 import com.bottari.data.model.member.CheckRegisteredMemberResponse
 import com.bottari.data.model.member.RegisterMemberRequest
@@ -9,9 +10,10 @@ import com.bottari.data.service.MemberService
 class MemberRemoteDataSourceImpl(
     private val memberService: MemberService,
 ) : MemberRemoteDataSource {
-    override suspend fun registerMember(request: RegisterMemberRequest): Result<Unit> =
-        safeApiCall {
-            memberService.registerMember(request)
+    override suspend fun registerMember(request: RegisterMemberRequest): Result<Long?> =
+        runCatching {
+            val response = memberService.registerMember(request)
+            response.extractIdFromHeader(HEADER_MEMBER_ID_PREFIX)
         }
 
     override suspend fun saveMemberNickname(
@@ -23,4 +25,8 @@ class MemberRemoteDataSourceImpl(
         safeApiCall {
             memberService.checkRegisteredMember(ssaid)
         }
+
+    companion object {
+        private const val HEADER_MEMBER_ID_PREFIX = "/members/"
+    }
 }

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package com.bottari.data.repository
 import com.bottari.data.model.member.CheckRegisteredMemberResponse
 import com.bottari.data.model.member.RegisterMemberRequest
 import com.bottari.data.model.member.SaveMemberNicknameRequest
+import com.bottari.data.source.local.UserInfoLocalDataSource
 import com.bottari.data.source.remote.MemberRemoteDataSource
 import com.bottari.data.testFixture.memberFixture
 import com.bottari.domain.repository.MemberRepository
@@ -24,6 +25,7 @@ import retrofit2.Response
 
 class MemberRepositoryImplTest {
     private lateinit var remoteDataSource: MemberRemoteDataSource
+    private lateinit var userInfoLocalDataSource: UserInfoLocalDataSource
     private lateinit var repository: MemberRepository
     private val errorResponseBody =
         """{"message":"잘못된 요청입니다."}""".toResponseBody("application/json".toMediaType())
@@ -31,7 +33,8 @@ class MemberRepositoryImplTest {
     @BeforeEach
     fun setUp() {
         remoteDataSource = mockk<MemberRemoteDataSource>()
-        repository = MemberRepositoryImpl(remoteDataSource)
+        userInfoLocalDataSource = mockk<UserInfoLocalDataSource>()
+        repository = MemberRepositoryImpl(remoteDataSource, userInfoLocalDataSource)
     }
 
     @DisplayName("회원 등록에 성공하면 Success를 반환한다")
@@ -41,7 +44,7 @@ class MemberRepositoryImplTest {
             // given
             val ssaid = "ssaid"
             val request = RegisterMemberRequest(ssaid)
-            coEvery { remoteDataSource.registerMember(request) } returns Result.success(Unit)
+            coEvery { remoteDataSource.registerMember(request) } returns Result.success(1)
 
             // when
             val result = repository.registerMember(ssaid)
@@ -128,7 +131,7 @@ class MemberRepositoryImplTest {
         runTest {
             // given
             val ssaid = "ssaid"
-            val response = CheckRegisteredMemberResponse(true, "test")
+            val response = CheckRegisteredMemberResponse(true, 1, "test")
             coEvery { remoteDataSource.checkRegisteredMember(ssaid) } returns
                 Result.success(
                     response,
@@ -141,6 +144,7 @@ class MemberRepositoryImplTest {
             assertSoftly(result) {
                 shouldBeSuccess()
                 getOrThrow().isRegistered shouldBe true
+                getOrThrow().id shouldBe 1
                 getOrThrow().name shouldBe "test"
             }
 
@@ -154,7 +158,7 @@ class MemberRepositoryImplTest {
         runTest {
             // given
             val ssaid = "ssaid"
-            val response = CheckRegisteredMemberResponse(false, "test")
+            val response = CheckRegisteredMemberResponse(false, 1, "test")
             coEvery { remoteDataSource.checkRegisteredMember(ssaid) } returns
                 Result.success(
                     response,
@@ -167,6 +171,7 @@ class MemberRepositoryImplTest {
             assertSoftly(result) {
                 shouldBeSuccess()
                 getOrThrow().isRegistered shouldBe false
+                getOrThrow().id shouldBe 1
                 getOrThrow().name shouldBe "test"
             }
         }

--- a/android/Bottari/di/src/main/java/com/bottari/di/DataSourceProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/DataSourceProvider.kt
@@ -2,6 +2,8 @@ package com.bottari.di
 
 import com.bottari.data.source.local.AppConfigDataSource
 import com.bottari.data.source.local.AppConfigLocalDataSourceImpl
+import com.bottari.data.source.local.UserInfoLocalDataSource
+import com.bottari.data.source.local.UserInfoLocalDataSourceImpl
 import com.bottari.data.source.remote.AlarmRemoteDataSource
 import com.bottari.data.source.remote.AlarmRemoteDataSourceImpl
 import com.bottari.data.source.remote.BottariItemRemoteDataSource
@@ -41,5 +43,8 @@ object DataSourceProvider {
     }
     val appConfigDataSource: AppConfigDataSource by lazy {
         AppConfigLocalDataSourceImpl(DataStoreProvider.provideAppConfigDataStore)
+    }
+    val userInfoLocalDataSource: UserInfoLocalDataSource by lazy {
+        UserInfoLocalDataSourceImpl(DataStoreProvider.provideUserInfoDataStore)
     }
 }

--- a/android/Bottari/di/src/main/java/com/bottari/di/DataStoreProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/DataStoreProvider.kt
@@ -1,9 +1,13 @@
 package com.bottari.di
 
 import com.bottari.data.local.AppConfigDataStore
+import com.bottari.data.local.UserInfoDataStore
 
 object DataStoreProvider {
     val provideAppConfigDataStore: AppConfigDataStore by lazy {
         AppConfigDataStore(ApplicationContextProvider.applicationContext)
+    }
+    val provideUserInfoDataStore: UserInfoDataStore by lazy {
+        UserInfoDataStore(ApplicationContextProvider.applicationContext)
     }
 }

--- a/android/Bottari/di/src/main/java/com/bottari/di/RepositoryProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/RepositoryProvider.kt
@@ -14,7 +14,12 @@ import com.bottari.domain.repository.BottariTemplateRepository
 import com.bottari.domain.repository.MemberRepository
 
 object RepositoryProvider {
-    val memberRepository: MemberRepository by lazy { MemberRepositoryImpl(DataSourceProvider.memberRemoteDataSource) }
+    val memberRepository: MemberRepository by lazy {
+        MemberRepositoryImpl(
+            DataSourceProvider.memberRemoteDataSource,
+            DataSourceProvider.userInfoLocalDataSource,
+        )
+    }
     val bottariRepository: BottariRepository by lazy { BottariRepositoryImpl(DataSourceProvider.bottariRemoteDataSource) }
     val alarmRepository: AlarmRepository by lazy { AlarmRepositoryImpl(DataSourceProvider.alarmRemoteDataSource) }
     val bottariItemRepository: BottariItemRepository by lazy {

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/model/member/RegisteredMember.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/model/member/RegisteredMember.kt
@@ -2,5 +2,6 @@ package com.bottari.domain.model.member
 
 data class RegisteredMember(
     val name: String?,
+    val id: Long?,
     val isRegistered: Boolean,
 )

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
@@ -4,7 +4,7 @@ import com.bottari.domain.model.member.Member
 import com.bottari.domain.model.member.RegisteredMember
 
 interface MemberRepository {
-    suspend fun registerMember(ssaid: String): Result<Unit>
+    suspend fun registerMember(ssaid: String): Result<Long?>
 
     suspend fun saveMemberNickname(member: Member): Result<Unit>
 

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/RegisterMemberUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/RegisterMemberUseCase.kt
@@ -5,5 +5,5 @@ import com.bottari.domain.repository.MemberRepository
 class RegisterMemberUseCase(
     private val memberRepository: MemberRepository,
 ) {
-    suspend operator fun invoke(ssaid: String): Result<Unit> = memberRepository.registerMember(ssaid)
+    suspend operator fun invoke(ssaid: String): Result<Long?> = memberRepository.registerMember(ssaid)
 }

--- a/android/Bottari/gradle/libs.versions.toml
+++ b/android/Bottari/gradle/libs.versions.toml
@@ -43,6 +43,11 @@ ktlint = "13.0.0"
 # Logging
 timber = "5.0.1"
 
+# Firebase
+firebaseBom = "34.0.0"
+googleGmsGoogleServices = "4.4.3"
+googleFirebaseCrashlytics = "3.0.5"
+
 [libraries]
 # --- AndroidX Core ---
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -83,6 +88,11 @@ kotest-runner-junit5 = { group = "io.kotest", name = "kotest-runner-junit5", ver
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotestVersion" }
 
+# --- Firebase ---
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
+
 [plugins]
 # --- Android Plugins ---
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -95,6 +105,10 @@ serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref 
 
 # --- Code Quality Plugins ---
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+
+# --- Firebase ---
+google-gms-google-services = { id = "com.google.gms.google-services", version.ref = "googleGmsGoogleServices" }
+google-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "googleFirebaseCrashlytics" }
 
 [bundles]
 test = [

--- a/android/Bottari/presentation/build.gradle.kts
+++ b/android/Bottari/presentation/build.gradle.kts
@@ -70,4 +70,8 @@ dependencies {
     testImplementation(libs.bundles.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics.ndk)
+    implementation(libs.firebase.analytics)
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseActivity.kt
@@ -30,11 +30,6 @@ abstract class BaseActivity<VB : ViewBinding>(
         setupNavigationBar()
     }
 
-    override fun onResume() {
-        super.onResume()
-        CrashlyticsLogger.setScreen(this)
-    }
-
     private fun setWindowInsets() {
         enableEdgeToEdge()
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseActivity.kt
@@ -10,6 +10,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 import androidx.viewbinding.ViewBinding
+import com.bottari.presentation.util.CrashlyticsLogger
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 abstract class BaseActivity<VB : ViewBinding>(
@@ -20,11 +21,18 @@ abstract class BaseActivity<VB : ViewBinding>(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        CrashlyticsLogger.setScreen(this)
+
         binding = bindingFactory(layoutInflater)
         setContentView(binding.root)
         setWindowInsets()
         setupStatusBar()
         setupNavigationBar()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        CrashlyticsLogger.setScreen(this)
     }
 
     private fun setWindowInsets() {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseFragment.kt
@@ -44,11 +44,6 @@ abstract class BaseFragment<VB : ViewBinding>(
         setupWindowInsets()
     }
 
-    override fun onResume() {
-        super.onResume()
-        CrashlyticsLogger.setScreen(this)
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseFragment.kt
@@ -9,6 +9,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.viewbinding.ViewBinding
+import com.bottari.presentation.util.CrashlyticsLogger
 import com.bottari.presentation.view.common.LoadingDialog
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
@@ -20,6 +21,11 @@ abstract class BaseFragment<VB : ViewBinding>(
     val binding: VB get() = _binding!!
 
     private val loadingDialog: LoadingDialog by lazy { LoadingDialog() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        CrashlyticsLogger.setScreen(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -36,6 +42,11 @@ abstract class BaseFragment<VB : ViewBinding>(
     ) {
         super.onViewCreated(view, savedInstanceState)
         setupWindowInsets()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        CrashlyticsLogger.setScreen(this)
     }
 
     override fun onDestroyView() {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/CrashlyticsLogger.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/CrashlyticsLogger.kt
@@ -1,0 +1,65 @@
+package com.bottari.presentation.util
+
+import android.app.Activity
+import androidx.fragment.app.Fragment
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import timber.log.Timber
+
+object CrashlyticsLogger {
+    private const val TAG = "CrashlyticsLogger"
+    private const val KEY_CURRENT_SCREEN = "current_screen"
+    private const val KEY_PARENT_ACTIVITY = "current_parent_activity"
+
+    private const val PREFIX_SET_USER_ID = "[SET_USER_ID] %s"
+    private const val PREFIX_LOG = "[LOG] %s"
+    private const val PREFIX_EXCEPTION = "[EXCEPTION] %s"
+    private const val PREFIX_ACTIVITY_SET_SCREEN = "[SET_ACTIVITY_SCREEN] %s"
+    private const val PREFIX_FRAGMENT_SET_SCREEN = "[SET_FRAGMENT_SCREEN] %s"
+
+    private val crashlytics: FirebaseCrashlytics
+        get() = FirebaseCrashlytics.getInstance()
+
+    fun setUserId(userId: String) {
+        val formatted = PREFIX_SET_USER_ID.format(userId)
+        Timber.tag(TAG).d(formatted)
+        crashlytics.setUserId(userId)
+    }
+
+    fun log(message: String) {
+        val formatted = PREFIX_LOG.format(message)
+        logAndSendToCrashlytics(formatted)
+    }
+
+    fun recordException(throwable: Throwable) {
+        val formatted = PREFIX_EXCEPTION.format(throwable.message.orEmpty())
+        Timber.tag(TAG).i(formatted)
+        crashlytics.log(formatted)
+        crashlytics.recordException(throwable)
+        Timber.tag(TAG).d("")
+    }
+
+    fun setScreen(activity: Activity) {
+        val className = activity::class.java.simpleName
+        val formatted = PREFIX_ACTIVITY_SET_SCREEN.format(className)
+        logAndSendToCrashlytics(formatted)
+        crashlytics.setCustomKey(KEY_CURRENT_SCREEN, className)
+    }
+
+    fun setScreen(fragment: Fragment) {
+        val className = fragment::class.java.simpleName
+        val parentClassName = fragment.activity?.javaClass?.simpleName
+        val formatted = PREFIX_FRAGMENT_SET_SCREEN.format("$parentClassName / $className")
+
+        logAndSendToCrashlytics(formatted)
+
+        crashlytics.setCustomKey(KEY_CURRENT_SCREEN, className)
+        parentClassName?.let {
+            crashlytics.setCustomKey(KEY_PARENT_ACTIVITY, it)
+        }
+    }
+
+    private fun logAndSendToCrashlytics(message: String) {
+        Timber.tag(TAG).d(message)
+        crashlytics.log(message)
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/CrashlyticsLogger.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/CrashlyticsLogger.kt
@@ -2,6 +2,7 @@ package com.bottari.presentation.util
 
 import android.app.Activity
 import androidx.fragment.app.Fragment
+import com.bottari.presentation.BuildConfig
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 
 object CrashlyticsLogger {
@@ -15,6 +16,10 @@ object CrashlyticsLogger {
 
     private val crashlytics: FirebaseCrashlytics
         get() = FirebaseCrashlytics.getInstance()
+
+    init {
+        crashlytics.isCrashlyticsCollectionEnabled = !BuildConfig.DEBUG
+    }
 
     fun setUserId(userId: String) {
         crashlytics.setUserId(userId)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/CrashlyticsLogger.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/CrashlyticsLogger.kt
@@ -3,63 +3,50 @@ package com.bottari.presentation.util
 import android.app.Activity
 import androidx.fragment.app.Fragment
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import timber.log.Timber
 
 object CrashlyticsLogger {
-    private const val TAG = "CrashlyticsLogger"
     private const val KEY_CURRENT_SCREEN = "current_screen"
     private const val KEY_PARENT_ACTIVITY = "current_parent_activity"
 
-    private const val PREFIX_SET_USER_ID = "[SET_USER_ID] %s"
     private const val PREFIX_LOG = "[LOG] %s"
     private const val PREFIX_EXCEPTION = "[EXCEPTION] %s"
-    private const val PREFIX_ACTIVITY_SET_SCREEN = "[SET_ACTIVITY_SCREEN] %s"
-    private const val PREFIX_FRAGMENT_SET_SCREEN = "[SET_FRAGMENT_SCREEN] %s"
+    private const val PREFIX_ACTIVITY_SCREEN = "[SET_ACTIVITY_SCREEN] %s"
+    private const val PREFIX_FRAGMENT_SCREEN = "[SET_FRAGMENT_SCREEN] %s"
 
     private val crashlytics: FirebaseCrashlytics
         get() = FirebaseCrashlytics.getInstance()
 
     fun setUserId(userId: String) {
-        val formatted = PREFIX_SET_USER_ID.format(userId)
-        Timber.tag(TAG).d(formatted)
         crashlytics.setUserId(userId)
     }
 
     fun log(message: String) {
-        val formatted = PREFIX_LOG.format(message)
-        logAndSendToCrashlytics(formatted)
+        crashlytics.log(PREFIX_LOG.format(message))
     }
 
     fun recordException(throwable: Throwable) {
-        val formatted = PREFIX_EXCEPTION.format(throwable.message.orEmpty())
-        Timber.tag(TAG).i(formatted)
-        crashlytics.log(formatted)
-        crashlytics.recordException(throwable)
-        Timber.tag(TAG).d("")
+        with(crashlytics) {
+            log(PREFIX_EXCEPTION.format(throwable.message.orEmpty()))
+            recordException(throwable)
+        }
     }
 
     fun setScreen(activity: Activity) {
         val className = activity::class.java.simpleName
-        val formatted = PREFIX_ACTIVITY_SET_SCREEN.format(className)
-        logAndSendToCrashlytics(formatted)
-        crashlytics.setCustomKey(KEY_CURRENT_SCREEN, className)
-    }
-
-    fun setScreen(fragment: Fragment) {
-        val className = fragment::class.java.simpleName
-        val parentClassName = fragment.activity?.javaClass?.simpleName
-        val formatted = PREFIX_FRAGMENT_SET_SCREEN.format("$parentClassName / $className")
-
-        logAndSendToCrashlytics(formatted)
-
-        crashlytics.setCustomKey(KEY_CURRENT_SCREEN, className)
-        parentClassName?.let {
-            crashlytics.setCustomKey(KEY_PARENT_ACTIVITY, it)
+        with(crashlytics) {
+            log(PREFIX_ACTIVITY_SCREEN.format(className))
+            setCustomKey(KEY_CURRENT_SCREEN, className)
         }
     }
 
-    private fun logAndSendToCrashlytics(message: String) {
-        Timber.tag(TAG).d(message)
-        crashlytics.log(message)
+    fun setScreen(fragment: Fragment) {
+        val fragmentName = fragment::class.java.simpleName
+        val parentName = fragment.activity?.javaClass?.simpleName
+
+        with(crashlytics) {
+            log(PREFIX_FRAGMENT_SCREEN.format("$parentName / $fragmentName"))
+            setCustomKey(KEY_CURRENT_SCREEN, fragmentName)
+            parentName?.let { setCustomKey(KEY_PARENT_ACTIVITY, it) }
+        }
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- Firebase Crashlytics 설정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #181 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- Firebase 의존성 설정
- Firebase Crashlytics 설정
- 디스코드 웹훅 플로우 구축
- `CrashlyticsLogger` 구현
- ProGuard 설정

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

[보따리 - 외부 모니터링 도구 Wiki](https://github.com/woowacourse-teams/2025-bottari/wiki/%5BAN%5D-외부-모니터링-도구-연동)

<br>
