### PR TITLE
[BE] open-in-view 비활성화 및 문제 대응

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/domain/BottariTemplate.java
+++ b/backend/bottari/src/main/java/com/bottari/domain/BottariTemplate.java
@@ -62,6 +62,7 @@ public class BottariTemplate {
         if (!(o instanceof final BottariTemplate bottariTemplate)) {
             return false;
         }
+
         return Objects.equals(getId(), bottariTemplate.getId());
     }
 

--- a/backend/bottari/src/main/java/com/bottari/domain/BottariTemplate.java
+++ b/backend/bottari/src/main/java/com/bottari/domain/BottariTemplate.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,5 +55,18 @@ public class BottariTemplate {
         if (title.isBlank() || title.length() > 15) {
             throw new IllegalArgumentException("보따리 템플릿 이름은 공백이거나 15자를 넘을 수 없습니다.");
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (!(o instanceof final BottariTemplate bottariTemplate)) {
+            return false;
+        }
+        return Objects.equals(getId(), bottariTemplate.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/AlarmRepository.java
@@ -4,6 +4,7 @@ import com.bottari.domain.Alarm;
 import com.bottari.domain.Bottari;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +13,7 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     Optional<Alarm> findByBottariId(final Long id);
 
+    @EntityGraph(attributePaths = {"bottari"})
     List<Alarm> findAllByBottariIn(final List<Bottari> bottaries);
 
     @Modifying(clearAutomatically = true)

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariItemRepository.java
@@ -3,6 +3,7 @@ package com.bottari.repository;
 import com.bottari.domain.Bottari;
 import com.bottari.domain.BottariItem;
 import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +12,7 @@ public interface BottariItemRepository extends JpaRepository<BottariItem, Long> 
 
     List<BottariItem> findAllByBottariId(final Long bottariId);
 
+    @EntityGraph(attributePaths = {"bottari"})
     List<BottariItem> findAllByBottariIn(final List<Bottari> bottaries);
 
     boolean existsByBottariIdAndName(

--- a/backend/bottari/src/main/java/com/bottari/repository/BottariTemplateItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/BottariTemplateItemRepository.java
@@ -3,6 +3,7 @@ package com.bottari.repository;
 import com.bottari.domain.BottariTemplate;
 import com.bottari.domain.BottariTemplateItem;
 import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +12,7 @@ public interface BottariTemplateItemRepository extends JpaRepository<BottariTemp
 
     List<BottariTemplateItem> findAllByBottariTemplateId(final Long id);
 
+    @EntityGraph(attributePaths = {"bottariTemplate"})
     List<BottariTemplateItem> findAllByBottariTemplateIn(final List<BottariTemplate> bottariTemplates);
 
     @Modifying(clearAutomatically = true)

--- a/backend/bottari/src/main/resources/application.yml
+++ b/backend/bottari/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     hibernate:
       ddl-auto: create
     defer-datasource-initialization: true
-    open-in-view: true
+    open-in-view: false
   sql:
     init:
       mode: always


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- open-in-view를 비활성화 시키면서 발생했던, `LazyInitializationException` 발생 부분 해결
  - 관련 이슈: #224 
<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #217 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->

### 문제 상황

- open-in-view 비활성화로 인해 트랜잭션 외부에서 지연 로딩이 발생하면서 `LazyInitializationException` 예외가 발생
    - 레포지토리 계층에서 조회한 엔티티의 연관 엔티티를 `@Transactional`이 붙지 않은 서비스 계층에서 사용하려다 예외 발생
- 추가로 보따리 템플릿의 equals/hashCode 구현되어 있지 않았음 (링해맵에서 사용하지만 구현 X) 

### 해결

- 간단하게 `@EntityGraph`를 사용하여 사용될 엔티티를 미리 가져오도록 하여 Lazy 로딩이 일어나지 않게 처리해둠
  - open-in-view를 비활성화 함으로써 데이터베이스에 접근하려면 트랜잭션 내에서 수행되어야 함을 명확하게 구분함

<img width="206" height="21" alt="image" src="https://github.com/user-attachments/assets/362c46d9-b5f7-4256-b69d-94b1c2ceeefe" />  

- 테스트 코드 모두 통과
- 스웨거로 모든 조회 기능 API 호출 이상 무

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

### 궁금증

```java
// BottariTemplateService#groupingItemsByTemplate 내부
for (final BottariTemplateItem item : items) {
    final BottariTemplate bottariTemplate = item.getBottariTemplate(); 

    // bottariTemplate이 초기화되어 있다면 (Eager 또는 Fetch Join) → true 출력 + 아래 groupByTemplates.get()도 문제 없음
    // 초기화되지 않은 상태라면 → 아래에서 LazyInitializationException 발생
    System.out.println(Hibernate.isInitialized(bottariTemplate)); 

    // bottariTemplate.getId()는 잘 동작함 (초기화 없이 ID 접근 가능)
    // 하지만, bottariTemplate.equals(...) 또는 bottariTemplate.hashCode() 호출 시 예외 발생

    final var bottariTemplateItems = groupByTemplates.get(bottariTemplate); // 이 줄에서 Lazy 예외 발생
    bottariTemplateItems.add(item);
}
```

세션이 종료된 상태에서 초기화되지 않았던 프록시 객체를 초기화시키려 해서 예외가 발생한 것 자체는 맞다. `LazyInitializationException`

세션이 닫힌 상태에서 프록시 객체가 equals()나 hashCode()에서 초기화를 시도하면서 `LazyInitializationException`이 발생함.
`getId()`만 사용한 재정의였는데도 문제가 발생하는 건, 프록시 구현이 해당 메서드 호출 시 초기화를 시도하도록 되어 있기 때문일 수 있음.
이 부분은 프록시 구현체(CGLIB, ByteBuddy 등)에 따라 달라질 수 있고, 디버깅 도중 프록시가 초기화될 수도 있어 주의가 필요함.

진짜 그런지 확인하기 어려우니 내일 확인

<br>
