### PR TITLE
[BE] 컨트롤러 @RequestHeader 적용

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariApiDocs.java
@@ -7,10 +7,10 @@ import com.bottari.bottari.dto.UpdateBottariRequest;
 import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 
@@ -27,7 +27,7 @@ public interface BottariApiDocs {
     })
     ResponseEntity<ReadBottariResponse> read(
             final Long id,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "내 보따리 목록 조회")
@@ -38,7 +38,7 @@ public interface BottariApiDocs {
             ErrorCode.MEMBER_NOT_FOUND
     })
     ResponseEntity<List<ReadBottariPreviewResponse>> readPreviews(
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "보따리 생성")
@@ -52,7 +52,7 @@ public interface BottariApiDocs {
     })
     ResponseEntity<Void> create(
             final CreateBottariRequest request,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "보따리 이름 수정")
@@ -69,7 +69,7 @@ public interface BottariApiDocs {
     ResponseEntity<Void> update(
             final Long id,
             final UpdateBottariRequest request,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "보따리 삭제")
@@ -82,6 +82,6 @@ public interface BottariApiDocs {
     })
     ResponseEntity<Void> delete(
             final Long id,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariController.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariController.java
@@ -1,11 +1,10 @@
 package com.bottari.bottari.controller;
 
-import com.bottari.bottari.service.BottariService;
 import com.bottari.bottari.dto.CreateBottariRequest;
 import com.bottari.bottari.dto.ReadBottariPreviewResponse;
 import com.bottari.bottari.dto.ReadBottariResponse;
 import com.bottari.bottari.dto.UpdateBottariRequest;
-import jakarta.servlet.http.HttpServletRequest;
+import com.bottari.bottari.service.BottariService;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +15,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,9 +30,8 @@ public class BottariController implements BottariApiDocs {
     @Override
     public ResponseEntity<ReadBottariResponse> read(
             @PathVariable final Long id,
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         final ReadBottariResponse response = bottariService.getById(ssaid, id);
 
         return ResponseEntity.ok(response);
@@ -41,9 +40,8 @@ public class BottariController implements BottariApiDocs {
     @GetMapping
     @Override
     public ResponseEntity<List<ReadBottariPreviewResponse>> readPreviews(
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         final List<ReadBottariPreviewResponse> responses = bottariService.getAllBySsaidSortedByLatest(ssaid);
 
         return ResponseEntity.ok(responses);
@@ -53,9 +51,8 @@ public class BottariController implements BottariApiDocs {
     @Override
     public ResponseEntity<Void> create(
             @RequestBody final CreateBottariRequest request,
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         final Long id = bottariService.create(ssaid, request);
 
         return ResponseEntity.created(URI.create("/bottaries/" + id)).build();
@@ -66,9 +63,8 @@ public class BottariController implements BottariApiDocs {
     public ResponseEntity<Void> update(
             @PathVariable final Long id,
             @RequestBody final UpdateBottariRequest request,
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         bottariService.update(request, id, ssaid);
 
         return ResponseEntity.noContent().build();
@@ -78,9 +74,8 @@ public class BottariController implements BottariApiDocs {
     @Override
     public ResponseEntity<Void> delete(
             @PathVariable final Long id,
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         bottariService.deleteById(id, ssaid);
 
         return ResponseEntity.noContent().build();

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateApiDocs.java
@@ -7,10 +7,10 @@ import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 
@@ -36,7 +36,7 @@ public interface BottariTemplateApiDocs {
             ErrorCode.MEMBER_NOT_FOUND
     })
     ResponseEntity<List<ReadBottariTemplateResponse>> readMine(
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "보따리 템플릿 목록 조회")
@@ -74,7 +74,7 @@ public interface BottariTemplateApiDocs {
     })
     ResponseEntity<Void> create(
             final CreateBottariTemplateRequest request,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "보따리 템플릿으로 보따리 생성")
@@ -91,7 +91,7 @@ public interface BottariTemplateApiDocs {
     })
     ResponseEntity<Void> createBottari(
             final Long id,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "보따리 템플릿 삭제")
@@ -104,6 +104,6 @@ public interface BottariTemplateApiDocs {
     })
     ResponseEntity<Void> delete(
             final Long id,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateController.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateController.java
@@ -1,11 +1,10 @@
 package com.bottari.bottaritemplate.controller;
 
-import com.bottari.bottaritemplate.service.BottariTemplateService;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
-import jakarta.servlet.http.HttpServletRequest;
+import com.bottari.bottaritemplate.service.BottariTemplateService;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +15,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,9 +40,8 @@ public class BottariTemplateController implements BottariTemplateApiDocs {
     @GetMapping("/me")
     @Override
     public ResponseEntity<List<ReadBottariTemplateResponse>> readMine(
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         final List<ReadBottariTemplateResponse> responses = bottariTemplateService.getBySsaid(ssaid);
 
         return ResponseEntity.ok(responses);
@@ -73,9 +72,8 @@ public class BottariTemplateController implements BottariTemplateApiDocs {
     @Override
     public ResponseEntity<Void> create(
             @RequestBody final CreateBottariTemplateRequest request,
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         final Long id = bottariTemplateService.create(ssaid, request);
 
         return ResponseEntity.created(URI.create("/templates/" + id)).build();
@@ -85,9 +83,8 @@ public class BottariTemplateController implements BottariTemplateApiDocs {
     @Override
     public ResponseEntity<Void> createBottari(
             @PathVariable final Long id,
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         final Long bottariId = bottariTemplateService.createBottari(id, ssaid);
 
         return ResponseEntity.created(URI.create("/bottaries/" + bottariId)).build();
@@ -97,9 +94,8 @@ public class BottariTemplateController implements BottariTemplateApiDocs {
     @Override
     public ResponseEntity<Void> delete(
             @PathVariable final Long id,
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         bottariTemplateService.deleteById(id, ssaid);
 
         return ResponseEntity.noContent().build();

--- a/backend/bottari/src/main/java/com/bottari/member/controller/MemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/member/controller/MemberApiDocs.java
@@ -1,15 +1,15 @@
 package com.bottari.member.controller;
 
+import com.bottari.error.ApiErrorCodes;
+import com.bottari.error.ErrorCode;
 import com.bottari.member.dto.CheckRegistrationResponse;
 import com.bottari.member.dto.CreateMemberRequest;
 import com.bottari.member.dto.UpdateMemberRequest;
-import com.bottari.error.ApiErrorCodes;
-import com.bottari.error.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Member", description = "사용자 API")
@@ -33,7 +33,7 @@ public interface MemberApiDocs {
             @ApiResponse(responseCode = "200", description = "사용자 회원가입 여부 확인 성공"),
     })
     ResponseEntity<CheckRegistrationResponse> checkRegistration(
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "사용자 이름 수정")
@@ -49,6 +49,6 @@ public interface MemberApiDocs {
     })
     ResponseEntity<Void> updateName(
             final UpdateMemberRequest request,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/member/controller/MemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/member/controller/MemberController.java
@@ -1,10 +1,9 @@
 package com.bottari.member.controller;
 
-import com.bottari.member.service.MemberService;
 import com.bottari.member.dto.CheckRegistrationResponse;
 import com.bottari.member.dto.CreateMemberRequest;
 import com.bottari.member.dto.UpdateMemberRequest;
-import jakarta.servlet.http.HttpServletRequest;
+import com.bottari.member.service.MemberService;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,9 +35,8 @@ public class MemberController implements MemberApiDocs {
     @GetMapping("/check")
     @Override
     public ResponseEntity<CheckRegistrationResponse> checkRegistration(
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         final CheckRegistrationResponse response = memberService.checkRegistration(ssaid);
 
         return ResponseEntity.ok(response);
@@ -47,9 +46,8 @@ public class MemberController implements MemberApiDocs {
     @Override
     public ResponseEntity<Void> updateName(
             @RequestBody final UpdateMemberRequest request,
-            final HttpServletRequest httpServletRequest
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         memberService.updateName(ssaid, request);
 
         return ResponseEntity.noContent().build();

--- a/backend/bottari/src/main/java/com/bottari/report/controller/ReportApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/report/controller/ReportApiDocs.java
@@ -4,9 +4,9 @@ import com.bottari.bottaritemplate.dto.ReportBottariTemplateRequest;
 import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 
 public interface ReportApiDocs {
@@ -23,6 +23,6 @@ public interface ReportApiDocs {
     ResponseEntity<Void> reportBottariTemplate(
             final Long id,
             final ReportBottariTemplateRequest request,
-            final HttpServletRequest httpServletRequest
+            @Parameter(hidden = true) final String ssaid
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/report/controller/ReportController.java
+++ b/backend/bottari/src/main/java/com/bottari/report/controller/ReportController.java
@@ -2,11 +2,12 @@ package com.bottari.report.controller;
 
 import com.bottari.bottaritemplate.dto.ReportBottariTemplateRequest;
 import com.bottari.report.service.ReportService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,10 +22,9 @@ public class ReportController implements ReportApiDocs {
     @Override
     public ResponseEntity<Void> reportBottariTemplate(
             @PathVariable final Long bottariTemplateId,
-            final ReportBottariTemplateRequest request,
-            final HttpServletRequest httpServletRequest
+            @RequestBody final ReportBottariTemplateRequest request,
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        final String ssaid = httpServletRequest.getHeader("ssaid");
         reportService.reportBottariTemplate(ssaid, bottariTemplateId, request);
 
         return ResponseEntity.ok().build();


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 컨트롤러 @RequestHeader 적용

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #245 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- SSAID 헤더 값 추출 시, `@RequestHeader` 사용
- docs에 `@Parameter(hidden = true) final String ssaid` 적용

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
| Before | After |
|--------|-------|
| (이전 화면) | (변경된 화면) |

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

ApiDocs에서 `@Parameter(hidden = true) final String ssaid` 적용해주셔야 합니다.
미적용 시, Swagger 문서에서 이를 QueryParam으로 인식하고 값을 받으려고 합니다.

<br>
