### PR TITLE
[AN] 개인 보따리 생성시 공백 입력 안되는 문제 수정

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateDialog.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateDialog.kt
@@ -22,7 +22,10 @@ class BottariCreateDialog :
     DialogFragment(),
     TextWatcher {
     private val viewModel: BottariCreateViewModel by viewModels {
-        BottariCreateViewModel.Factory(getString(R.string.bottari_create_default_title_text))
+        BottariCreateViewModel.Factory(
+            ssaid = requireContext().getSSAID(),
+            defaultTitle = getString(R.string.bottari_create_default_title_text),
+        )
     }
     private var _binding: DialogBottariCreateBinding? = null
     val binding: DialogBottariCreateBinding get() = _binding!!
@@ -64,7 +67,7 @@ class BottariCreateDialog :
     }
 
     override fun afterTextChanged(s: Editable?) {
-        viewModel.updateBottariTitle(s.toString().trim())
+        viewModel.updateBottariTitle(s.toString())
     }
 
     override fun onTextChanged(
@@ -98,8 +101,7 @@ class BottariCreateDialog :
         binding.etBottariCreateName.addTextChangedListener(this)
         binding.btnBottariCreateClose.setOnClickListener { dismiss() }
         binding.btnBottariCreate.setOnClickListener {
-            val title = binding.etBottariCreateName.text.toString()
-            viewModel.createBottari(requireContext().getSSAID(), title)
+            viewModel.createBottari()
         }
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/bottari/create/BottariCreateViewModel.kt
@@ -28,14 +28,14 @@ class BottariCreateViewModel(
     private val _uiEvent: SingleLiveEvent<BottariCreateUiEvent> = SingleLiveEvent()
     val uiEvent: LiveData<BottariCreateUiEvent> get() = _uiEvent
 
+    private val ssaid: String = stateHandle[KEY_SSAID]!!
+
     fun updateBottariTitle(title: String) {
         _uiState.update { copy(bottariTitle = title) }
     }
 
-    fun createBottari(
-        ssaid: String,
-        title: String,
-    ) {
+    fun createBottari() {
+        val title = uiState.value?.bottariTitle?.trim() ?: return
         if (title.isBlank()) return
 
         viewModelScope.launch {
@@ -46,13 +46,18 @@ class BottariCreateViewModel(
     }
 
     companion object {
+        private const val KEY_SSAID = "KEY_SSAID"
         private const val KEY_BOTTARI_TITLE = "KEY_BOTTARI_TITLE"
         private const val EMPTY_BOTTARI_TITLE = ""
 
-        fun Factory(defaultTitle: String): ViewModelProvider.Factory =
+        fun Factory(
+            ssaid: String,
+            defaultTitle: String,
+        ): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
                     val stateHandle = createSavedStateHandle()
+                    stateHandle[KEY_SSAID] = ssaid
                     stateHandle[KEY_BOTTARI_TITLE] = defaultTitle
 
                     BottariCreateViewModel(


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 보따리 생성시 제목에 trim 시점 변경

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #249

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- API 호출시에만 trim 시키도록 변경

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
