### PR TITLE
[AN] 보따리 편집 화면에서 popupMenu가 간혈적으로 뜨지 않는 버그 수정

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/main/PersonalBottariEditFragment.kt
@@ -32,7 +32,7 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
         val bottariId = requireArguments().getLong(ARG_BOTTARI_ID)
         PersonalBottariEditViewModel.Factory(requireContext().getSSAID(), bottariId)
     }
-    private val popupMenu: PopupMenu by lazy { createPopupMenu() }
+    private lateinit var popupMenu: PopupMenu
     private val itemAdapter: PersonalBottariEditItemAdapter by lazy { PersonalBottariEditItemAdapter() }
     private val permissionLauncher = getPermissionLauncher()
     private val alarmViewBinder: AlarmViewBinder by lazy { AlarmViewBinder(requireContext()) }
@@ -149,6 +149,7 @@ class PersonalBottariEditFragment : BaseFragment<FragmentPersonalBottariEditBind
     }
 
     private fun setupPopupMenu() {
+        popupMenu = createPopupMenu()
         popupMenu.menuInflater.inflate(R.menu.personal_bottari_edit_popup_menu, popupMenu.menu)
     }
 


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- PopupMenu 인스턴스를 lazy 초기화에서 직접 생성으로 변경

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #248

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
-PopupMenu 인스턴스를 lazy 초기화할 시, 생명주기와 맞지 않아서 죽은 view를 참조하고 있는 문제 발생.
option을 클릭할 시 직접 생성으로 변경

<br>

## 📸 스크린샷 (선택)

[Screen_recording_20250806_171225.webm](https://github.com/user-attachments/assets/2e66ed59-c0f9-45bd-a358-24ebdf18f760)

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
