### PR TITLE
[BE] 개인 보따리 체크 시, 본인 확인

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariItemApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariItemApiDocs.java
@@ -1,11 +1,12 @@
 package com.bottari.bottari.controller;
 
 import com.bottari.bottari.dto.CreateBottariItemRequest;
-import com.bottari.bottari.dto.ReadBottariItemResponse;
 import com.bottari.bottari.dto.EditBottariItemsRequest;
+import com.bottari.bottari.dto.ReadBottariItemResponse;
 import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -76,7 +77,8 @@ public interface BottariItemApiDocs {
             ErrorCode.BOTTARI_ITEM_ALREADY_CHECKED
     })
     ResponseEntity<Void> check(
-            final Long id
+            final Long id,
+            @Parameter(hidden = true) final String ssaid
     );
 
     @Operation(summary = "보따리 물품 체크 해제")
@@ -88,6 +90,7 @@ public interface BottariItemApiDocs {
             ErrorCode.BOTTARI_ITEM_ALREADY_UNCHECKED
     })
     ResponseEntity<Void> uncheck(
-            final Long id
+            final Long id,
+            @Parameter(hidden = true) final String ssaid
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariItemController.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariItemController.java
@@ -1,9 +1,9 @@
 package com.bottari.bottari.controller;
 
-import com.bottari.bottari.service.BottariItemService;
 import com.bottari.bottari.dto.CreateBottariItemRequest;
-import com.bottari.bottari.dto.ReadBottariItemResponse;
 import com.bottari.bottari.dto.EditBottariItemsRequest;
+import com.bottari.bottari.dto.ReadBottariItemResponse;
+import com.bottari.bottari.service.BottariItemService;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -67,9 +68,10 @@ public class BottariItemController implements BottariItemApiDocs {
     @PatchMapping("/bottari-items/{id}/check")
     @Override
     public ResponseEntity<Void> check(
-            @PathVariable final Long id
+            @PathVariable final Long id,
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        bottariItemService.check(id);
+        bottariItemService.check(id, ssaid);
 
         return ResponseEntity.noContent().build();
     }
@@ -77,9 +79,10 @@ public class BottariItemController implements BottariItemApiDocs {
     @PatchMapping("/bottari-items/{id}/uncheck")
     @Override
     public ResponseEntity<Void> uncheck(
-            @PathVariable final Long id
+            @PathVariable final Long id,
+            @RequestHeader("ssaid") final String ssaid
     ) {
-        bottariItemService.uncheck(id);
+        bottariItemService.uncheck(id, ssaid);
 
         return ResponseEntity.noContent().build();
     }

--- a/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariItemController.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/controller/BottariItemController.java
@@ -4,6 +4,7 @@ import com.bottari.bottari.dto.CreateBottariItemRequest;
 import com.bottari.bottari.dto.EditBottariItemsRequest;
 import com.bottari.bottari.dto.ReadBottariItemResponse;
 import com.bottari.bottari.service.BottariItemService;
+import com.bottari.config.MemberIdentifier;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -69,7 +69,7 @@ public class BottariItemController implements BottariItemApiDocs {
     @Override
     public ResponseEntity<Void> check(
             @PathVariable final Long id,
-            @RequestHeader("ssaid") final String ssaid
+            @MemberIdentifier final String ssaid
     ) {
         bottariItemService.check(id, ssaid);
 
@@ -80,7 +80,7 @@ public class BottariItemController implements BottariItemApiDocs {
     @Override
     public ResponseEntity<Void> uncheck(
             @PathVariable final Long id,
-            @RequestHeader("ssaid") final String ssaid
+            @MemberIdentifier final String ssaid
     ) {
         bottariItemService.uncheck(id, ssaid);
 

--- a/backend/bottari/src/main/java/com/bottari/bottari/domain/BottariItem.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/domain/BottariItem.java
@@ -54,6 +54,10 @@ public class BottariItem {
         this.isChecked = false;
     }
 
+    public boolean isOwner(final String ssaid) {
+        return bottari.isOwner(ssaid);
+    }
+
     private void validateName(final String name) {
         if (name.isBlank()) {
             throw new BusinessException(ErrorCode.BOTTARI_ITEM_NAME_BLANK);

--- a/backend/bottari/src/main/java/com/bottari/bottari/repository/BottariItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/repository/BottariItemRepository.java
@@ -3,11 +3,20 @@ package com.bottari.bottari.repository;
 import com.bottari.bottari.domain.Bottari;
 import com.bottari.bottari.domain.BottariItem;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface BottariItemRepository extends JpaRepository<BottariItem, Long> {
+
+    @Query("""
+            SELECT bt
+            FROM BottariItem bt
+            JOIN FETCH Bottari b ON bt.id = b.id
+            WHERE bt.id = :id
+            """)
+    Optional<BottariItem> findByIdWithBottari(final Long id);
 
     List<BottariItem> findAllByBottariId(final Long bottariId);
 

--- a/backend/bottari/src/main/java/com/bottari/bottari/service/BottariItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/service/BottariItemService.java
@@ -2,11 +2,11 @@ package com.bottari.bottari.service;
 
 import com.bottari.bottari.domain.Bottari;
 import com.bottari.bottari.domain.BottariItem;
-import com.bottari.bottari.repository.BottariItemRepository;
-import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.bottari.dto.CreateBottariItemRequest;
 import com.bottari.bottari.dto.EditBottariItemsRequest;
 import com.bottari.bottari.dto.ReadBottariItemResponse;
+import com.bottari.bottari.repository.BottariItemRepository;
+import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import java.util.HashSet;
@@ -72,16 +72,24 @@ public class BottariItemService {
     }
 
     @Transactional
-    public void check(final Long id) {
-        final BottariItem bottariItem = bottariItemRepository.findById(id)
+    public void check(
+            final Long id,
+            final String ssaid
+    ) {
+        final BottariItem bottariItem = bottariItemRepository.findByIdWithBottari(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.BOTTARI_ITEM_NOT_FOUND));
+        validateOwner(ssaid, bottariItem);
         bottariItem.check();
     }
 
     @Transactional
-    public void uncheck(final Long id) {
-        final BottariItem bottariItem = bottariItemRepository.findById(id)
+    public void uncheck(
+            final Long id,
+            final String ssaid
+    ) {
+        final BottariItem bottariItem = bottariItemRepository.findByIdWithBottari(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.BOTTARI_ITEM_NOT_FOUND));
+        validateOwner(ssaid, bottariItem);
         bottariItem.uncheck();
     }
 
@@ -153,6 +161,15 @@ public class BottariItemService {
         final int totalItemCount = bottariItemCount + itemNames.size();
         if (totalItemCount > MAX_BOTTARI_ITEMS_COUNT) {
             throw new BusinessException(ErrorCode.BOTTARI_ITEM_MAXIMUM_EXCEEDED, MAX_BOTTARI_ITEMS_COUNT + "개 초과");
+        }
+    }
+
+    private void validateOwner(
+            final String ssaid,
+            final BottariItem bottariItem
+    ) {
+        if (!bottariItem.getBottari().isOwner(ssaid)) {
+            throw new BusinessException(ErrorCode.BOTTARI_ITEM_NOT_OWNED, "본인의 보따리 물품이 아닙니다.");
         }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/bottari/service/BottariItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/service/BottariItemService.java
@@ -168,7 +168,7 @@ public class BottariItemService {
             final String ssaid,
             final BottariItem bottariItem
     ) {
-        if (!bottariItem.getBottari().isOwner(ssaid)) {
+        if (!bottariItem.isOwner(ssaid)) {
             throw new BusinessException(ErrorCode.BOTTARI_ITEM_NOT_OWNED, "본인의 보따리 물품이 아닙니다.");
         }
     }

--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     BOTTARI_ITEM_CHECK_STATE_INVALID(HttpStatus.BAD_REQUEST, "해당 보따리 물품의 체크 상태가 이미 요청된 상태입니다."),
     BOTTARI_ITEM_NAME_BLANK(HttpStatus.BAD_REQUEST, "보따리 물품명은 공백일 수 없습니다."),
     BOTTARI_ITEM_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "보따리 물품명이 너무 깁니다."),
+    BOTTARI_ITEM_NOT_OWNED(HttpStatus.FORBIDDEN, "해당 보따리 물품에 접근할 수 있는 권한이 없습니다."),
 
     // ===== BOTTARI_TEMPLATE 관련 =====
     BOTTARI_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "보따리 템플릿을 찾을 수 없습니다."),

--- a/backend/bottari/src/test/java/com/bottari/bottari/controller/BottariItemControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottari/controller/BottariItemControllerTest.java
@@ -113,11 +113,13 @@ class BottariItemControllerTest {
     void check() throws Exception {
         // given
         final Long bottariItemId = 1L;
+        final String ssaid = "ssaid";
         willDoNothing().given(bottariItemService)
-                .check(bottariItemId);
+                .check(bottariItemId, ssaid);
 
         // when & then
-        mockMvc.perform(patch("/bottari-items/" + bottariItemId + "/check"))
+        mockMvc.perform(patch("/bottari-items/" + bottariItemId + "/check")
+                        .header("ssaid", ssaid))
                 .andExpect(status().isNoContent());
     }
 
@@ -126,11 +128,13 @@ class BottariItemControllerTest {
     void uncheck() throws Exception {
         // given
         final Long bottariItemId = 1L;
+        final String ssaid = "ssaid";
         willDoNothing().given(bottariItemService)
-                .uncheck(bottariItemId);
+                .uncheck(bottariItemId, ssaid);
 
         // when & then
-        mockMvc.perform(patch("/bottari-items/" + bottariItemId + "/uncheck"))
+        mockMvc.perform(patch("/bottari-items/" + bottariItemId + "/uncheck")
+                        .header("ssaid", ssaid))
                 .andExpect(status().isNoContent());
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/bottari/domain/BottariItemTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottari/domain/BottariItemTest.java
@@ -4,10 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.bottari.error.BusinessException;
+import com.bottari.fixture.BottariFixture;
+import com.bottari.fixture.BottariItemFixture;
 import com.bottari.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class BottariItemTest {
@@ -98,5 +101,27 @@ class BottariItemTest {
         assertThatThrownBy(bottariItem::uncheck)
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("해당 보따리 물품은 이미 체크 해제되어 있습니다.");
+    }
+
+    @DisplayName("본인의 보따리 물품인지 확인한다.")
+    @ParameterizedTest
+    @CsvSource({
+            "same_ssaid, true",
+            "diff_ssaid, false"
+    })
+    void isOwner(
+            final String ssaid,
+            final boolean expected
+    ) {
+        // given
+        final Member member = new Member("same_ssaid", "name");
+        final Bottari bottari = BottariFixture.BOTTARI.get(member);
+        final BottariItem bottariItem = BottariItemFixture.BOTTARI_ITEM_1.get(bottari);
+
+        // when
+        final boolean actual = bottariItem.isOwner(ssaid);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/bottari/service/BottariItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottari/service/BottariItemServiceTest.java
@@ -378,11 +378,32 @@ class BottariItemServiceTest {
             entityManager.persist(bottariItem);
 
             // when
-            bottariItemService.check(bottariItem.getId());
+            bottariItemService.check(bottariItem.getId(), member.getSsaid());
 
             // then
             final BottariItem actual = entityManager.find(BottariItem.class, bottariItem.getId());
             assertThat(actual.isChecked()).isTrue();
+        }
+
+        @DisplayName("물품 체크 시, 보따리 물품 주인이 아니라면, 예외를 던진다.")
+        @Test
+        void check_Exception_NotOwned() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final Bottari bottari = BottariFixture.BOTTARI.get(member);
+            entityManager.persist(bottari);
+
+            final BottariItem bottariItem = BottariItemFixture.BOTTARI_ITEM_1.get(bottari);
+            entityManager.persist(bottariItem);
+
+            final String invalidSsaid = "invalid_ssaid";
+
+            // when & then
+            assertThatThrownBy(() -> bottariItemService.check(bottariItem.getId(), invalidSsaid))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 보따리 물품에 접근할 수 있는 권한이 없습니다. - 본인의 보따리 물품이 아닙니다.");
         }
 
         @DisplayName("물품 체크 시, 보따리 물품을 찾을 수 없다면, 예외를 던진다.")
@@ -395,7 +416,7 @@ class BottariItemServiceTest {
             final Long notExistsBottariItemId = 1L;
 
             // when & then
-            assertThatThrownBy(() -> bottariItemService.check(notExistsBottariItemId))
+            assertThatThrownBy(() -> bottariItemService.check(notExistsBottariItemId, member.getSsaid()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("보따리 물품을 찾을 수 없습니다.");
         }
@@ -419,11 +440,32 @@ class BottariItemServiceTest {
             entityManager.persist(bottariItem);
 
             // when
-            bottariItemService.uncheck(bottariItem.getId());
+            bottariItemService.uncheck(bottariItem.getId(), member.getSsaid());
 
             // then
             final BottariItem actual = entityManager.find(BottariItem.class, bottariItem.getId());
             assertThat(actual.isChecked()).isFalse();
+        }
+
+        @DisplayName("물품 체크 해제 시, 보따리 물품 주인이 아니라면, 예외를 던진다.")
+        @Test
+        void uncheck_Exception_NotOwned() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final Bottari bottari = BottariFixture.BOTTARI.get(member);
+            entityManager.persist(bottari);
+
+            final BottariItem bottariItem = BottariItemFixture.BOTTARI_ITEM_1.get(bottari);
+            entityManager.persist(bottariItem);
+
+            final String invalidSsaid = "invalid_ssaid";
+
+            // when & then
+            assertThatThrownBy(() -> bottariItemService.uncheck(bottariItem.getId(), invalidSsaid))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 보따리 물품에 접근할 수 있는 권한이 없습니다. - 본인의 보따리 물품이 아닙니다.");
         }
 
         @DisplayName("물품 체크 해제 시, 보따리 물품을 찾을 수 없다면, 예외를 던진다.")
@@ -436,7 +478,7 @@ class BottariItemServiceTest {
             final Long notExistsBottariItemId = 1L;
 
             // when & then
-            assertThatThrownBy(() -> bottariItemService.uncheck(notExistsBottariItemId))
+            assertThatThrownBy(() -> bottariItemService.uncheck(notExistsBottariItemId, member.getSsaid()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("보따리 물품을 찾을 수 없습니다.");
         }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 개인 보따리 체크 시, 본인 확인 로직 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #251 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 개인 보따리 체크 / 언체크 시, 본인 확인 로직 구현
- `BottariItem` 조회 시, `Bottari` fetch join
- `Bottari` 내의 `isOwner` 메서드 재사용
- 에러코드 추가 `BOTTARI_ITEM_NOT_OWNED(HttpStatus.FORBIDDEN, "해당 보따리 물품에 접근할 수 있는 권한이 없습니다.")`

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
