### PR TITLE
[BE] 팀 보따리 관련 엔티티 설계

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -49,6 +49,11 @@ public enum ErrorCode {
     BOTTARI_TEMPLATE_ITEM_NAME_BLANK(HttpStatus.BAD_REQUEST, "보따리 템플릿 물품명은 공백일 수 없습니다."),
     BOTTARI_TEMPLATE_ITEM_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "보따리 템플릿 물품명이 너무 깁니다."),
 
+    // ===== TEAM_BOTTARI 관련 =====
+    TEAM_BOTTARI_TITLE_BLANK(HttpStatus.BAD_REQUEST, "팀 보따리 제목은 공백일 수 없습니다."),
+    TEAM_BOTTARI_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "팀 보따리 제목이 너무 깁니다."),
+
+
     // ===== ALARM 관련 =====
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알람을 찾을 수 없습니다."),
     ALARM_ALREADY_ACTIVE(HttpStatus.CONFLICT, "알람이 이미 활성화되어 있습니다."),

--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -53,6 +53,9 @@ public enum ErrorCode {
     TEAM_BOTTARI_TITLE_BLANK(HttpStatus.BAD_REQUEST, "팀 보따리 제목은 공백일 수 없습니다."),
     TEAM_BOTTARI_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "팀 보따리 제목이 너무 깁니다."),
 
+    // ===== TEAM_BOTTARI_ITEM 관련 =====
+    TEAM_BOTTARI_ITEM_NAME_BLANK(HttpStatus.BAD_REQUEST, "팀 보따리 물품명은 공백일 수 없습니다."),
+    TEAM_BOTTARI_ITEM_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "팀 보따리 물품명이 너무 깁니다."),
 
     // ===== ALARM 관련 =====
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알람을 찾을 수 없습니다."),

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItem.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItem.java
@@ -1,0 +1,40 @@
+package com.bottari.teambottari.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeamAssignedItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean isChecked;
+
+    @ManyToOne
+    @JoinColumn(name = "team_assigned_item_info_id")
+    private TeamAssignedItemInfo info;
+
+    @ManyToOne
+    @JoinColumn(name = "team_member_id")
+    private TeamMember teamMember;
+
+    public TeamAssignedItem(
+            final TeamAssignedItemInfo info,
+            final TeamMember teamMember
+    ) {
+        this.info = info;
+        this.teamMember = teamMember;
+        this.isChecked = false;
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItem.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItem.java
@@ -1,6 +1,7 @@
 package com.bottari.teambottari.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -21,11 +22,11 @@ public class TeamAssignedItem {
 
     private boolean isChecked;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_assigned_item_info_id")
     private TeamAssignedItemInfo info;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_member_id")
     private TeamMember teamMember;
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItemInfo.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItemInfo.java
@@ -3,6 +3,7 @@ package com.bottari.teambottari.domain;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,7 +24,7 @@ public class TeamAssignedItemInfo {
 
     private String name;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_bottari_id")
     private TeamBottari teamBottari;
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItemInfo.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItemInfo.java
@@ -1,0 +1,47 @@
+package com.bottari.teambottari.domain;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeamAssignedItemInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "team_bottari_id")
+    private TeamBottari teamBottari;
+
+    public TeamAssignedItemInfo(
+            final String name,
+            final TeamBottari teamBottari
+    ) {
+        validateName(name);
+        this.name = name;
+        this.teamBottari = teamBottari;
+    }
+
+    private void validateName(final String name) {
+        if (name.isBlank()) {
+            throw new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NAME_BLANK);
+        }
+        if (name.length() > 20) {
+            throw new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NAME_TOO_LONG, "최대 20자까지 입력 가능합니다.");
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamBottari.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamBottari.java
@@ -11,9 +11,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -33,6 +35,9 @@ public class TeamBottari {
     private Member owner;
 
     private String inviteCode;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
 
     public TeamBottari(
             final String title,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamBottari.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamBottari.java
@@ -1,0 +1,56 @@
+package com.bottari.teambottari.domain;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import com.bottari.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeamBottari {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private Member owner;
+
+    private String inviteCode;
+
+    public TeamBottari(
+            final String title,
+            final Member owner,
+            final String inviteCode
+    ) {
+        validateTitle(title);
+        this.title = title;
+        this.owner = owner;
+        this.inviteCode = inviteCode;
+    }
+
+    private void validateTitle(final String title) {
+        if (title.isBlank()) {
+            throw new BusinessException(ErrorCode.TEAM_BOTTARI_TITLE_BLANK);
+        }
+        if (title.length() > 15) {
+            throw new BusinessException(ErrorCode.TEAM_BOTTARI_TITLE_TOO_LONG, "최대 15자까지 입력 가능합니다.");
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamMember.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamMember.java
@@ -2,6 +2,7 @@ package com.bottari.teambottari.domain;
 
 import com.bottari.member.domain.Member;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,11 +21,11 @@ public class TeamMember {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_bottari_id")
     private TeamBottari teamBottari;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamMember.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamMember.java
@@ -1,0 +1,38 @@
+package com.bottari.teambottari.domain;
+
+import com.bottari.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeamMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "team_bottari_id")
+    private TeamBottari teamBottari;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public TeamMember(
+            final TeamBottari teamBottari,
+            final Member member
+    ) {
+        this.teamBottari = teamBottari;
+        this.member = member;
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamPersonalItem.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamPersonalItem.java
@@ -3,6 +3,7 @@ package com.bottari.teambottari.domain;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,7 +26,7 @@ public class TeamPersonalItem {
 
     private boolean isChecked;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_member_id")
     private TeamMember teamMember;
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamPersonalItem.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamPersonalItem.java
@@ -1,0 +1,50 @@
+package com.bottari.teambottari.domain;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeamPersonalItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private boolean isChecked;
+
+    @ManyToOne
+    @JoinColumn(name = "team_member_id")
+    private TeamMember teamMember;
+
+    public TeamPersonalItem(
+            final String name,
+            final TeamMember teamMember
+    ) {
+        validateName(name);
+        this.name = name;
+        this.teamMember = teamMember;
+        this.isChecked = false;
+    }
+
+    private void validateName(final String name) {
+        if (name.isBlank()) {
+            throw new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NAME_BLANK);
+        }
+        if (name.length() > 20) {
+            throw new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NAME_TOO_LONG, "최대 20자까지 입력 가능합니다.");
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItem.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItem.java
@@ -1,0 +1,40 @@
+package com.bottari.teambottari.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeamSharedItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean isChecked;
+
+    @ManyToOne
+    @JoinColumn(name = "team_shared_item_info_id")
+    private TeamSharedItemInfo info;
+
+    @ManyToOne
+    @JoinColumn(name = "team_member_id")
+    private TeamMember teamMember;
+
+    public TeamSharedItem(
+            final TeamSharedItemInfo info,
+            final TeamMember teamMember
+    ) {
+        this.info = info;
+        this.teamMember = teamMember;
+        this.isChecked = false;
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItem.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItem.java
@@ -1,6 +1,7 @@
 package com.bottari.teambottari.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -21,11 +22,11 @@ public class TeamSharedItem {
 
     private boolean isChecked;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_shared_item_info_id")
     private TeamSharedItemInfo info;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_member_id")
     private TeamMember teamMember;
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItemInfo.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItemInfo.java
@@ -1,0 +1,47 @@
+package com.bottari.teambottari.domain;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeamSharedItemInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "team_bottari_id")
+    private TeamBottari teamBottari;
+
+    public TeamSharedItemInfo(
+            final String name,
+            final TeamBottari teamBottari
+    ) {
+        validateName(name);
+        this.name = name;
+        this.teamBottari = teamBottari;
+    }
+
+    private void validateName(final String name) {
+        if (name.isBlank()) {
+            throw new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NAME_BLANK);
+        }
+        if (name.length() > 20) {
+            throw new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NAME_TOO_LONG, "최대 20자까지 입력 가능합니다.");
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItemInfo.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItemInfo.java
@@ -3,6 +3,7 @@ package com.bottari.teambottari.domain;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,7 +24,7 @@ public class TeamSharedItemInfo {
 
     private String name;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_bottari_id")
     private TeamBottari teamBottari;
 

--- a/backend/bottari/src/test/java/com/bottari/fixture/TeamBottariFixture.java
+++ b/backend/bottari/src/test/java/com/bottari/fixture/TeamBottariFixture.java
@@ -5,7 +5,6 @@ import com.bottari.teambottari.domain.TeamBottari;
 
 public enum TeamBottariFixture {
 
-
     TEAM_BOTTARI("title"),
     TEAM_BOTTARI_2("title2"),
     ANOTHER_TEAM_BOTTARI("another title"),

--- a/backend/bottari/src/test/java/com/bottari/fixture/TeamBottariFixture.java
+++ b/backend/bottari/src/test/java/com/bottari/fixture/TeamBottariFixture.java
@@ -1,0 +1,23 @@
+package com.bottari.fixture;
+
+import com.bottari.member.domain.Member;
+import com.bottari.teambottari.domain.TeamBottari;
+
+public enum TeamBottariFixture {
+
+
+    TEAM_BOTTARI("title"),
+    TEAM_BOTTARI_2("title2"),
+    ANOTHER_TEAM_BOTTARI("another title"),
+    ;
+
+    private final String title;
+
+    TeamBottariFixture(final String title) {
+        this.title = title;
+    }
+
+    public TeamBottari get(final Member member) {
+        return new TeamBottari(title, member, "inviteCode");
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamAssignedItemInfoTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamAssignedItemInfoTest.java
@@ -1,0 +1,42 @@
+package com.bottari.teambottari.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bottari.error.BusinessException;
+import com.bottari.fixture.MemberFixture;
+import com.bottari.fixture.TeamBottariFixture;
+import com.bottari.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TeamAssignedItemInfoTest {
+
+    @DisplayName("팀 보따리 물품명이 공백인 경우, 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   "})
+    void validateName_Blank(final String name) {
+        // given
+        final Member member = MemberFixture.MEMBER.get();
+        final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+
+        // when & then
+        assertThatThrownBy(() -> new TeamAssignedItemInfo(name, teamBottari))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("팀 보따리 물품명은 공백일 수 없습니다.");
+    }
+
+    @DisplayName("팀 보따리 물품명이 20자를 초과하는 경우, 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"이름이너무길어서보따리물품명으로사용할수없습니다", "이름이너무길어서보따리물품명으로사용할수없습니다!"})
+    void validateName_TooLong(final String name) {
+        // given
+        final Member member = MemberFixture.MEMBER.get();
+        final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+
+        // when & then
+        assertThatThrownBy(() -> new TeamAssignedItemInfo(name, teamBottari))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("팀 보따리 물품명이 너무 깁니다. - 최대 20자까지 입력 가능합니다.");
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamBottariTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamBottariTest.java
@@ -1,0 +1,40 @@
+package com.bottari.teambottari.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bottari.bottari.domain.Bottari;
+import com.bottari.error.BusinessException;
+import com.bottari.fixture.MemberFixture;
+import com.bottari.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TeamBottariTest {
+
+    @DisplayName("팀 보따리 제목이 공백인 경우, 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", "     "})
+    void validateTitle_Blank(final String title) {
+        // given
+        final Member member = MemberFixture.MEMBER.get();
+
+        // when & then
+        assertThatThrownBy(() -> new TeamBottari(title, member, "inviteCode"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("팀 보따리 제목은 공백일 수 없습니다.");
+    }
+
+    @DisplayName("팀 보따리 제목이 15자를 초과하는 경우, 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"열다섯글자가넘는보따리이름입니다", "열다섯글자가넘는보따리이름입니다!"})
+    void validateTitle_TooLong(final String title) {
+        // given
+        final Member member = MemberFixture.MEMBER.get();
+
+        // when & then
+        assertThatThrownBy(() -> new TeamBottari(title, member, "inviteCode"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("팀 보따리 제목이 너무 깁니다. - 최대 15자까지 입력 가능합니다.");
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamPersonalItemTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamPersonalItemTest.java
@@ -10,32 +10,34 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class TeamAssignedItemInfoTest {
+class TeamPersonalItemTest {
 
-    @DisplayName("팀 담당 보따리 물품명이 공백인 경우, 예외를 던진다.")
+    @DisplayName("팀 개인 보따리 물품명이 공백인 경우, 예외를 던진다.")
     @ParameterizedTest
     @ValueSource(strings = {"", "   "})
     void validateName_Blank(final String name) {
         // given
         final Member member = MemberFixture.MEMBER.get();
         final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+        final TeamMember teamMember = new TeamMember(teamBottari, member);
 
         // when & then
-        assertThatThrownBy(() -> new TeamAssignedItemInfo(name, teamBottari))
+        assertThatThrownBy(() -> new TeamPersonalItem(name, teamMember))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("팀 보따리 물품명은 공백일 수 없습니다.");
     }
 
-    @DisplayName("팀 담당 보따리 물품명이 20자를 초과하는 경우, 예외를 던진다.")
+    @DisplayName("팀 개인 보따리 물품명이 20자를 초과하는 경우, 예외를 던진다.")
     @ParameterizedTest
     @ValueSource(strings = {"이름이너무길어서보따리물품명으로사용할수없습니다", "이름이너무길어서보따리물품명으로사용할수없습니다!"})
     void validateName_TooLong(final String name) {
         // given
         final Member member = MemberFixture.MEMBER.get();
         final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+        final TeamMember teamMember = new TeamMember(teamBottari, member);
 
         // when & then
-        assertThatThrownBy(() -> new TeamAssignedItemInfo(name, teamBottari))
+        assertThatThrownBy(() -> new TeamPersonalItem(name, teamMember))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("팀 보따리 물품명이 너무 깁니다. - 최대 20자까지 입력 가능합니다.");
     }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamSharedItemInfoTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamSharedItemInfoTest.java
@@ -1,0 +1,46 @@
+package com.bottari.teambottari.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.bottari.bottari.domain.Bottari;
+import com.bottari.bottari.domain.BottariItem;
+import com.bottari.error.BusinessException;
+import com.bottari.fixture.BottariFixture;
+import com.bottari.fixture.MemberFixture;
+import com.bottari.fixture.TeamBottariFixture;
+import com.bottari.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TeamSharedItemInfoTest {
+
+    @DisplayName("팀 보따리 물품명이 공백인 경우, 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   "})
+    void validateName_Blank(final String name) {
+        // given
+        final Member member = MemberFixture.MEMBER.get();
+        final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+
+        // when & then
+        assertThatThrownBy(() -> new TeamSharedItemInfo(name, teamBottari))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("팀 보따리 물품명은 공백일 수 없습니다.");
+    }
+
+    @DisplayName("팀 보따리 물품명이 20자를 초과하는 경우, 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"이름이너무길어서보따리물품명으로사용할수없습니다", "이름이너무길어서보따리물품명으로사용할수없습니다!"})
+    void validateName_TooLong(final String name) {
+        // given
+        final Member member = MemberFixture.MEMBER.get();
+        final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+
+        // when & then
+        assertThatThrownBy(() -> new TeamSharedItemInfo(name, teamBottari))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("팀 보따리 물품명이 너무 깁니다. - 최대 20자까지 입력 가능합니다.");
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamSharedItemInfoTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamSharedItemInfoTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class TeamSharedItemInfoTest {
 
-    @DisplayName("팀 보따리 물품명이 공백인 경우, 예외를 던진다.")
+    @DisplayName("팀 공유 보따리 물품명이 공백인 경우, 예외를 던진다.")
     @ParameterizedTest
     @ValueSource(strings = {"", "   "})
     void validateName_Blank(final String name) {
@@ -30,7 +30,7 @@ class TeamSharedItemInfoTest {
                 .hasMessage("팀 보따리 물품명은 공백일 수 없습니다.");
     }
 
-    @DisplayName("팀 보따리 물품명이 20자를 초과하는 경우, 예외를 던진다.")
+    @DisplayName("팀 공유 보따리 물품명이 20자를 초과하는 경우, 예외를 던진다.")
     @ParameterizedTest
     @ValueSource(strings = {"이름이너무길어서보따리물품명으로사용할수없습니다", "이름이너무길어서보따리물품명으로사용할수없습니다!"})
     void validateName_TooLong(final String name) {


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 관련 엔티티 설계

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #229 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 팀 보따리 관련 엔티티 구현
- 해당 엔티티 기본 검증 로직 구현
- 해당 기본 검증 로직 테스트 추가

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
<img width="1640" height="1002" alt="team_bottari (2)" src="https://github.com/user-attachments/assets/8a80e2fe-56e3-4c33-89cd-a83fb7687f21" />

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- 추가적인 도메인 로직은 기능 구현하면서 추가하는게 나을 것 같음 (예 : check, uncheck ..)
- 현재 `TeamBottari`과 `Alarm`간 의존관계 없음
  - 차후 `Bottari`가 `Alarm`의 외래키를 가지고 있도록 수정 한 후, 이부분도 수정해야 할듯 ? 

<br>
