### PR TITLE
[AN] 알람 ID를 식별하지 못하는 문제

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/receiver/AlarmReceiver.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/receiver/AlarmReceiver.kt
@@ -21,7 +21,7 @@ class AlarmReceiver : BroadcastReceiver() {
     ) {
         val notification = intent.getParcelableCompat<NotificationUiModel>(EXTRA_NOTIFICATION)
         notificationHelper.sendNotification(notification.id, notification.title)
-        scheduler.scheduleNextWeekAlarm(notification)
+        scheduler.scheduleNextAlarm(notification)
         BottariLogger.ui(
             UiEventType.NOTIFICATION_CREATE,
             mapOf("notification_id" to notification.id, "time" to LocalDateTime.now().toString()),

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/AlarmScheduler.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/AlarmScheduler.kt
@@ -47,6 +47,8 @@ class AlarmScheduler(
     }
 
     private fun scheduleNonRepeatAlarm(notification: NotificationUiModel) {
+        val alarm = notification.alarm
+        if (alarm.time.isBefore(LocalTime.now())) return
         val triggerTime =
             LocalDateTime.of(notification.alarm.date, notification.alarm.time).toTimeMillis()
         scheduleAlarmInternal(notification, triggerTime)


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 각 보따리 별 알람의 고유 식별자 통일

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #268

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 보따리 알람 설정 시 알람 유형과 상관없이 하나의 식별자를 사용하도록 개선
- `AlarmReceiver`에서 다음 알람을 설정하는 메소드 호출

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- 일회성 알람을 설정할 때 현재 날짜의 이전 시간을 선택할 경우 바로 알람이 울리는 문제가 있었는데, 우선은 알람 자체가 설정되지 않도록 했습니다. 알람 편집 화면에서 해결할 수 있을 것 같은데 이에 대한 논의가 필요합니다.

<br>
