### PR TITLE
[BE] 팀원 관리 화면에 필요한 데이터 조회 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -52,12 +52,16 @@ public enum ErrorCode {
     BOTTARI_TEMPLATE_ITEM_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "보따리 템플릿 물품명이 너무 깁니다."),
 
     // ===== TEAM_BOTTARI 관련 =====
+    TEAM_BOTTARI_NOT_FOUND(HttpStatus.NOT_FOUND, "팀 보따리를 찾을 수 없습니다."),
     TEAM_BOTTARI_TITLE_BLANK(HttpStatus.BAD_REQUEST, "팀 보따리 제목은 공백일 수 없습니다."),
     TEAM_BOTTARI_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "팀 보따리 제목이 너무 깁니다."),
 
     // ===== TEAM_BOTTARI_ITEM 관련 =====
     TEAM_BOTTARI_ITEM_NAME_BLANK(HttpStatus.BAD_REQUEST, "팀 보따리 물품명은 공백일 수 없습니다."),
     TEAM_BOTTARI_ITEM_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "팀 보따리 물품명이 너무 깁니다."),
+
+    // ===== TEAM_MEMBER 관련 =====
+    MEMBER_NOT_IN_TEAM_BOTTARI(HttpStatus.FORBIDDEN, "해당 팀 보따리의 팀 멤버가 아닙니다."),
 
     // ===== ALARM 관련 =====
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알람을 찾을 수 없습니다."),

--- a/backend/bottari/src/main/java/com/bottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/repository/TeamMemberRepository.java
@@ -1,0 +1,10 @@
+package com.bottari.repository;
+
+import com.bottari.teambottari.domain.TeamMember;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    List<TeamMember> findAllByTeamBottariId(final Long teamBottariId);
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
@@ -1,0 +1,27 @@
+package com.bottari.teambottari.controller;
+
+import com.bottari.error.ApiErrorCodes;
+import com.bottari.error.ErrorCode;
+import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Team Bottari", description = "팀 보따리 API")
+public interface TeamMemberApiDocs {
+
+    @Operation(summary = "팀 보따리 팀원 관리 정보 조회 ")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 보따리 팀원 관리 정보 조회 성공"),
+    })
+    @ApiErrorCodes({
+            ErrorCode.TEAM_BOTTARI_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI
+    })
+    ResponseEntity<ReadTeamMemberInfoResponse> readTeamMemberManagementInfo(
+            final Long teamBottariId,
+            final String ssaid
+    );
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
@@ -1,0 +1,4 @@
+package com.bottari.teambottari.controller;
+
+public class TeamMemberController {
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
@@ -1,4 +1,31 @@
 package com.bottari.teambottari.controller;
 
-public class TeamMemberController {
+import com.bottari.config.MemberIdentifier;
+import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
+import com.bottari.teambottari.service.TeamMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamMemberController implements TeamMemberApiDocs {
+
+    private final TeamMemberService teamMemberService;
+
+    @GetMapping("/team-bottaries/{teamBottariId}/members")
+    @Override
+    public ResponseEntity<ReadTeamMemberInfoResponse> readTeamMemberManagementInfo(
+            @PathVariable final Long teamBottariId,
+            @MemberIdentifier final String ssaid
+    ) {
+        final ReadTeamMemberInfoResponse response = teamMemberService.getTeamMemberInfoByTeamBottariId(
+                teamBottariId,
+                ssaid
+        );
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadTeamMemberInfoResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadTeamMemberInfoResponse.java
@@ -1,0 +1,25 @@
+package com.bottari.teambottari.dto;
+
+import com.bottari.teambottari.domain.TeamBottari;
+import com.bottari.teambottari.domain.TeamMember;
+import java.util.List;
+
+public record ReadTeamMemberInfoResponse(
+        String inviteCode,
+        int teamMemberCount,
+        List<String> teamMemberNames
+) {
+
+    public static ReadTeamMemberInfoResponse of(
+            final TeamBottari teamBottari,
+            final List<TeamMember> teamMembers
+    ) {
+        return new ReadTeamMemberInfoResponse(
+                teamBottari.getInviteCode(),
+                teamMembers.size(),
+                teamMembers.stream()
+                        .map(teamMember -> teamMember.getMember().getName())
+                        .toList()
+        );
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadTeamMemberInfoResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadTeamMemberInfoResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record ReadTeamMemberInfoResponse(
         String inviteCode,
         int teamMemberCount,
+        String ownerName,
         List<String> teamMemberNames
 ) {
 
@@ -17,6 +18,7 @@ public record ReadTeamMemberInfoResponse(
         return new ReadTeamMemberInfoResponse(
                 teamBottari.getInviteCode(),
                 teamMembers.size(),
+                teamBottari.getOwner().getName(),
                 teamMembers.stream()
                         .map(teamMember -> teamMember.getMember().getName())
                         .toList()

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
@@ -1,0 +1,7 @@
+package com.bottari.teambottari.repository;
+
+import com.bottari.teambottari.domain.TeamBottari;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamBottariRepository extends JpaRepository<TeamBottari, Long> {
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -1,0 +1,43 @@
+package com.bottari.teambottari.service;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import com.bottari.repository.TeamMemberRepository;
+import com.bottari.teambottari.domain.TeamBottari;
+import com.bottari.teambottari.domain.TeamMember;
+import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
+import com.bottari.teambottari.repository.TeamBottariRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TeamMemberService {
+
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamBottariRepository teamBottariRepository;
+
+    public ReadTeamMemberInfoResponse getTeamMemberInfoByTeamBottariId(
+            final Long teamBottariId,
+            final String ssaid
+    ) {
+        final TeamBottari teamBottari = teamBottariRepository.findById(teamBottariId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND));
+        final List<TeamMember> teamMembers = teamMemberRepository.findAllByTeamBottariId(teamBottariId);
+        validateMemberInTeam(ssaid, teamMembers);
+
+        return ReadTeamMemberInfoResponse.of(teamBottari, teamMembers);
+    }
+
+    private void validateMemberInTeam(
+            final String ssaid,
+            final List<TeamMember> teamMembers
+    ) {
+        teamMembers.stream()
+                .map(teamMember -> teamMember.getMember().getSsaid())
+                .filter(memberSsaid -> memberSsaid.equals(ssaid))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI));
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
@@ -1,0 +1,58 @@
+package com.bottari.teambottari.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bottari.log.LogFormatter;
+import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
+import com.bottari.teambottari.service.TeamMemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TeamMemberController.class)
+@Import(LogFormatter.class)
+class TeamMemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TeamMemberService teamMemberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("팀원 관리 정보를 조회한다.")
+    @Test
+    void readTeamMemberManagementInfo() throws Exception {
+        // given
+        final String ssaid = "ssaid";
+        final Long teamBottariId = 1L;
+        final ReadTeamMemberInfoResponse response = new ReadTeamMemberInfoResponse(
+                "Invite Code",
+                3,
+                List.of(
+                        "TeamMember1",
+                        "TeamMember2",
+                        "TeamMember3"
+                )
+        );
+        given(teamMemberService.getTeamMemberInfoByTeamBottariId(teamBottariId, ssaid))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/team-bottaries/{teamBottariId}/members", teamBottariId)
+                        .header("ssaid", ssaid))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
@@ -40,6 +40,7 @@ class TeamMemberControllerTest {
         final ReadTeamMemberInfoResponse response = new ReadTeamMemberInfoResponse(
                 "Invite Code",
                 3,
+                "TeamMember1",
                 List.of(
                         "TeamMember1",
                         "TeamMember2",

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
@@ -62,6 +62,7 @@ class TeamMemberServiceTest {
             assertAll(
                     () -> assertThat(actual.inviteCode()).isEqualTo("inviteCode"),
                     () -> assertThat(actual.teamMemberCount()).isEqualTo(2),
+                    () -> assertThat(actual.ownerName()).isEqualTo(owner.getName()),
                     () -> assertThat(actual.teamMemberNames()).containsExactlyInAnyOrder(
                             owner.getName(),
                             anotherMember.getName()

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
@@ -1,0 +1,111 @@
+package com.bottari.teambottari.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import com.bottari.fixture.MemberFixture;
+import com.bottari.fixture.TeamBottariFixture;
+import com.bottari.member.domain.Member;
+import com.bottari.teambottari.domain.TeamBottari;
+import com.bottari.teambottari.domain.TeamMember;
+import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TeamMemberService.class)
+class TeamMemberServiceTest {
+
+    @Autowired
+    private TeamMemberService teamMemberService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+
+    @Nested
+    class GetTeamMemberInfoByTeamBottariIdTest {
+
+        @DisplayName("팀원 정보 및 팀원 초대 코드를 조회한다.")
+        @Test
+        void getTeamMemberInfoByTeamBottariId() {
+            // given
+            final Member owner = MemberFixture.MEMBER.get();
+            entityManager.persist(owner);
+
+            final Member anotherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(anotherMember);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(owner);
+            entityManager.persist(teamBottari);
+
+            final TeamMember ownerTeamMember = new TeamMember(teamBottari, owner);
+            entityManager.persist(ownerTeamMember);
+
+            final TeamMember anotherTeamMember = new TeamMember(teamBottari, anotherMember);
+            entityManager.persist(anotherTeamMember);
+
+            // when
+            final ReadTeamMemberInfoResponse actual = teamMemberService.getTeamMemberInfoByTeamBottariId(
+                    teamBottari.getId(), anotherMember.getSsaid()
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(actual.inviteCode()).isEqualTo("inviteCode"),
+                    () -> assertThat(actual.teamMemberCount()).isEqualTo(2),
+                    () -> assertThat(actual.teamMemberNames()).containsExactlyInAnyOrder(
+                            owner.getName(),
+                            anotherMember.getName()
+                    )
+            );
+        }
+
+        @DisplayName("존재하지 않는 팀 보따리일 경우, 예외를 던진다.")
+        @Test
+        void getTeamMemberInfoByTeamBottariId_Exception_TeamBottariNotFound() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final Long notExistsTeamBottariId = 1L;
+
+            // when & then
+            assertThatThrownBy(() -> teamMemberService.getTeamMemberInfoByTeamBottariId(
+                    notExistsTeamBottariId, member.getSsaid()
+            )).isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.TEAM_BOTTARI_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("해당 ssaid의 멤버가 팀 보따리에 속한 멤버가 아닐 경우, 예외를 던진다.")
+        @Test
+        void getTeamMemberInfoByTeamBottariId_Exception_MemberNotInTeamBottari() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember ownerTeamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(ownerTeamMember);
+
+            final Member anotherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(anotherMember);
+
+            // when & then
+            assertThatThrownBy(() -> teamMemberService.getTeamMemberInfoByTeamBottariId(
+                    teamBottari.getId(), member.getSsaid()
+            )).isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI.getMessage());
+        }
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
@@ -95,15 +95,15 @@ class TeamMemberServiceTest {
             final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
             entityManager.persist(teamBottari);
 
-            final TeamMember ownerTeamMember = new TeamMember(teamBottari, member);
-            entityManager.persist(ownerTeamMember);
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
 
             final Member anotherMember = MemberFixture.ANOTHER_MEMBER.get();
             entityManager.persist(anotherMember);
 
             // when & then
             assertThatThrownBy(() -> teamMemberService.getTeamMemberInfoByTeamBottariId(
-                    teamBottari.getId(), member.getSsaid()
+                    teamBottari.getId(), anotherMember.getSsaid()
             )).isInstanceOf(BusinessException.class)
                     .hasMessage(ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI.getMessage());
         }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
- 팀원 관리 화면에 필요한 데이터 조회 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #313 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 팀원 초대 코드, 팀원 수, 방장 이름, 팀원 이름 목록이 응답됨
  - 팀원 목록은 id에 의존적으로 조회됨 (팀 보따리에 참여한 순서)

<br>


## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
