### PR TITLE
[BE] 내 팀 보따리 목록 조회 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
+@Tag(name = "Team Bottari", description = "팀 보따리 API")
 public interface TeamBottariApiDocs {
 
     @Operation(summary = "보따리 생성")

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
@@ -3,15 +3,28 @@ package com.bottari.teambottari.controller;
 import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import com.bottari.teambottari.dto.CreateTeamBottariRequest;
+import com.bottari.teambottari.dto.ReadTeamBottariPreviewResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Team Bottari", description = "팀 보따리 API")
 public interface TeamBottariApiDocs {
+
+    @Operation(summary = "내가 소속된 팀 보따리 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 소속된 팀 보따리 목록 조회 성공"),
+    })
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND
+    })
+    ResponseEntity<List<ReadTeamBottariPreviewResponse>> readPreviews(
+            @Parameter(hidden = true) final String ssaid
+    );
 
     @Operation(summary = "보따리 생성")
     @ApiResponses(value = {

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariController.java
@@ -2,10 +2,13 @@ package com.bottari.teambottari.controller;
 
 import com.bottari.config.MemberIdentifier;
 import com.bottari.teambottari.dto.CreateTeamBottariRequest;
+import com.bottari.teambottari.dto.ReadTeamBottariPreviewResponse;
 import com.bottari.teambottari.service.TeamBottariService;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +20,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class TeamBottariController implements TeamBottariApiDocs {
 
     private final TeamBottariService teamBottariService;
+
+    @GetMapping
+    @Override
+    public ResponseEntity<List<ReadTeamBottariPreviewResponse>> readPreviews(
+            @MemberIdentifier final String ssaid
+    ) {
+        final List<ReadTeamBottariPreviewResponse> responses = teamBottariService.getAllBySsaid(ssaid);
+
+        return ResponseEntity.ok(responses);
+    }
 
     @PostMapping
     @Override

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "Team Bottari", description = "팀 보따리 API")
+@Tag(name = "Team Member", description = "팀 멤버 API")
 public interface TeamMemberApiDocs {
 
     @Operation(summary = "팀 보따리 팀원 관리 정보 조회 ")

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadTeamBottariPreviewResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadTeamBottariPreviewResponse.java
@@ -1,0 +1,13 @@
+package com.bottari.teambottari.dto;
+
+import com.bottari.alarm.dto.AlarmResponse;
+
+public record ReadTeamBottariPreviewResponse(
+        Long id,
+        String title,
+        int totalItemsCount,
+        int checkedItemsCount,
+        int memberCount,
+        AlarmResponse alarm
+) {
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/TeamBottariMemberCountProjection.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/TeamBottariMemberCountProjection.java
@@ -1,0 +1,8 @@
+package com.bottari.teambottari.dto;
+
+public interface TeamBottariMemberCountProjection {
+
+    Long getTeamBottariId();
+
+    int getMemberCount();
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedItem, Long> {
 
-    List<TeamAssignedItem> findAllByTeamMemberIn(List<TeamMember> teamMembers);
+    List<TeamAssignedItem> findAllByTeamMemberIn(final List<TeamMember> teamMembers);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -1,0 +1,11 @@
+package com.bottari.teambottari.repository;
+
+import com.bottari.teambottari.domain.TeamAssignedItem;
+import com.bottari.teambottari.domain.TeamMember;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedItem, Long> {
+
+    List<TeamAssignedItem> findAllByTeamMemberIn(List<TeamMember> teamMembers);
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -24,7 +24,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             JOIN FETCH tm.teamBottari t
             WHERE m.id = :memberId
            """)
-    List<TeamMember> findAllByMemberId(Long memberId);
+    List<TeamMember> findAllByMemberId(final Long memberId);
 
     @Query("""
             SELECT tm.teamBottari.id AS teamBottariId, COUNT(tm) AS memberCount
@@ -32,5 +32,5 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             WHERE tm.teamBottari IN :teamBottaries
             GROUP BY tm.teamBottari
            """)
-    List<TeamBottariMemberCountProjection> countMembersByTeamBottariIn(List<TeamBottari> teamBottaries);
+    List<TeamBottariMemberCountProjection> countMembersByTeamBottariIn(final List<TeamBottari> teamBottaries);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -1,6 +1,8 @@
 package com.bottari.teambottari.repository;
 
+import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
+import com.bottari.teambottari.dto.TeamBottariMemberCountProjection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +16,21 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             WHERE tm.teamBottari.id = :teamBottariId
            """)
     List<TeamMember> findAllByTeamBottariId(final Long teamBottariId);
+
+    @Query("""
+            SELECT tm
+            FROM TeamMember tm
+            JOIN FETCH tm.member m
+            JOIN FETCH tm.teamBottari t
+            WHERE m.id = :memberId
+           """)
+    List<TeamMember> findAllByMemberId(Long memberId);
+
+    @Query("""
+            SELECT tm.teamBottari.id AS teamBottariId, COUNT(tm) AS memberCount
+            FROM TeamMember tm
+            WHERE tm.teamBottari IN :teamBottaries
+            GROUP BY tm.teamBottari
+           """)
+    List<TeamBottariMemberCountProjection> countMembersByTeamBottariIn(List<TeamBottari> teamBottaries);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -2,7 +2,7 @@ package com.bottari.teambottari.repository;
 
 import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
-import com.bottari.teambottari.dto.TeamBottariMemberCountProjection;
+import com.bottari.teambottari.repository.dto.TeamBottariMemberCountProjection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -20,9 +20,8 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     @Query("""
             SELECT tm
             FROM TeamMember tm
-            JOIN FETCH tm.member m
-            JOIN FETCH tm.teamBottari t
-            WHERE m.id = :memberId
+            JOIN FETCH tm.teamBottari tㅌㅈ
+            WHERE tm.member.id = :memberId
            """)
     List<TeamMember> findAllByMemberId(final Long memberId);
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -25,7 +25,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     @Query("""
             SELECT tm
             FROM TeamMember tm
-            JOIN FETCH tm.teamBottari tㅌㅈ
+            JOIN FETCH tm.teamBottari t
             WHERE tm.member.id = :memberId
            """)
     List<TeamMember> findAllByMemberId(final Long memberId);

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
@@ -1,0 +1,11 @@
+package com.bottari.teambottari.repository;
+
+import com.bottari.teambottari.domain.TeamMember;
+import com.bottari.teambottari.domain.TeamPersonalItem;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamPersonalItemRepository extends JpaRepository<TeamPersonalItem, Long> {
+
+    List<TeamPersonalItem> findAllByTeamMemberIn(List<TeamMember> teamMembers);
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamPersonalItemRepository extends JpaRepository<TeamPersonalItem, Long> {
 
-    List<TeamPersonalItem> findAllByTeamMemberIn(List<TeamMember> teamMembers);
+    List<TeamPersonalItem> findAllByTeamMemberIn(final List<TeamMember> teamMembers);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -1,0 +1,12 @@
+package com.bottari.teambottari.repository;
+
+import com.bottari.teambottari.domain.TeamMember;
+import com.bottari.teambottari.domain.TeamSharedItem;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, Long> {
+
+    List<TeamSharedItem> findAllByTeamMemberIn(Collection<TeamMember> teamMembers);
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -2,11 +2,10 @@ package com.bottari.teambottari.repository;
 
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamSharedItem;
-import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, Long> {
 
-    List<TeamSharedItem> findAllByTeamMemberIn(Collection<TeamMember> teamMembers);
+    List<TeamSharedItem> findAllByTeamMemberIn(final List<TeamMember> teamMembers);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/dto/TeamBottariMemberCountProjection.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/dto/TeamBottariMemberCountProjection.java
@@ -1,4 +1,4 @@
-package com.bottari.teambottari.dto;
+package com.bottari.teambottari.repository.dto;
 
 public interface TeamBottariMemberCountProjection {
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
@@ -12,7 +12,7 @@ import com.bottari.teambottari.domain.TeamPersonalItem;
 import com.bottari.teambottari.domain.TeamSharedItem;
 import com.bottari.teambottari.dto.CreateTeamBottariRequest;
 import com.bottari.teambottari.dto.ReadTeamBottariPreviewResponse;
-import com.bottari.teambottari.dto.TeamBottariMemberCountProjection;
+import com.bottari.teambottari.repository.dto.TeamBottariMemberCountProjection;
 import com.bottari.teambottari.repository.TeamAssignedItemRepository;
 import com.bottari.teambottari.repository.TeamBottariRepository;
 import com.bottari.teambottari.repository.TeamMemberRepository;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
@@ -5,11 +5,23 @@ import com.bottari.error.ErrorCode;
 import com.bottari.member.domain.Member;
 import com.bottari.member.repository.MemberRepository;
 import com.bottari.teambottari.domain.InviteCodeGenerator;
+import com.bottari.teambottari.domain.TeamAssignedItem;
 import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
+import com.bottari.teambottari.domain.TeamPersonalItem;
+import com.bottari.teambottari.domain.TeamSharedItem;
 import com.bottari.teambottari.dto.CreateTeamBottariRequest;
+import com.bottari.teambottari.dto.ReadTeamBottariPreviewResponse;
+import com.bottari.teambottari.dto.TeamBottariMemberCountProjection;
+import com.bottari.teambottari.repository.TeamAssignedItemRepository;
 import com.bottari.teambottari.repository.TeamBottariRepository;
 import com.bottari.teambottari.repository.TeamMemberRepository;
+import com.bottari.teambottari.repository.TeamPersonalItemRepository;
+import com.bottari.teambottari.repository.TeamSharedItemRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -22,6 +34,18 @@ public class TeamBottariService {
     private final TeamBottariRepository teamBottariRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
+    private final TeamSharedItemRepository teamSharedItemRepository;
+    private final TeamAssignedItemRepository teamAssignedItemRepository;
+    private final TeamPersonalItemRepository teamPersonalItemRepository;
+
+    @Transactional(readOnly = true)
+    public List<ReadTeamBottariPreviewResponse> getAllBySsaid(final String ssaid) {
+        final Member member = memberRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        final List<TeamMember> teamMembers = teamMemberRepository.findAllByMemberId(member.getId());
+
+        return buildReadTeamBottariPreviewResponses(teamMembers);
+    }
 
     @Transactional
     public Long create(
@@ -41,5 +65,80 @@ public class TeamBottariService {
         } catch (final DataIntegrityViolationException exception) {
             throw new BusinessException(ErrorCode.TEAM_BOTTARI_INVITE_CODE_GENERATION_FAILED);
         }
+    }
+
+    private List<ReadTeamBottariPreviewResponse> buildReadTeamBottariPreviewResponses(final List<TeamMember> teamMembers) {
+        final Map<TeamMember, List<TeamSharedItem>> teamSharedItemsGroupByTeamMember = groupingTeamSharedItem(teamMembers);
+        final Map<TeamMember, List<TeamAssignedItem>> teamAssignedItemsGroupByTeamMember = groupingTeamAssignedItem(teamMembers);
+        final Map<TeamMember, List<TeamPersonalItem>> teamPersonalItemsGroupByTeamMember = groupingTeamPersonalItem(teamMembers);
+        final Map<Long, Integer> memberCountsByTeamBottariId = getMembersCountByTeamBottariId(teamMembers);
+
+        return teamMembers.stream()
+                .map(teamMember -> {
+                    final TeamBottari teamBottari = teamMember.getTeamBottari();
+                    final List<TeamSharedItem> sharedItems = teamSharedItemsGroupByTeamMember.getOrDefault(teamMember, Collections.emptyList());
+                    final List<TeamAssignedItem> assignedItems = teamAssignedItemsGroupByTeamMember.getOrDefault(teamMember, Collections.emptyList());
+                    final List<TeamPersonalItem> personalItems = teamPersonalItemsGroupByTeamMember.getOrDefault(teamMember, Collections.emptyList());
+                    final int totalItemsCount = sharedItems.size() + assignedItems.size() + personalItems.size();
+                    final int checkedItemsCount = getCheckedItemsCount(sharedItems, assignedItems, personalItems);
+                    final int memberCount = memberCountsByTeamBottariId.getOrDefault(teamBottari.getId(), 0);
+
+                    return new ReadTeamBottariPreviewResponse(
+                            teamBottari.getId(),
+                            teamBottari.getTitle(),
+                            totalItemsCount,
+                            checkedItemsCount,
+                            memberCount,
+                            null // TODO: 알람 매핑 방향 의논 필요, 우선 null 반환
+                    );
+                })
+                .toList();
+    }
+
+    private Map<Long, Integer> getMembersCountByTeamBottariId(final List<TeamMember> teamMembers) {
+        final List<TeamBottari> teamBottaries = teamMembers.stream()
+                .map(TeamMember::getTeamBottari)
+                .distinct()
+                .collect(Collectors.toList());
+        final List<TeamBottariMemberCountProjection> memberCountResponses = teamMemberRepository.countMembersByTeamBottariIn(teamBottaries);
+
+        return memberCountResponses.stream()
+                .collect(Collectors.toMap(
+                        TeamBottariMemberCountProjection::getTeamBottariId,
+                        TeamBottariMemberCountProjection::getMemberCount
+                ));
+    }
+
+    private int getCheckedItemsCount(
+            final List<TeamSharedItem> sharedItems,
+            final List<TeamAssignedItem> assignedItems,
+            final List<TeamPersonalItem> personalItems
+    ) {
+        final long checkedSharedItemsCount = sharedItems.stream().filter(TeamSharedItem::isChecked).count();
+        final long checkedAssignedItemsCount = assignedItems.stream().filter(TeamAssignedItem::isChecked).count();
+        final long checkedPersonalItemsCount = personalItems.stream().filter(TeamPersonalItem::isChecked).count();
+
+        return (int) (checkedSharedItemsCount + checkedAssignedItemsCount + checkedPersonalItemsCount);
+    }
+
+    private Map<TeamMember, List<TeamSharedItem>> groupingTeamSharedItem(final List<TeamMember> teamMembers) {
+        final List<TeamSharedItem> allByTeamMemberIn = teamSharedItemRepository.findAllByTeamMemberIn(teamMembers);
+
+        return allByTeamMemberIn.stream()
+                .collect(Collectors.groupingBy(TeamSharedItem::getTeamMember));
+    }
+
+    private Map<TeamMember, List<TeamAssignedItem>> groupingTeamAssignedItem(final List<TeamMember> teamMembers) {
+        final List<TeamAssignedItem> allByTeamMemberIn = teamAssignedItemRepository.findAllByTeamMemberIn(teamMembers);
+
+        return allByTeamMemberIn.stream()
+                .collect(Collectors.groupingBy(TeamAssignedItem::getTeamMember));
+    }
+
+    private Map<TeamMember, List<TeamPersonalItem>> groupingTeamPersonalItem(final List<TeamMember> teamMembers) {
+        final List<TeamPersonalItem> allByTeamMemberIn = teamPersonalItemRepository.findAllByTeamMemberIn(teamMembers);
+
+        return allByTeamMemberIn.stream()
+                .collect(Collectors.groupingBy(TeamPersonalItem::getTeamMember));
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
@@ -100,9 +100,9 @@ public class TeamBottariService {
                 .map(TeamMember::getTeamBottari)
                 .distinct()
                 .collect(Collectors.toList());
-        final List<TeamBottariMemberCountProjection> memberCountResponses = teamMemberRepository.countMembersByTeamBottariIn(teamBottaries);
+        final List<TeamBottariMemberCountProjection> teamMembersCount = teamMemberRepository.countMembersByTeamBottariIn(teamBottaries);
 
-        return memberCountResponses.stream()
+        return teamMembersCount.stream()
                 .collect(Collectors.toMap(
                         TeamBottariMemberCountProjection::getTeamBottariId,
                         TeamBottariMemberCountProjection::getMemberCount

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariControllerTest.java
@@ -1,14 +1,18 @@
 package com.bottari.teambottari.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bottari.log.LogFormatter;
 import com.bottari.teambottari.dto.CreateTeamBottariRequest;
+import com.bottari.teambottari.dto.ReadTeamBottariPreviewResponse;
 import com.bottari.teambottari.service.TeamBottariService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +35,26 @@ class TeamBottariControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @DisplayName("내가 소속된 팀 보따리 목록을 조회한다.")
+    @Test
+    void readPreviews() throws Exception {
+        // given
+        final String ssaid = "ssaid";
+        final List<ReadTeamBottariPreviewResponse> response = List.of(
+                new ReadTeamBottariPreviewResponse(1L, "title", 5, 3, 2, null),
+                new ReadTeamBottariPreviewResponse(2L, "another title", 10, 7, 3, null)
+        );
+        given(teamBottariService.getAllBySsaid(ssaid))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/team-bottaries")
+                        .header("ssaid", ssaid)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+    }
 
     @DisplayName("팀 보따리를 생성한다.")
     @Test


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 조회 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #324 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 내가 속한 팀 보따리 목록 조회 기능
- 개인 보따리랑 팀 보따리 화면을 분리함 [다이스 PR](https://github.com/woowacourse-teams/2025-bottari/pull/332) 화면 이미지 참고

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- 알람은 아직 미구현 상태입니다. (알람, 엔티티 매핑 방향 논의 필요)

<br>
