### PR TITLE
[BE] 중복된 메서드 제거로 충돌 해결

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -27,12 +27,4 @@ public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, 
             WHERE tsi.teamMember.id = :teamMemberId
             """)
     List<TeamSharedItem> findAllByTeamMemberId(final Long teamMemberId);
-
-    @Query("""
-            SELECT tsi
-            FROM TeamSharedItem tsi
-            JOIN FETCH tsi.info
-            WHERE tsi.teamMember.teamBottari.id = :teamBottariId
-           """)
-    List<TeamSharedItem> findAllByTeamBottariId(final Long teamBottariId);
 }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.bottari.config.JpaAuditingConfig;
 import com.bottari.error.BusinessException;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.fixture.TeamBottariFixture;
@@ -38,6 +39,7 @@ import org.springframework.context.annotation.Import;
         TeamSharedItemService.class,
         TeamAssignedItemService.class,
         TeamPersonalItemService.class,
+        JpaAuditingConfig.class
 })
 public class TeamItemFacadeTest {
 


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 충돌로 생긴 중복된 메서드 지워서 해결

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- 긴급 수정

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->

<img width="213" height="26" alt="image" src="https://github.com/user-attachments/assets/9e67566f-2207-403e-8c94-6bdafb6f30fe" />
- 통과함 

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
