### PR TITLE
[BE] 팀 보따리 초대 코드로 팀 보따리 참여 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
 
     // ===== TEAM_MEMBER 관련 =====
     MEMBER_NOT_IN_TEAM_BOTTARI(HttpStatus.FORBIDDEN, "해당 팀 보따리의 팀 멤버가 아닙니다."),
+    MEMBER_ALREADY_IN_TEAM_BOTTARI(HttpStatus.CONFLICT, "이미 해당 팀 보따리에 참여한 멤버입니다."),
 
     // ===== ALARM 관련 =====
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알람을 찾을 수 없습니다."),

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
@@ -47,7 +47,9 @@ public interface TeamMemberApiDocs {
             @ApiResponse(responseCode = "201", description = "팀 보따리 참가 성공"),
     })
     @ApiErrorCodes({
-            // todo : 추가필요
+            ErrorCode.TEAM_BOTTARI_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.MEMBER_ALREADY_IN_TEAM_BOTTARI,
     })
     ResponseEntity<Void> joinTeamBottari(
             final JoinTeamBottariRequest request,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
@@ -1,8 +1,8 @@
 package com.bottari.teambottari.controller;
 
-import com.bottari.config.MemberIdentifier;
 import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
+import com.bottari.teambottari.dto.JoinTeamBottariRequest;
 import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
 import com.bottari.teambottari.dto.ReadTeamMemberStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,12 +12,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Team Member", description = "팀 멤버 API")
 public interface TeamMemberApiDocs {
 
-    @Operation(summary = "팀 보따리 팀원 관리 정보 조회")
+    @Operation(summary = "팀 보따리 팀원 관리 정보 조회 ")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "팀 보따리 팀원 관리 정보 조회 성공"),
     })
@@ -40,6 +39,18 @@ public interface TeamMemberApiDocs {
     })
     ResponseEntity<List<ReadTeamMemberStatusResponse>> readTeamMemberStatus(
             final Long teamBottariId,
+            @Parameter(hidden = true) final String ssaid
+    );
+
+    @Operation(summary = "팀 보따리 참가")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "팀 보따리 참가 성공"),
+    })
+    @ApiErrorCodes({
+            // todo : 추가필요
+    })
+    ResponseEntity<Void> joinTeamBottari(
+            final JoinTeamBottariRequest request,
             @Parameter(hidden = true) final String ssaid
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Team Member", description = "팀 멤버 API")
 public interface TeamMemberApiDocs {
 
-    @Operation(summary = "팀 보따리 팀원 관리 정보 조회 ")
+    @Operation(summary = "팀 보따리 팀원 관리 정보 조회")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "팀 보따리 팀원 관리 정보 조회 성공"),
     })

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
@@ -1,14 +1,18 @@
 package com.bottari.teambottari.controller;
 
 import com.bottari.config.MemberIdentifier;
+import com.bottari.teambottari.dto.JoinTeamBottariRequest;
 import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
 import com.bottari.teambottari.dto.ReadTeamMemberStatusResponse;
 import com.bottari.teambottari.service.TeamMemberService;
+import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,5 +47,16 @@ public class TeamMemberController implements TeamMemberApiDocs {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/team-bottaries/members/join")
+    @Override
+    public ResponseEntity<Void> joinTeamBottari(
+            @RequestBody final JoinTeamBottariRequest request,
+            @MemberIdentifier final String ssaid
+    ) {
+        final Long id = teamMemberService.joinTeamBottari(request, ssaid);
+
+        return ResponseEntity.created(URI.create("/team-members/" + id)).build();
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
@@ -49,7 +49,7 @@ public class TeamMemberController implements TeamMemberApiDocs {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/team-bottaries/members/join")
+    @PostMapping("/team-bottaries/join")
     @Override
     public ResponseEntity<Void> joinTeamBottari(
             @RequestBody final JoinTeamBottariRequest request,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/JoinTeamBottariRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/JoinTeamBottariRequest.java
@@ -1,0 +1,6 @@
+package com.bottari.teambottari.dto;
+
+public record JoinTeamBottariRequest(
+        String inviteCode
+) {
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
@@ -1,7 +1,10 @@
 package com.bottari.teambottari.repository;
 
 import com.bottari.teambottari.domain.TeamBottari;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamBottariRepository extends JpaRepository<TeamBottari, Long> {
+
+    Optional<TeamBottari> findByInviteCode(final String inviteCode);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -43,4 +43,9 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             final Long teamBottariId,
             final String ssaid
     );
+
+    boolean existsByTeamBottariIdAndMemberId(
+            final Long teamBottariId,
+            final Long memberId
+    );
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -72,7 +72,7 @@ public class TeamMemberService {
                         "해당하는 초대코드 없음"));
         final Member member = memberRepository.findBySsaid(ssaid)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        validateMemberNotInTeam(teamBottari.getId(), ssaid);
+        validateMemberNotInTeam(teamBottari, member);
         final TeamMember teamMember = new TeamMember(teamBottari, member);
         teamMemberRepository.save(teamMember);
         addTeamMemberSharedItems(teamBottari.getId(), teamMember);
@@ -104,10 +104,10 @@ public class TeamMemberService {
     }
 
     private void validateMemberNotInTeam(
-            final Long teamBottariId,
-            final String ssaid
+            final TeamBottari teamBottari,
+            final Member member
     ) {
-        if (teamMemberRepository.existsByTeamBottariIdAndMemberSsaid(teamBottariId, ssaid)) {
+        if (teamMemberRepository.existsByTeamBottariIdAndMemberId(teamBottari.getId(), member.getId())) {
             throw new BusinessException(ErrorCode.MEMBER_ALREADY_IN_TEAM_BOTTARI);
         }
     }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -71,7 +71,7 @@ public class TeamMemberService {
                         ErrorCode.TEAM_BOTTARI_NOT_FOUND,
                         "해당하는 초대코드 없음"));
         final Member member = memberRepository.findBySsaid(ssaid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
         validateMemberNotInTeam(teamBottari, member);
         final TeamMember teamMember = new TeamMember(teamBottari, member);
         teamMemberRepository.save(teamMember);

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -87,10 +87,10 @@ public class TeamMemberService {
         final List<TeamSharedItemInfo> sharedItemInfos = teamSharedItemInfoRepository.findAllByTeamBottariId(
                 teamBottariId
         );
-        for (final TeamSharedItemInfo info : sharedItemInfos) {
-            final TeamSharedItem teamSharedItem = new TeamSharedItem(info, teamMember);
-            teamSharedItemRepository.save(teamSharedItem);
-        }
+        final List<TeamSharedItem> teamSharedItems = sharedItemInfos.stream()
+                .map(info -> new TeamSharedItem(info, teamMember))
+                .toList();
+        teamSharedItemRepository.saveAll(teamSharedItems);
     }
 
     private void validateMemberInTeam(

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -2,16 +2,21 @@ package com.bottari.teambottari.service;
 
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
+import com.bottari.member.domain.Member;
+import com.bottari.member.repository.MemberRepository;
 import com.bottari.teambottari.domain.TeamAssignedItem;
 import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamSharedItem;
+import com.bottari.teambottari.domain.TeamSharedItemInfo;
+import com.bottari.teambottari.dto.JoinTeamBottariRequest;
 import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
 import com.bottari.teambottari.dto.ReadTeamMemberStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
 import com.bottari.teambottari.repository.TeamAssignedItemRepository;
 import com.bottari.teambottari.repository.TeamBottariRepository;
 import com.bottari.teambottari.repository.TeamMemberRepository;
+import com.bottari.teambottari.repository.TeamSharedItemInfoRepository;
 import com.bottari.teambottari.repository.TeamSharedItemRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +31,8 @@ public class TeamMemberService {
     private final TeamBottariRepository teamBottariRepository;
     private final TeamSharedItemRepository teamSharedItemRepository;
     private final TeamAssignedItemRepository teamAssignedItemRepository;
+    private final TeamSharedItemInfoRepository teamSharedItemInfoRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
     public ReadTeamMemberInfoResponse getTeamMemberInfoByTeamBottariId(
@@ -54,6 +61,38 @@ public class TeamMemberService {
                 .toList();
     }
 
+    @Transactional
+    public Long joinTeamBottari(
+            final JoinTeamBottariRequest request,
+            final String ssaid
+    ) {
+        final TeamBottari teamBottari = teamBottariRepository.findByInviteCode(request.inviteCode())
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.TEAM_BOTTARI_NOT_FOUND,
+                        "해당하는 초대코드 없음"));
+        final Member member = memberRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        validateMemberNotInTeam(teamBottari.getId(), ssaid);
+        final TeamMember teamMember = new TeamMember(teamBottari, member);
+        teamMemberRepository.save(teamMember);
+        addTeamMemberSharedItems(teamBottari.getId(), teamMember);
+
+        return teamMember.getId();
+    }
+
+    private void addTeamMemberSharedItems(
+            final Long teamBottariId,
+            final TeamMember teamMember
+    ) {
+        final List<TeamSharedItemInfo> sharedItemInfos = teamSharedItemInfoRepository.findAllByTeamBottariId(
+                teamBottariId
+        );
+        for (final TeamSharedItemInfo info : sharedItemInfos) {
+            final TeamSharedItem teamSharedItem = new TeamSharedItem(info, teamMember);
+            teamSharedItemRepository.save(teamSharedItem);
+        }
+    }
+
     private void validateMemberInTeam(
             final String ssaid,
             final List<TeamMember> teamMembers
@@ -62,6 +101,15 @@ public class TeamMemberService {
                 .filter(teamMember -> teamMember.getMember().isSameBySsaid(ssaid))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI));
+    }
+
+    private void validateMemberNotInTeam(
+            final Long teamBottariId,
+            final String ssaid
+    ) {
+        if (teamMemberRepository.existsByTeamBottariIdAndMemberSsaid(teamBottariId, ssaid)) {
+            throw new BusinessException(ErrorCode.MEMBER_ALREADY_IN_TEAM_BOTTARI);
+        }
     }
 
     private void validateTeamBottariExists(final Long teamBottariId) {

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
@@ -113,7 +113,7 @@ class TeamMemberControllerTest {
                 .willReturn(teamMemberId);
 
         // when & then
-        mockMvc.perform(post("/team-bottaries/members/join")
+        mockMvc.perform(post("/team-bottaries/join")
                         .header("ssaid", ssaid)
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(request)))

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
@@ -2,10 +2,13 @@ package com.bottari.teambottari.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bottari.log.LogFormatter;
+import com.bottari.teambottari.dto.JoinTeamBottariRequest;
 import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
 import com.bottari.teambottari.dto.ReadTeamMemberStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
@@ -97,5 +100,24 @@ class TeamMemberControllerTest {
                         .header("ssaid", ssaid))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(response)));
+    }
+
+    @DisplayName("멤버가 팀 보따리에 참가한다.")
+    @Test
+    void joinTeamBottari() throws Exception {
+        // given
+        final String ssaid = "ssaid";
+        final Long teamMemberId = 1L;
+        final JoinTeamBottariRequest request = new JoinTeamBottariRequest("inviteCode");
+        given(teamMemberService.joinTeamBottari(request, ssaid))
+                .willReturn(teamMemberId);
+
+        // when & then
+        mockMvc.perform(post("/team-bottaries/members/join")
+                        .header("ssaid", ssaid)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/team-members/" + teamMemberId));
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
@@ -359,7 +359,7 @@ class TeamMemberServiceTest {
             // when & then
             assertThatThrownBy(() -> teamMemberService.joinTeamBottari(request, notExistsSsaid))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage("사용자를 찾을 수 없습니다.");
+                    .hasMessage("사용자를 찾을 수 없습니다. - 등록되지 않은 ssaid입니다.");
         }
 
         @DisplayName("이미 팀 보따리에 속한 멤버일 경우, 예외를 던진다.")

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
@@ -14,6 +14,7 @@ import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamSharedItem;
 import com.bottari.teambottari.domain.TeamSharedItemInfo;
+import com.bottari.teambottari.dto.JoinTeamBottariRequest;
 import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
 import com.bottari.teambottari.dto.ReadTeamMemberStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
@@ -241,6 +242,143 @@ class TeamMemberServiceTest {
                     teamBottari.getId(), anotherMember.getSsaid()
             )).isInstanceOf(BusinessException.class)
                     .hasMessage("해당 팀 보따리의 팀 멤버가 아닙니다.");
+        }
+    }
+
+    @Nested
+    class JoinTeamBottariTest {
+
+        @DisplayName("해당 멤버가 팀 보따리에 참가한다.")
+        @Test
+        void joinTeamBottari() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final Member joinMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(joinMember);
+
+            final JoinTeamBottariRequest request = new JoinTeamBottariRequest(teamBottari.getInviteCode());
+
+            // when
+            final Long joinTeamMemberId = teamMemberService.joinTeamBottari(request, joinMember.getSsaid());
+
+            // then
+            final TeamMember findTeamMember = entityManager.find(TeamMember.class, joinTeamMemberId);
+            assertAll(
+                    () -> assertThat(findTeamMember).isNotNull(),
+                    () -> assertThat(findTeamMember.getTeamBottari()).isEqualTo(teamBottari),
+                    () -> assertThat(findTeamMember.getMember()).isEqualTo(joinMember)
+            );
+        }
+
+        @DisplayName("팀 보따리에 팀 멤버를 추가하면, 해당 멤버의 팀 보따리 공통 물건도 추가된다.")
+        @Test
+        void joinTeamBottari_AddTeamMemberSharedItems() {
+            // given
+            final Member owner = MemberFixture.MEMBER.get();
+            entityManager.persist(owner);
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(owner);
+            entityManager.persist(teamBottari);
+            final TeamMember ownerTeamMember = new TeamMember(teamBottari, owner);
+            entityManager.persist(ownerTeamMember);
+
+            final TeamSharedItemInfo teamSharedItemInfo1 = new TeamSharedItemInfo("sharedItem1", teamBottari);
+            final TeamSharedItemInfo teamSharedItemInfo2 = new TeamSharedItemInfo("sharedItem2", teamBottari);
+            entityManager.persist(teamSharedItemInfo1);
+            entityManager.persist(teamSharedItemInfo2);
+
+            final TeamSharedItem teamSharedItem1 = new TeamSharedItem(teamSharedItemInfo1, ownerTeamMember);
+            final TeamSharedItem teamSharedItem2 = new TeamSharedItem(teamSharedItemInfo2, ownerTeamMember);
+            entityManager.persist(teamSharedItem1);
+            entityManager.persist(teamSharedItem2);
+
+            final Member joinMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(joinMember);
+
+            final JoinTeamBottariRequest request = new JoinTeamBottariRequest(teamBottari.getInviteCode());
+
+            // when
+            final Long joinTeamMemberId = teamMemberService.joinTeamBottari(request, joinMember.getSsaid());
+
+            // then
+            final List<TeamSharedItem> joinTeamMemberSharedItems = entityManager.createQuery("""
+                            SELECT tsi
+                            FROM TeamSharedItem tsi
+                            WHERE tsi.teamMember.id = :teamMemberId
+                            """, TeamSharedItem.class)
+                    .setParameter("teamMemberId", joinTeamMemberId)
+                    .getResultList();
+
+            assertAll(
+                    () -> assertThat(joinTeamMemberSharedItems).hasSize(2),
+                    () -> assertThat(joinTeamMemberSharedItems).extracting("info.name")
+                            .containsExactlyInAnyOrder("sharedItem1", "sharedItem2"),
+                    () -> assertThat(joinTeamMemberSharedItems.get(0).getTeamMember().getMember()).isEqualTo(
+                            joinMember),
+                    () -> assertThat(joinTeamMemberSharedItems.get(1).getTeamMember().getMember()).isEqualTo(joinMember)
+            );
+        }
+
+        @DisplayName("초대코드에 해당하는 팀 보따리가 존재하지 않는 경우, 예외를 던진다.")
+        @Test
+        void joinTeamBottari_Exception_TeamBottariNotFound() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final String notExistsTeamBottariInviteCode = "notExistsInviteCode";
+            final JoinTeamBottariRequest request = new JoinTeamBottariRequest(notExistsTeamBottariInviteCode);
+
+            // when & then
+            assertThatThrownBy(() -> teamMemberService.joinTeamBottari(request, member.getSsaid()))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("팀 보따리를 찾을 수 없습니다. - 해당하는 초대코드 없음");
+        }
+
+        @DisplayName("존재하지 않는 멤버일 경우, 예외를 던진다.")
+        @Test
+        void joinTeamBottari_Exception_MemberNotFound() {
+            // given
+            final Member owner = MemberFixture.MEMBER.get();
+            entityManager.persist(owner);
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(owner);
+            entityManager.persist(teamBottari);
+            final TeamMember teamMember = new TeamMember(teamBottari, owner);
+            entityManager.persist(teamMember);
+
+            final String notExistsSsaid = "notExistsSsaid";
+            final JoinTeamBottariRequest request = new JoinTeamBottariRequest(teamBottari.getInviteCode());
+
+            // when & then
+            assertThatThrownBy(() -> teamMemberService.joinTeamBottari(request, notExistsSsaid))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("사용자를 찾을 수 없습니다.");
+        }
+
+        @DisplayName("이미 팀 보따리에 속한 멤버일 경우, 예외를 던진다.")
+        @Test
+        void joinTeamBottari_Exception_MemberAlreadyInTeamBottari() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final JoinTeamBottariRequest request = new JoinTeamBottariRequest(teamBottari.getInviteCode());
+
+            // when & then
+            assertThatThrownBy(() -> teamMemberService.joinTeamBottari(request, member.getSsaid()))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("이미 해당 팀 보따리에 참여한 멤버입니다.");
         }
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 초대 코드와 ssaid를 통해 팀 보따리에 참여하는 API

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #349 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 비즈니스 로직 수행 순서
  1. 초대코드에 해당하는 팀 보따리 존재 여부 확인
  2. 멤버 존재 여부 확인
  3. 해당 멤버 팀 보따리 미소속 확인
  4. 해당 멤버를 팀 보따리의 팀 멤버로 추가
  5. 팀 보따리 공통 물건을 해당 팀 멤버에게 추가

<br>


## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
