### PR TITLE
[BE] 팀 보따리 현황 내, 보채기 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -65,6 +65,10 @@ public enum ErrorCode {
     TEAM_BOTTARI_ITEM_NOT_OWNED(HttpStatus.FORBIDDEN, "해당 팀 보따리 물품에 접근할 수 있는 권한이 없습니다."),
     TEAM_BOTTARI_ITEM_ALREADY_CHECKED(HttpStatus.CONFLICT, "해당 팀 보따리 물품은 이미 체크되어 있습니다."),
     TEAM_BOTTARI_ITEM_ALREADY_UNCHECKED(HttpStatus.CONFLICT, "해당 팀 보따리 물품은 이미 체크 해제되어 있습니다."),
+    TEAM_BOTTARI_ITEM_INAPPROPRIATE_TYPE(HttpStatus.BAD_REQUEST, "적절하지 않은 아이템 타입입니다."),
+
+    // ===== TEAM_BOTTARI_ITEM_INFO 관련 =====
+    TEAM_BOTTARI_ITEM_INFO_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀 보따리 물품 정보를 찾을 수 없습니다."),
 
     // ===== TEAM_MEMBER 관련 =====
     MEMBER_NOT_IN_TEAM_BOTTARI(HttpStatus.FORBIDDEN, "해당 팀 보따리의 팀 멤버가 아닙니다."),
@@ -86,8 +90,7 @@ public enum ErrorCode {
 
     // ===== 기타 =====
     DATE_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 날짜 형식입니다."),
-    NUMBER_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 숫자 형식입니다.")
-    ;
+    NUMBER_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 숫자 형식입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageSender.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageSender.java
@@ -70,7 +70,7 @@ public class FcmMessageSender {
         final MessagingErrorCode messagingErrorCode = exception.getMessagingErrorCode();
 
         return messagingErrorCode == MessagingErrorCode.UNREGISTERED
-                || messagingErrorCode == MessagingErrorCode.INVALID_ARGUMENT;
+               || messagingErrorCode == MessagingErrorCode.INVALID_ARGUMENT;
     }
 
     private Message createMessage(
@@ -79,8 +79,8 @@ public class FcmMessageSender {
     ) {
         return Message.builder()
                 .setToken(fcmToken.getToken())
-                .setNotification(request.createNotification())
                 .putData("type", request.messageType().name())
+                .putAllData(request.dataToJsonValue())
                 .build();
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/fcm/dto/MessageType.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/dto/MessageType.java
@@ -3,5 +3,6 @@ package com.bottari.fcm.dto;
 public enum MessageType {
 
     TEAM_ITEM_CHANGED,
-    HURRY_UP
+    REMIND,
+    ;
 }

--- a/backend/bottari/src/main/java/com/bottari/fcm/dto/SendMessageRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/dto/SendMessageRequest.java
@@ -1,5 +1,6 @@
 package com.bottari.fcm.dto;
 
+import com.bottari.teambottari.domain.TeamBottari;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -7,6 +8,22 @@ public record SendMessageRequest(
         Map<String, Object> data,
         MessageType messageType
 ) {
+
+    private static final String TEAM_BOTTARI_ID = "teamBottariId";
+    private static final String TEAM_BOTTARI_TITLE = "teamBottariTitle";
+
+    public static SendMessageRequest of(
+            final TeamBottari teamBottari,
+            final MessageType messageType
+    ) {
+        return new SendMessageRequest(
+                Map.of(
+                        TEAM_BOTTARI_ID, teamBottari.getId(),
+                        TEAM_BOTTARI_TITLE, teamBottari.getTitle()
+                ),
+                messageType
+        );
+    }
 
     public Map<String, String> dataToJsonValue() {
         return data.keySet()

--- a/backend/bottari/src/main/java/com/bottari/fcm/dto/SendMessageRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/dto/SendMessageRequest.java
@@ -1,17 +1,16 @@
 package com.bottari.fcm.dto;
 
-import com.google.firebase.messaging.Notification;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public record SendMessageRequest(
-        String title,
-        String message,
+        Map<String, Object> data,
         MessageType messageType
 ) {
 
-    public Notification createNotification() {
-        return Notification.builder()
-                .setTitle(title)
-                .setBody(message)
-                .build();
+    public Map<String, String> dataToJsonValue() {
+        return data.keySet()
+                .stream()
+                .collect(Collectors.toMap(key -> key, key -> data.get(key).toString()));
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemApiDocs.java
@@ -4,6 +4,7 @@ import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import com.bottari.teambottari.dto.CheckTeamItemRequest;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
+import com.bottari.teambottari.dto.RemindTeamItemRequest;
 import com.bottari.teambottari.dto.TeamMemberChecklistResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,6 +25,16 @@ public interface TeamBottariItemApiDocs {
     })
     ResponseEntity<ReadTeamItemStatusResponse> readTeamItemsStatus(
             final Long teamBottariId,
+            @Parameter(hidden = true) final String ssaid
+    );
+
+    @Operation(summary = "팀 보따리 공통/담당 물품 보채기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "보채기 알람 전송 성공")
+    })
+    ResponseEntity<Void> sendRemindAlarmByInfo(
+            final Long id,
+            final RemindTeamItemRequest request,
             @Parameter(hidden = true) final String ssaid
     );
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemController.java
@@ -3,6 +3,7 @@ package com.bottari.teambottari.controller;
 import com.bottari.config.MemberIdentifier;
 import com.bottari.teambottari.dto.CheckTeamItemRequest;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
+import com.bottari.teambottari.dto.RemindTeamItemRequest;
 import com.bottari.teambottari.dto.TeamMemberChecklistResponse;
 import com.bottari.teambottari.service.TeamItemFacade;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,6 +30,18 @@ public class TeamBottariItemController implements TeamBottariItemApiDocs {
         final ReadTeamItemStatusResponse response = teamItemFacade.getTeamItemStatus(teamBottariId, ssaid);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/team-items/{infoId}/remind")
+    @Override
+    public ResponseEntity<Void> sendRemindAlarmByInfo(
+            @PathVariable final Long infoId,
+            @RequestBody final RemindTeamItemRequest request,
+            @MemberIdentifier final String ssaid
+    ) {
+        teamItemFacade.sendRemindAlarmByInfo(infoId, request, ssaid);
+
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/team-bottaries/{teamBottariId}/checklist")

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/RemindTeamItemRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/RemindTeamItemRequest.java
@@ -1,0 +1,8 @@
+package com.bottari.teambottari.dto;
+
+import com.bottari.teambottari.domain.TeamItemType;
+
+public record RemindTeamItemRequest(
+        TeamItemType type
+) {
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/TeamItemStatusResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/TeamItemStatusResponse.java
@@ -7,6 +7,7 @@ import com.bottari.teambottari.domain.TeamSharedItemInfo;
 import java.util.List;
 
 public record TeamItemStatusResponse(
+        Long id,
         String name,
         List<MemberCheckStatusResponse> memberCheckStatus,
         int checkItemsCount,
@@ -24,6 +25,7 @@ public record TeamItemStatusResponse(
                 .toList();
 
         return new TeamItemStatusResponse(
+                info.getId(),
                 info.getName(),
                 checkStatusResponses,
                 checkItemsCount,
@@ -42,6 +44,7 @@ public record TeamItemStatusResponse(
                 .toList();
 
         return new TeamItemStatusResponse(
+                info.getId(),
                 info.getName(),
                 checkStatusResponses,
                 checkItemsCount,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
@@ -1,12 +1,11 @@
 package com.bottari.teambottari.repository;
 
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;
-import com.bottari.teambottari.domain.TeamSharedItemInfo;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamSharedItemInfo, Long> {
+public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamAssignedItemInfo, Long> {
 
     @Query("""
             SELECT taii

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -27,4 +27,14 @@ public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedIt
             WHERE tai.teamMember.id = :teamMemberId
             """)
     List<TeamAssignedItem> findAllByTeamMemberId(final Long teamMemberId);
+
+    @Query("""
+            SELECT tai
+            FROM TeamAssignedItem tai
+            JOIN FETCH TeamBottari tb ON  tai.info.teamBottari.id = :infoId
+            JOIN FETCH tai.teamMember tm
+            JOIN FETCH tm.member
+            WHERE tai.info.id = :infoId
+            """)
+    List<TeamAssignedItem> findAllByInfoIdWithMember(Long infoId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -27,4 +27,14 @@ public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, 
             WHERE tsi.teamMember.id = :teamMemberId
             """)
     List<TeamSharedItem> findAllByTeamMemberId(final Long teamMemberId);
+
+    @Query("""
+            SELECT tsi
+            FROM TeamSharedItem tsi
+            JOIN FETCH TeamBottari tb ON  tsi.info.teamBottari.id = :infoId
+            JOIN FETCH tsi.teamMember tm
+            JOIN FETCH tm.member
+            WHERE tsi.info.id = :infoId
+            """)
+    List<TeamSharedItem> findAllByInfoIdWithMember(Long infoId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
@@ -7,11 +7,13 @@ import com.bottari.fcm.dto.MessageType;
 import com.bottari.fcm.dto.SendMessageRequest;
 import com.bottari.teambottari.domain.TeamAssignedItem;
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;
+import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
 import com.bottari.teambottari.repository.TeamAssignedItemInfoRepository;
 import com.bottari.teambottari.repository.TeamAssignedItemRepository;
+import com.bottari.teambottari.repository.TeamMemberRepository;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +29,7 @@ public class TeamAssignedItemService {
     private final FcmMessageSender fcmMessageSender;
     private final TeamAssignedItemRepository teamAssignedItemRepository;
     private final TeamAssignedItemInfoRepository teamAssignedItemInfoRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     public List<TeamItemStatusResponse> getAllWithMemberStatusByTeamBottariId(final Long teamBottariId) {
         final List<TeamAssignedItem> items = teamAssignedItemRepository.findAllByTeamBottariId(teamBottariId);
@@ -69,9 +72,13 @@ public class TeamAssignedItemService {
         item.uncheck();
     }
 
-    public void sendRemindAlarm(final Long infoId) {
+    public void sendRemindAlarm(
+            final Long infoId,
+            final String ssaid
+    ) {
         final TeamAssignedItemInfo info = teamAssignedItemInfoRepository.findById(infoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_INFO_NOT_FOUND, "담당"));
+        validateMemberInTeam(info.getTeamBottari(), ssaid);
         final List<TeamAssignedItem> items = teamAssignedItemRepository.findAllByInfoIdWithMember(infoId);
         final List<Long> uncheckedMemberIds = collectUncheckedMemberIds(items);
         final SendMessageRequest sendMessageRequest = SendMessageRequest.of(info.getTeamBottari(), MessageType.REMIND);
@@ -118,6 +125,15 @@ public class TeamAssignedItemService {
     ) {
         if (!item.isOwner(ssaid)) {
             throw new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NOT_OWNED, "본인의 팀 보따리 물품이 아닙니다.");
+        }
+    }
+
+    private void validateMemberInTeam(
+            final TeamBottari teamBottari,
+            final String ssaid
+    ) {
+        if (!teamMemberRepository.existsByTeamBottariIdAndMemberSsaid(teamBottari.getId(), ssaid)) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI);
         }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
@@ -2,11 +2,15 @@ package com.bottari.teambottari.service;
 
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
+import com.bottari.fcm.FcmMessageSender;
+import com.bottari.fcm.dto.MessageType;
+import com.bottari.fcm.dto.SendMessageRequest;
 import com.bottari.teambottari.domain.TeamAssignedItem;
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
+import com.bottari.teambottari.repository.TeamAssignedItemInfoRepository;
 import com.bottari.teambottari.repository.TeamAssignedItemRepository;
 import java.util.Comparator;
 import java.util.List;
@@ -20,7 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TeamAssignedItemService {
 
+    private final FcmMessageSender fcmMessageSender;
     private final TeamAssignedItemRepository teamAssignedItemRepository;
+    private final TeamAssignedItemInfoRepository teamAssignedItemInfoRepository;
 
     public List<TeamItemStatusResponse> getAllWithMemberStatusByTeamBottariId(final Long teamBottariId) {
         final List<TeamAssignedItem> items = teamAssignedItemRepository.findAllByTeamBottariId(teamBottariId);
@@ -63,6 +69,15 @@ public class TeamAssignedItemService {
         item.uncheck();
     }
 
+    public void sendRemindAlarm(final Long infoId) {
+        final TeamAssignedItemInfo info = teamAssignedItemInfoRepository.findById(infoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_INFO_NOT_FOUND, "담당"));
+        final List<TeamAssignedItem> items = teamAssignedItemRepository.findAllByInfoIdWithMember(infoId);
+        final List<Long> uncheckedMemberIds = collectUncheckedMemberIds(items);
+        final SendMessageRequest sendMessageRequest = SendMessageRequest.of(info.getTeamBottari(), MessageType.REMIND);
+        fcmMessageSender.sendMessageToMembers(uncheckedMemberIds, sendMessageRequest);
+    }
+
     private Map<TeamAssignedItemInfo, List<TeamAssignedItem>> groupByInfo(final List<TeamAssignedItem> assignedItems) {
         return assignedItems.stream()
                 .collect(Collectors.groupingBy(TeamAssignedItem::getInfo));
@@ -86,8 +101,15 @@ public class TeamAssignedItemService {
         final long count = items.stream()
                 .filter(TeamAssignedItem::isChecked)
                 .count();
-        
+
         return Math.toIntExact(count);
+    }
+
+    private List<Long> collectUncheckedMemberIds(final List<TeamAssignedItem> items) {
+        return items.stream()
+                .filter(item -> !item.isChecked())
+                .map(item -> item.getTeamMember().getMember().getId())
+                .toList();
     }
 
     private void validateOwner(

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
@@ -7,6 +7,7 @@ import com.bottari.member.repository.MemberRepository;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.dto.CheckTeamItemRequest;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
+import com.bottari.teambottari.dto.RemindTeamItemRequest;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberChecklistResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
@@ -74,6 +75,19 @@ public class TeamItemFacade {
             case SHARED -> teamSharedItemService.uncheck(id, ssaid);
             case ASSIGNED -> teamAssignedItemService.uncheck(id, ssaid);
             case PERSONAL -> teamPersonalItemService.uncheck(id, ssaid);
+        }
+    }
+
+    public void sendRemindAlarmByInfo(
+            final Long infoId,
+            final RemindTeamItemRequest request,
+            final String ssaid
+    ) {
+        switch (request.type()) {
+            case SHARED -> teamSharedItemService.sendRemindAlarm(infoId, ssaid);
+            case ASSIGNED -> teamAssignedItemService.sendRemindAlarm(infoId, ssaid);
+            case PERSONAL -> throw new BusinessException(
+                    ErrorCode.TEAM_BOTTARI_ITEM_INAPPROPRIATE_TYPE, "보채기 알람은 공통/담당 물품만 가능합니다.");
         }
     }
 

--- a/backend/bottari/src/test/java/com/bottari/fcm/FcmMessageSenderTest.java
+++ b/backend/bottari/src/test/java/com/bottari/fcm/FcmMessageSenderTest.java
@@ -24,6 +24,7 @@ import com.google.firebase.messaging.MessagingErrorCode;
 import jakarta.persistence.EntityManager;
 import java.lang.reflect.Constructor;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -61,7 +62,7 @@ class FcmMessageSenderTest {
             entityManager.persist(fcmToken);
             doAnswer(invocation -> null)
                     .when(firebaseMessaging).send(any(Message.class));
-            final SendMessageRequest request = new SendMessageRequest("title", "message", MessageType.HURRY_UP);
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND);
 
             // when & then
             assertThatCode(() -> fcmMessageSender.sendMessageToMember(member.getId(), request))
@@ -74,7 +75,7 @@ class FcmMessageSenderTest {
             // given
             final Member member = MemberFixture.MEMBER.get();
             entityManager.persist(member);
-            final SendMessageRequest request = new SendMessageRequest("title", "message", MessageType.HURRY_UP);
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND);
 
             // when & then
             assertThatThrownBy(() -> fcmMessageSender.sendMessageToMember(member.getId(), request))
@@ -92,7 +93,7 @@ class FcmMessageSenderTest {
             entityManager.persist(member);
             final FcmToken fcmToken = FcmTokenFixture.FCM_TOKEN.get(member);
             entityManager.persist(fcmToken);
-            final SendMessageRequest request = new SendMessageRequest("title", "message", MessageType.HURRY_UP);
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND);
             final FirebaseMessagingException exception = createFirebaseMessagingException(errorCode);
             doThrow(exception).when(firebaseMessaging).send(any(Message.class));
 
@@ -101,8 +102,8 @@ class FcmMessageSenderTest {
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("유효하지 않은 토큰으로 인해 FCM 메시지 전송을 실패하였습니다.");
             final FcmToken actual = (FcmToken) entityManager.createNativeQuery("""
-                           SELECT * FROM fcm_token WHERE member_id = :id
-                     """, FcmToken.class)
+                                  SELECT * FROM fcm_token WHERE member_id = :id
+                            """, FcmToken.class)
                     .setParameter("id", member.getId())
                     .getSingleResult();
             assertThat(actual.getDeletedAt()).isNotNull();
@@ -119,7 +120,7 @@ class FcmMessageSenderTest {
             entityManager.persist(member);
             final FcmToken fcmToken = FcmTokenFixture.FCM_TOKEN.get(member);
             entityManager.persist(fcmToken);
-            final SendMessageRequest request = new SendMessageRequest("title", "message", MessageType.HURRY_UP);
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND);
             final FirebaseMessagingException exception = createFirebaseMessagingException(errorCode);
             doThrow(exception).when(firebaseMessaging).send(any(Message.class));
 
@@ -148,7 +149,7 @@ class FcmMessageSenderTest {
             doAnswer(invocation -> null)
                     .when(firebaseMessaging).send(any(Message.class));
             final List<Long> memberIds = List.of(member1.getId(), member2.getId());
-            final SendMessageRequest request = new SendMessageRequest("title", "message", MessageType.HURRY_UP);
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND);
 
             // when & then
             assertThatCode(() -> fcmMessageSender.sendMessageToMembers(memberIds, request))
@@ -161,7 +162,7 @@ class FcmMessageSenderTest {
             // given
             final Member member = MemberFixture.MEMBER.get();
             entityManager.persist(member);
-            final SendMessageRequest request = new SendMessageRequest("title", "message", MessageType.HURRY_UP);
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND);
 
             // when & then
             assertThatThrownBy(() -> fcmMessageSender.sendMessageToMember(member.getId(), request))
@@ -192,20 +193,20 @@ class FcmMessageSenderTest {
                 return null;
             }).when(firebaseMessaging).send(any(Message.class));
             final List<Long> memberIds = List.of(member1.getId(), member2.getId());
-            final SendMessageRequest request = new SendMessageRequest("title", "message", MessageType.HURRY_UP);
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND);
 
             // when & then
             assertThatThrownBy(() -> fcmMessageSender.sendMessageToMembers(memberIds, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("유효하지 않은 토큰으로 인해 FCM 메시지 전송을 실패하였습니다.");
             final FcmToken member1Token = (FcmToken) entityManager.createNativeQuery("""
-                         SELECT * FROM fcm_token WHERE member_id = :id
-                     """, FcmToken.class)
+                                SELECT * FROM fcm_token WHERE member_id = :id
+                            """, FcmToken.class)
                     .setParameter("id", member1.getId())
                     .getSingleResult();
             final FcmToken member2Token = (FcmToken) entityManager.createNativeQuery("""
-                         SELECT * FROM fcm_token WHERE member_id = :id
-                     """, FcmToken.class)
+                                SELECT * FROM fcm_token WHERE member_id = :id
+                            """, FcmToken.class)
                     .setParameter("id", member2.getId())
                     .getSingleResult();
             assertThat(member1Token.getDeletedAt()).isNotNull();
@@ -228,7 +229,7 @@ class FcmMessageSenderTest {
             final FcmToken fcmToken2 = FcmTokenFixture.FCM_TOKEN.get(member2);
             entityManager.persist(fcmToken2);
             final List<Long> memberIds = List.of(member1.getId(), member2.getId());
-            final SendMessageRequest request = new SendMessageRequest("title", "message", MessageType.HURRY_UP);
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND);
             final FirebaseMessagingException exception = createFirebaseMessagingException(errorCode);
             doThrow(exception).when(firebaseMessaging).send(any(Message.class));
 

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
@@ -12,6 +12,7 @@ import com.bottari.log.LogFormatter;
 import com.bottari.teambottari.domain.TeamItemType;
 import com.bottari.teambottari.dto.CheckTeamItemRequest;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
+import com.bottari.teambottari.dto.RemindTeamItemRequest;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse.MemberCheckStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberChecklistResponse;
@@ -157,6 +158,29 @@ class TeamBottariItemControllerTest {
 
         // when & then
         mockMvc.perform(patch("/team-items/{id}/uncheck", itemId)
+                        .header("ssaid", ssaid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("보채기 알람을 전송한다.")
+    @ParameterizedTest
+    @CsvSource({
+            "SHARED",
+            "ASSIGNED"
+    })
+    void sendRemindAlarmByInfo(final TeamItemType type) throws Exception {
+        // given
+        final Long infoId = 1L;
+        final String ssaid = "test-ssaid";
+        final RemindTeamItemRequest request = new RemindTeamItemRequest(type);
+
+        willDoNothing().given(teamItemFacade)
+                .sendRemindAlarmByInfo(infoId, request, ssaid);
+
+        // when & then
+        mockMvc.perform(patch("/team-items/{id}/uncheck", infoId)
                         .header("ssaid", ssaid)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
@@ -61,12 +61,12 @@ class TeamBottariItemControllerTest {
         );
 
         final List<TeamItemStatusResponse> sharedItems = List.of(
-                new TeamItemStatusResponse("잠옷", sharedItemMemberStatus, 2, 3),
-                new TeamItemStatusResponse("세면도구", sharedItemMemberStatus, 2, 3)
+                new TeamItemStatusResponse(1L, "잠옷", sharedItemMemberStatus, 2, 3),
+                new TeamItemStatusResponse(2L, "세면도구", sharedItemMemberStatus, 2, 3)
         );
         final List<TeamItemStatusResponse> assignedItems = List.of(
-                new TeamItemStatusResponse("가스 버너", assignedItemMemberStatus, 1, 2),
-                new TeamItemStatusResponse("생수", assignedItemMemberStatus, 1, 2)
+                new TeamItemStatusResponse(1L, "가스 버너", assignedItemMemberStatus, 1, 2),
+                new TeamItemStatusResponse(2L, "생수", assignedItemMemberStatus, 1, 2)
         );
 
         final ReadTeamItemStatusResponse response = new ReadTeamItemStatusResponse(sharedItems, assignedItems);

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamAssignedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamAssignedItemServiceTest.java
@@ -1,10 +1,16 @@
 package com.bottari.teambottari.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 
 import com.bottari.error.BusinessException;
+import com.bottari.fcm.FcmMessageSender;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.fixture.TeamBottariFixture;
 import com.bottari.member.domain.Member;
@@ -21,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
 @Import(TeamAssignedItemService.class)
@@ -28,6 +35,9 @@ class TeamAssignedItemServiceTest {
 
     @Autowired
     private TeamAssignedItemService teamAssignedItemService;
+
+    @MockitoBean
+    private FcmMessageSender fcmMessageSender;
 
     @Autowired
     private EntityManager entityManager;
@@ -209,6 +219,58 @@ class TeamAssignedItemServiceTest {
             assertThatThrownBy(() -> teamAssignedItemService.uncheck(notExistsBottariItemId, member.getSsaid()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("팀 보따리 물품을 찾을 수 없습니다. - 담당");
+        }
+    }
+
+    @Nested
+    class SendRemindAlarmTest {
+
+        @DisplayName("해당 물품을 챙기지 않은 팀 멤버에게 알람을 보낸다.")
+        @Test
+        void sendRemindAlarm() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final TeamAssignedItemInfo teamAssignedItemInfo = new TeamAssignedItemInfo("담당 물품", teamBottari);
+            entityManager.persist(teamAssignedItemInfo);
+
+            final TeamAssignedItem teamAssignedItem = new TeamAssignedItem(teamAssignedItemInfo, teamMember);
+            entityManager.persist(teamAssignedItem);
+
+            doNothing().when(fcmMessageSender).sendMessageToMembers(anyList(), any());
+
+            // when & then
+            assertThatCode(() -> teamAssignedItemService.sendRemindAlarm(teamAssignedItemInfo.getId()))
+                    .doesNotThrowAnyException();
+            verify(fcmMessageSender).sendMessageToMembers(anyList(), any());
+        }
+
+        @DisplayName("보채기 알람을 보낼 때, 물품 정보가 존재하지 않는다면 예외를 던진다.")
+        @Test
+        void sendRemindAlarm_Exception_NotFountItemInfo() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final Long invalid_item_info_id = -1L;
+
+            // when & then
+            assertThatThrownBy(() -> teamAssignedItemService.sendRemindAlarm(invalid_item_info_id))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("팀 보따리 물품 정보를 찾을 수 없습니다. - 담당");
         }
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.bottari.config.JpaAuditingConfig;
 import com.bottari.error.BusinessException;
+import com.bottari.fcm.FcmMessageSender;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.fixture.TeamBottariFixture;
 import com.bottari.member.domain.Member;
@@ -32,6 +33,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
 @Import({
@@ -45,6 +47,9 @@ public class TeamItemFacadeTest {
 
     @Autowired
     private TeamItemFacade teamItemFacade;
+
+    @MockitoBean
+    private FcmMessageSender fcmMessageSender;
 
     @Autowired
     private EntityManager entityManager;

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
@@ -108,11 +108,13 @@ public class TeamItemFacadeTest {
             );
 
             final List<TeamItemStatusResponse> expectedSharedItems = List.of(
-                    new TeamItemStatusResponse("공통 물품", expectedSharedMemberStatus, 0, 2)
+                    new TeamItemStatusResponse(teamSharedItemInfo.getId(), "공통 물품", expectedSharedMemberStatus, 0, 2)
             );
             final List<TeamItemStatusResponse> expectedAssignedItems = List.of(
-                    new TeamItemStatusResponse("멤버 1 물품", expectedMember1AssignedStatus, 0, 1),
-                    new TeamItemStatusResponse("멤버 2 물품", expectedMember2AssignedStatus, 1, 1)
+                    new TeamItemStatusResponse(
+                            teamAssignedItemInfo_1.getId(), "멤버 1 물품", expectedMember1AssignedStatus, 0, 1),
+                    new TeamItemStatusResponse(
+                            teamAssignedItemInfo_2.getId(), "멤버 2 물품", expectedMember2AssignedStatus, 1, 1)
             );
             final ReadTeamItemStatusResponse expected = new ReadTeamItemStatusResponse(expectedSharedItems,
                     expectedAssignedItems);

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
@@ -1,10 +1,17 @@
 package com.bottari.teambottari.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 
+import com.bottari.config.JpaAuditingConfig;
 import com.bottari.error.BusinessException;
+import com.bottari.fcm.FcmMessageSender;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.fixture.TeamBottariFixture;
 import com.bottari.member.domain.Member;
@@ -21,13 +28,20 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
-@Import(TeamSharedItemService.class)
+@Import({
+        TeamSharedItemService.class,
+        JpaAuditingConfig.class
+})
 class TeamSharedItemServiceTest {
 
     @Autowired
     private TeamSharedItemService teamSharedItemService;
+
+    @MockitoBean
+    private FcmMessageSender fcmMessageSender;
 
     @Autowired
     private EntityManager entityManager;
@@ -209,6 +223,58 @@ class TeamSharedItemServiceTest {
             assertThatThrownBy(() -> teamSharedItemService.uncheck(notExistsBottariItemId, member.getSsaid()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("팀 보따리 물품을 찾을 수 없습니다. - 공통");
+        }
+    }
+
+    @Nested
+    class SendRemindAlarmTest {
+
+        @DisplayName("해당 물품을 챙기지 않은 팀 멤버에게 알람을 보낸다.")
+        @Test
+        void sendRemindAlarm() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final TeamSharedItemInfo teamSharedItemInfo = new TeamSharedItemInfo("공통 물품", teamBottari);
+            entityManager.persist(teamSharedItemInfo);
+
+            final TeamSharedItem teamSharedItem = new TeamSharedItem(teamSharedItemInfo, teamMember);
+            entityManager.persist(teamSharedItem);
+
+            doNothing().when(fcmMessageSender).sendMessageToMembers(anyList(), any());
+
+            // when & then
+            assertThatCode(() -> teamSharedItemService.sendRemindAlarm(teamSharedItemInfo.getId()))
+                    .doesNotThrowAnyException();
+            verify(fcmMessageSender).sendMessageToMembers(anyList(), any());
+        }
+
+        @DisplayName("보채기 알람을 보낼 때, 물품 정보가 존재하지 않는다면 예외를 던진다.")
+        @Test
+        void sendRemindAlarm_Exception_NotFountItemInfo() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final Long invalid_item_info_id = -1L;
+
+            // when & then
+            assertThatThrownBy(() -> teamSharedItemService.sendRemindAlarm(invalid_item_info_id))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("팀 보따리 물품 정보를 찾을 수 없습니다. - 공통");
         }
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
@@ -251,7 +251,7 @@ class TeamSharedItemServiceTest {
             doNothing().when(fcmMessageSender).sendMessageToMembers(anyList(), any());
 
             // when & then
-            assertThatCode(() -> teamSharedItemService.sendRemindAlarm(teamSharedItemInfo.getId()))
+            assertThatCode(() -> teamSharedItemService.sendRemindAlarm(teamSharedItemInfo.getId(), member.getSsaid()))
                     .doesNotThrowAnyException();
             verify(fcmMessageSender).sendMessageToMembers(anyList(), any());
         }
@@ -272,9 +272,37 @@ class TeamSharedItemServiceTest {
             final Long invalid_item_info_id = -1L;
 
             // when & then
-            assertThatThrownBy(() -> teamSharedItemService.sendRemindAlarm(invalid_item_info_id))
+            assertThatThrownBy(() -> teamSharedItemService.sendRemindAlarm(invalid_item_info_id, member.getSsaid()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("팀 보따리 물품 정보를 찾을 수 없습니다. - 공통");
+        }
+
+        @DisplayName("보채기 알람을 보낼 때, 팀 멤버가 아니라면 예외를 던진다.")
+        @Test
+        void sendRemindAlarm_Exception_NotTeamMember() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final TeamSharedItemInfo info = new TeamSharedItemInfo("공통 물품", teamBottari);
+            entityManager.persist(info);
+
+            final TeamSharedItem item = new TeamSharedItem(info, teamMember);
+            entityManager.persist(item);
+
+            final String invalid_ssaid = "invalid_ssaid";
+
+            // when & then
+            assertThatThrownBy(
+                    () -> teamSharedItemService.sendRemindAlarm(info.getId(), invalid_ssaid))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 팀 보따리의 팀 멤버가 아닙니다.");
         }
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 현황 내, 보채기 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #355  

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 팀 보따리 현황 내, 물품에 따른 보채기 기능 구현
- 물품을 챙기지 않은 사용자에 대해 FCM 발송
- FCM DTO `SendMessageRequest` 형식 변경
- Facade 내 분기 처리

테스트의 경우, `FcmMessageSender`를 Mocking한 후,
이를 호출했는지 검증 (`verify()` 사용)

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
