### PR TITLE
[AN] CI 워크플로우 캐싱 도입으로 속도 개선

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -2,7 +2,12 @@ name: Android CI [ an/develop ]
 
 on:
   pull_request:
-    branches: [ "an/develop" ]
+    branches: ["an/develop"]
+
+# 동일한 PR에 대해 새로운 커밋이 푸시되면 진행 중인 워크플로우를 취소하고 새로 시작
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -23,15 +28,28 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        # CI에서는 전체 히스토리가 필요 없음, 체크아웃 속도 향상
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
+          # setup-java 액션 자체의 Gradle 캐시는 Gradle Wrapper와 종속성을 캐시합니다.
           cache: gradle
+
+      # 프로젝트 레벨의 빌드 캐시를 위한 추가 단계
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ./android/Bottari/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Grant execute permission to gradlew
         run: chmod +x gradlew
@@ -42,11 +60,5 @@ jobs:
       - name: Create local.properties
         run: echo "$LOCAL_PROPERTIES_CONTENTS" > ./local.properties
 
-      - name: Run ktlint Check
-        run: ./gradlew ktlintCheck
-
-      - name: Run Unit Tests
-        run: ./gradlew test
-
-      - name: Assemble Build
+      - name: Build and Check
         run: ./gradlew build


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- CI 워크플로우 캐싱 도입으로 속도 개선

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- 없습니다.

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->


> ### 요약
>
> CI 파이프라인의 무료 사용량(혹은 자원) 절감을 위해 캐싱 전략을 도입하여 빌드(Andorid CI Workflow) 시간을 단축

<img width="922" height="871" alt="image" src="https://github.com/user-attachments/assets/e3a1cd5c-9ebe-4788-b2d1-50c7813a946f" />

무료 Organization의 무료 러닝 타임은 2,000분/1달로 알고 있는데, 
2주만에 약 67%를 소모했고,
그중에서 Android CI가 49%를 차지합니다.

- [GitHub 공식 요금 표](https://docs.github.com/en/billing/concepts/product-billing/github-actions#included-storage-and-minutes)에서 GitHub Free for organizations 부분 참고

간단한 작업이라 바로 PR로 올렸습니다.
직접 핏하게 수정하고 반영하셔도 돼요.

## 개선 사항

| 항목       | 이전 방식 (비효율적)                        | 개선된 방식 (효율적)                                  |
| ---------- | ------------------------------------------- | ---------------------------------------------------- |
| 실행 제어  | 새 커밋마다 계속 새롭게 실행                 | 최신 커밋만 실행, 이전 작업은 자동 취소 (`concurrency`) |
| 코드 다운로드 | 프로젝트 전체 이력 다운로드                 | 최신 코드만 다운로드 (`fetch-depth: 1`)               |
| 캐싱       | 캐시 없거나, 단일 캐시 사용                  | 2중 캐시: 외부 라이브러리 + 내부 빌드 결과물           |
| 빌드 명령어 | `test`, `lint`, `build` 개별 실행 (중복 발생) | `build` 하나로 통합 실행 (중복 제거)                  |

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<img width="930" height="816" alt="image" src="https://github.com/user-attachments/assets/ff9022fa-134a-4a53-b6e5-4bd34d50e4e1" />

### 기존 평균 CI 시간 (8월 1일 ~ 금일)

- 5분 42초 (108번 기준)

<br>
