### PR TITLE
[AN] 사용자 등록 시 FCM 토큰 전달

### DIFF
--- a/android/Bottari/data/src/main/java/com/bottari/data/model/member/RegisterMemberRequest.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/member/RegisterMemberRequest.kt
@@ -7,4 +7,6 @@ import kotlinx.serialization.Serializable
 data class RegisterMemberRequest(
     @SerialName("ssaid")
     val ssaid: String,
+    @SerialName("fcmToken")
+    val fcmToken: String,
 )

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -13,9 +13,9 @@ class MemberRepositoryImpl(
     private val memberRemoteDataSource: MemberRemoteDataSource,
     private val memberIdentifierLocalDataSource: MemberIdentifierLocalDataSource,
 ) : MemberRepository {
-    override suspend fun registerMember(): Result<Long?> =
+    override suspend fun registerMember(fcmToken: String): Result<Long?> =
         memberRemoteDataSource
-            .registerMember(RegisterMemberRequest(getMemberIdentifier()))
+            .registerMember(RegisterMemberRequest(getMemberIdentifier(), fcmToken))
 
     override suspend fun saveMemberNickname(nickname: Nickname): Result<Unit> =
         memberRemoteDataSource.saveMemberNickname(nickname.toRequest())

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -42,12 +42,12 @@ class MemberRepositoryImplTest {
     fun registerMemberSuccessReturnsSuccess() =
         runTest {
             // given
-            val request = RegisterMemberRequest("ssaid")
+            val request = RegisterMemberRequest("ssaid", "token")
             coEvery { remoteDataSource.registerMember(request) } returns Result.success(1)
             coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.success("ssaid")
 
             // when
-            val result = repository.registerMember()
+            val result = repository.registerMember("token")
 
             // then
             result.shouldBeSuccess()
@@ -61,13 +61,13 @@ class MemberRepositoryImplTest {
     fun registerMemberFailsReturnsFailure() =
         runTest {
             // given
-            val request = RegisterMemberRequest("ssaid")
+            val request = RegisterMemberRequest("ssaid", "token")
             val exception = HttpException(Response.error<Unit>(400, errorResponseBody))
             coEvery { remoteDataSource.registerMember(request) } returns Result.failure(exception)
             coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.success("ssaid")
 
             // when
-            val result = repository.registerMember()
+            val result = repository.registerMember("token")
 
             // then
             result.shouldBeFailure { it shouldBe exception }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
@@ -4,7 +4,7 @@ import com.bottari.domain.model.member.Nickname
 import com.bottari.domain.model.member.RegisteredMember
 
 interface MemberRepository {
-    suspend fun registerMember(): Result<Long?>
+    suspend fun registerMember(fcmToken: String): Result<Long?>
 
     suspend fun saveMemberNickname(nickname: Nickname): Result<Unit>
 

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/RegisterMemberUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/RegisterMemberUseCase.kt
@@ -5,5 +5,5 @@ import com.bottari.domain.repository.MemberRepository
 class RegisterMemberUseCase(
     private val memberRepository: MemberRepository,
 ) {
-    suspend operator fun invoke(): Result<Long?> = memberRepository.registerMember()
+    suspend operator fun invoke(fcmToken: String): Result<Long?> = memberRepository.registerMember(fcmToken)
 }

--- a/android/Bottari/gradle/libs.versions.toml
+++ b/android/Bottari/gradle/libs.versions.toml
@@ -99,6 +99,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
 firebase-installations = { module = "com.google.firebase:firebase-installations" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 
 [plugins]
 # --- Android Plugins ---

--- a/android/Bottari/presentation/build.gradle.kts
+++ b/android/Bottari/presentation/build.gradle.kts
@@ -81,6 +81,8 @@ dependencies {
     implementation(libs.material.calendarview)
     implementation(libs.threetenabp)
     implementation(libs.androidx.core.splashscreen)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging)
     testImplementation(libs.bundles.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/Bottari/presentation/src/main/AndroidManifest.xml
+++ b/android/Bottari/presentation/src/main/AndroidManifest.xml
@@ -22,8 +22,8 @@
         <activity
             android:name=".view.home.HomeActivity"
             android:exported="false"
-            android:windowSoftInputMode="adjustNothing"
-            android:launchMode="singleTask" />
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustNothing" />
         <activity
             android:name=".view.checklist.personal.ChecklistActivity"
             android:exported="false" />

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
@@ -10,6 +10,8 @@ import com.bottari.domain.usecase.appConfig.SavePermissionFlagUseCase
 import com.bottari.domain.usecase.member.CheckRegisteredMemberUseCase
 import com.bottari.domain.usecase.member.RegisterMemberUseCase
 import com.bottari.presentation.common.base.BaseViewModel
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.tasks.await
 
 class MainViewModel(
     private val registerMemberUseCase: RegisterMemberUseCase,
@@ -68,7 +70,8 @@ class MainViewModel(
 
     private fun registerMember() {
         launch {
-            registerMemberUseCase()
+            val fcmToken = FirebaseMessaging.getInstance().token.await()
+            registerMemberUseCase(fcmToken)
                 .onSuccess {
                     updateState { copy(isLoading = false, isReady = true) }
                     emitEvent(MainUiEvent.LoginSuccess(currentState.hasPermissionFlag))


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 사용자 등록 시 FCM 토큰 전달

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #370

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 사용자 등록 시 FCM 토큰 전달

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
