### PR TITLE
[BE] 팀 보따리 멤버 별 보채기 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottari/domain/Bottari.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/domain/Bottari.java
@@ -70,15 +70,6 @@ public class Bottari {
         return title.title();
     }
 
-    private void validateTitle(final String title) {
-        if (title.isBlank()) {
-            throw new BusinessException(ErrorCode.BOTTARI_TITLE_BLANK);
-        }
-        if (title.length() > 15) {
-            throw new BusinessException(ErrorCode.BOTTARI_TITLE_TOO_LONG, "최대 15자까지 입력 가능합니다.");
-        }
-    }
-
     @Override
     public boolean equals(final Object o) {
         if (!(o instanceof final Bottari bottari)) {

--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
     TEAM_BOTTARI_ITEM_INFO_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀 보따리 물품 정보를 찾을 수 없습니다."),
 
     // ===== TEAM_MEMBER 관련 =====
+    TEAM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "팀 멤버를 찾을 수 없습니다."),
     MEMBER_NOT_IN_TEAM_BOTTARI(HttpStatus.FORBIDDEN, "해당 팀 보따리의 팀 멤버가 아닙니다."),
     MEMBER_ALREADY_IN_TEAM_BOTTARI(HttpStatus.CONFLICT, "이미 해당 팀 보따리에 참여한 멤버입니다."),
 

--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -82,6 +82,8 @@ public enum ErrorCode {
     TEAM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "팀 멤버를 찾을 수 없습니다."),
     MEMBER_NOT_IN_TEAM_BOTTARI(HttpStatus.FORBIDDEN, "해당 팀 보따리의 팀 멤버가 아닙니다."),
     MEMBER_ALREADY_IN_TEAM_BOTTARI(HttpStatus.CONFLICT, "이미 해당 팀 보따리에 참여한 멤버입니다."),
+    TEAM_MEMBER_ALREADY_CHECKED_ALL(HttpStatus.CONFLICT, "해당 팀 멤버는 모든 팀 보따리 물품을 체크했습니다."),
+    CANNOT_SEND_REMIND_TO_SELF(HttpStatus.BAD_REQUEST, "본인에게 보채기 알림을 보낼 수 없습니다."),
 
     // ===== ALARM 관련 =====
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알람을 찾을 수 없습니다."),
@@ -97,6 +99,7 @@ public enum ErrorCode {
     FCM_INITIALIZED_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase 초기화를 실패하였습니다."),
     FCM_MESSAGE_SEND_FAIL(HttpStatus.BAD_GATEWAY, "FCM 서버 문제로 FCM 메시지 전송을 실패하였습니다."),
     FCM_INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰으로 인해 FCM 메시지 전송을 실패하였습니다."),
+    FCM_MESSAGE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 메시지 변환을 실패하였습니다."),
 
     // ===== 기타 =====
     DATE_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 날짜 형식입니다."),

--- a/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageConverter.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageConverter.java
@@ -18,7 +18,7 @@ public class FcmMessageConverter {
 
     private static final String TEAM_BOTTARI_ID = "teamBottariId";
     private static final String TEAM_BOTTARI_TITLE = "teamBottariTitle";
-    public static final String TEAM_ITEM_NAME = "teamItemName";
+    private static final String TEAM_ITEM_NAME = "teamItemName";
     private static final String TEAM_SHARED_ITEM_NAMES = "teamSharedItemNames";
     private static final String TEAM_ASSIGNED_ITEM_NAMES = "teamAssignedItemNames";
 

--- a/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageConverter.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageConverter.java
@@ -1,10 +1,15 @@
 package com.bottari.fcm;
 
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
 import com.bottari.fcm.dto.MessageType;
 import com.bottari.fcm.dto.SendMessageRequest;
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;
 import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamSharedItemInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +19,10 @@ public class FcmMessageConverter {
     private static final String TEAM_BOTTARI_ID = "teamBottariId";
     private static final String TEAM_BOTTARI_TITLE = "teamBottariTitle";
     public static final String TEAM_ITEM_NAME = "teamItemName";
+    private static final String TEAM_SHARED_ITEM_NAMES = "teamSharedItemNames";
+    private static final String TEAM_ASSIGNED_ITEM_NAMES = "teamAssignedItemNames";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public SendMessageRequest convert(
             final TeamBottari teamBottari,
@@ -51,5 +60,35 @@ public class FcmMessageConverter {
                 ),
                 messageType
         );
+    }
+
+    public SendMessageRequest convert(
+            final TeamBottari teamBottari,
+            final List<TeamSharedItemInfo> uncheckedSharedItemInfos,
+            final List<TeamAssignedItemInfo> uncheckedAssignedItemsInfos,
+            final MessageType messageType
+    ) {
+        final Long teamBottariId = teamBottari.getId();
+        final String teamBottariTitle = teamBottari.getTitle();
+        final List<String> sharedItemNames = uncheckedSharedItemInfos.stream()
+                .map(TeamSharedItemInfo::getName)
+                .toList();
+        final List<String> assignedItemNames = uncheckedAssignedItemsInfos.stream()
+                .map(TeamAssignedItemInfo::getName)
+                .toList();
+
+        try {
+            return new SendMessageRequest(
+                    Map.of(
+                            TEAM_BOTTARI_ID, String.valueOf(teamBottariId),
+                            TEAM_BOTTARI_TITLE, String.valueOf(teamBottariTitle),
+                            TEAM_SHARED_ITEM_NAMES, objectMapper.writeValueAsString(sharedItemNames),
+                            TEAM_ASSIGNED_ITEM_NAMES, objectMapper.writeValueAsString(assignedItemNames)
+                    ),
+                    messageType
+            );
+        } catch (final JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.FCM_MESSAGE_CONVERT_FAIL);
+        }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/fcm/dto/MessageType.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/dto/MessageType.java
@@ -4,5 +4,6 @@ public enum MessageType {
 
     TEAM_ITEM_CHANGED,
     REMIND_BY_ITEM,
+    REMIND_BY_TEAM_MEMBER,
     ;
 }

--- a/backend/bottari/src/main/java/com/bottari/member/domain/Member.java
+++ b/backend/bottari/src/main/java/com/bottari/member/domain/Member.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -74,5 +75,19 @@ public class Member {
         if (BadWordValidator.hasBadWord(name)) {
             throw new BusinessException(ErrorCode.MEMBER_NAME_OFFENSIVE);
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (!(o instanceof final Member member)) {
+            return false;
+        }
+
+        return Objects.equals(getId(), member.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberApiDocs.java
@@ -55,4 +55,25 @@ public interface TeamMemberApiDocs {
             final JoinTeamBottariRequest request,
             @Parameter(hidden = true) final String ssaid
     );
+
+    @Operation(summary = "팀 보따리 멤버 보채기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "팀 보따리 멤버 보채기 성공"),
+    })
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.CANNOT_SEND_REMIND_TO_SELF,
+            ErrorCode.TEAM_BOTTARI_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI,
+            ErrorCode.TEAM_MEMBER_ALREADY_CHECKED_ALL,
+            ErrorCode.FCM_MESSAGE_CONVERT_FAIL,
+            ErrorCode.FCM_TOKEN_NOT_FOUND,
+            ErrorCode.FCM_INVALID_TOKEN,
+            ErrorCode.FCM_MESSAGE_SEND_FAIL
+    })
+    ResponseEntity<Void> sendRemindAlarmByMember(
+            final Long teamBottariId,
+            final Long memberId,
+            @Parameter(hidden = true) final String ssaid
+    );
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamMemberController.java
@@ -59,4 +59,16 @@ public class TeamMemberController implements TeamMemberApiDocs {
 
         return ResponseEntity.created(URI.create("/team-members/" + id)).build();
     }
+
+    @PostMapping("/team-bottaries/{teamBottariId}/members/{memberId}/remind")
+    @Override
+    public ResponseEntity<Void> sendRemindAlarmByMember(
+            @PathVariable final Long teamBottariId,
+            @PathVariable final Long memberId,
+            @MemberIdentifier final String ssaid
+    ) {
+        teamMemberService.sendRemindAlarm(teamBottariId, memberId, ssaid);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadTeamMemberStatusResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadTeamMemberStatusResponse.java
@@ -3,6 +3,7 @@ package com.bottari.teambottari.dto;
 import java.util.List;
 
 public record ReadTeamMemberStatusResponse(
+        Long memberId,
         String teamMemberName,
         boolean isOwner,
         int totalItemsCount,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -43,4 +43,9 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             final Long teamBottariId,
             final Long memberId
     );
+
+    boolean existsByTeamBottariIdAndMemberId(
+            final Long teamBottariId,
+            final Long memberId
+    );
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -43,9 +43,4 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             final Long teamBottariId,
             final Long memberId
     );
-
-    boolean existsByTeamBottariIdAndMemberId(
-            final Long teamBottariId,
-            final Long memberId
-    );
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -2,9 +2,10 @@ package com.bottari.teambottari.service;
 
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
+import com.bottari.fcm.FcmMessageSender;
 import com.bottari.member.domain.Member;
-import com.bottari.member.repository.MemberRepository;
 import com.bottari.teambottari.domain.TeamAssignedItem;
+import com.bottari.member.repository.MemberRepository;
 import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamSharedItem;
@@ -33,6 +34,8 @@ public class TeamMemberService {
     private final TeamAssignedItemRepository teamAssignedItemRepository;
     private final TeamSharedItemInfoRepository teamSharedItemInfoRepository;
     private final MemberRepository memberRepository;
+
+    private final FcmMessageSender fcmMessageSender;
 
     @Transactional(readOnly = true)
     public ReadTeamMemberInfoResponse getTeamMemberInfoByTeamBottariId(
@@ -93,6 +96,17 @@ public class TeamMemberService {
         teamSharedItemRepository.saveAll(teamSharedItems);
     }
 
+    public void sendRemindAlarm(
+            final Long teamMemberId, // 보채기를 당할사람
+            final String ssaid // 보채기를 누른사람
+    ) {
+        final Member reminder = memberRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        final TeamMember teamMember = teamMemberRepository.findById(teamMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_MEMBER_NOT_FOUND));
+        validateMemberInTeam(teamMember.getTeamBottari(), reminder);
+    }
+
     private void validateMemberInTeam(
             final String ssaid,
             final List<TeamMember> teamMembers
@@ -101,6 +115,15 @@ public class TeamMemberService {
                 .filter(teamMember -> teamMember.getMember().isSameBySsaid(ssaid))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI));
+    }
+
+    private void validateMemberInTeam(
+            final TeamBottari teamBottari,
+            final Member member
+    ) {
+        if (!teamMemberRepository.existsByTeamBottariIdAndMemberId(teamBottari.getId(), member.getId())) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI);
+        }
     }
 
     private void validateMemberNotInTeam(

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -131,6 +131,7 @@ public class TeamMemberService {
                 .toList();
 
         return new ReadTeamMemberStatusResponse(
+                teamMember.getMember().getId(),
                 teamMember.getMember().getName(),
                 teamMember.isTeamBottariOwner(),
                 totalItemsCount,

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
@@ -1,6 +1,7 @@
 package com.bottari.teambottari.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -121,5 +122,21 @@ class TeamMemberControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/team-members/" + teamMemberId));
+    }
+
+    @DisplayName("팀 보따리 멤버 보채기를 한다.")
+    @Test
+    void sendRemindAlarmByMember() throws Exception {
+        // given
+        final Long teamBottariId = 1L;
+        final Long memberId = 2L;
+        final String ssaid = "ssaid";
+        willDoNothing().given(teamMemberService)
+                .sendRemindAlarm(teamBottariId, memberId, ssaid);
+
+        // when & then
+        mockMvc.perform(post("/team-bottaries/{teamBottariId}/members/{memberId}/remind", teamBottariId, memberId)
+                        .header("ssaid", ssaid))
+                .andExpect(status().isNoContent());
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamMemberControllerTest.java
@@ -70,6 +70,7 @@ class TeamMemberControllerTest {
         final String ssaid = "ssaid";
         final List<ReadTeamMemberStatusResponse> response = List.of(
                 new ReadTeamMemberStatusResponse(
+                        1L,
                         "owner_name",
                         true,
                         2,
@@ -80,6 +81,7 @@ class TeamMemberControllerTest {
                         ),
                         List.of()
                 ), new ReadTeamMemberStatusResponse(
+                        2L,
                         "member_name",
                         false,
                         3,

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.bottari.error.BusinessException;
+import com.bottari.fcm.FcmMessageSender;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.fixture.TeamBottariFixture;
 import com.bottari.member.domain.Member;
@@ -26,9 +27,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
-@Import(TeamMemberService.class)
+@Import({TeamMemberService.class})
 class TeamMemberServiceTest {
 
     @Autowired
@@ -37,6 +39,8 @@ class TeamMemberServiceTest {
     @Autowired
     private EntityManager entityManager;
 
+    @MockitoBean
+    private FcmMessageSender fcmMessageSender;
 
     @Nested
     class GetTeamMemberInfoByTeamBottariIdTest {
@@ -176,6 +180,7 @@ class TeamMemberServiceTest {
             );
 
             final ReadTeamMemberStatusResponse expectedElement1 = new ReadTeamMemberStatusResponse(
+                    owner.getId(),
                     owner.getName(),
                     true,
                     2,
@@ -187,6 +192,7 @@ class TeamMemberServiceTest {
                     List.of()
             );
             final ReadTeamMemberStatusResponse expectedElement2 = new ReadTeamMemberStatusResponse(
+                    anotherMember.getId(),
                     anotherMember.getName(),
                     false,
                     3,


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 멤버 별 보채기 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #376 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
### 비즈니스 로직 순서
1. 보채기를 보내는 Member 조회 및 없으면 예외
2. 보채기를 받는 Member 조회 및 없으면 예외
3. 보내는 사람과 받는 사람이 동일하다면 예외
4. TeamBottari 조회 및 없으면 예외
5. 보내는 사람이 팀 보따리 소속인지 확인 후 아니라면 예외
6. 받는 사람이 팀 보따리 소속인지 확인 후 아니라면 예외
7. 받는 사람의 공통 아이템 중 체크하지 않은 아이템 조회
8. 받는 사람의 담당 아이템 중 체크하지 않은 아이템 조회
9. 모든 공통/담당 아이템을 체크했다면 예외
10. FCM 메시지 전송

<br>


## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- FCM 응답 json 메시지 예시는 아래와 같음
```json
{
  "data": {
    "teamBottariId": "1",
    "teamBottariTitle": "주말 캠핑 준비",
    "teamSharedItemNames": "[\"텐트\",\"버너\"]",
    "teamAssignedItemNames": "[\"물\",\"고기\"]"
  },
  "messageType": "REMIND_BY_TEAM_MEMBER"
}
```
- FCM message에 `Map<String, String>`만 넣을 수 있어서 value에 List 반환을 못함
- 안드로이드에서 item names 파싱 로직이 필요할 듯


- 코드리뷰하러 checkout을 자주하다보니 temp 커밋을 실수로 안되돌렸음..
  - 어짜피 스쿼시 되니깐 괜찮을거예요 ~

<br>
