### PR TITLE
[BE] 멤버 ID가 둘다 null인 경우 서로 다른 멤버 객체의 equals 값이 true인 문제 해결

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/member/domain/Member.java
+++ b/backend/bottari/src/main/java/com/bottari/member/domain/Member.java
@@ -82,6 +82,9 @@ public class Member {
         if (!(o instanceof final Member member)) {
             return false;
         }
+        if (getId() == null && member.getId() == null) {
+            return Objects.equals(getSsaid(), member.getSsaid());
+        }
 
         return Objects.equals(getId(), member.getId());
     }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamMemberTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamMemberTest.java
@@ -30,16 +30,16 @@ class TeamMemberTest {
     @Test
     void isTeamBottariOwner_false() {
         // given
-        final Member member = MemberFixture.MEMBER.get();
-        final Member anotherMember = MemberFixture.ANOTHER_MEMBER.get();
+        final Member owner = MemberFixture.MEMBER.get();
+        final Member notOwner = MemberFixture.ANOTHER_MEMBER.get();
 
-        final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+        final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(owner);
 
-        final TeamMember teamMember = new TeamMember(teamBottari, member);
-        final TeamMember anotherTeamMember = new TeamMember(teamBottari, anotherMember);
+        final TeamMember ownerTeamMember = new TeamMember(teamBottari, owner);
+        final TeamMember notOwnerTeamMember = new TeamMember(teamBottari, notOwner);
 
         // when
-        final boolean actual = anotherTeamMember.isTeamBottariOwner();
+        final boolean actual = notOwnerTeamMember.isTeamBottariOwner();
 
         // then
         assertThat(actual).isFalse();


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 멤버 ID가 둘다 null인 경우 서로 다른 멤버 객체의 equals 값이 true인 문제 해결

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- eqauls 메서드에서 id가 둘 다 null 일 경우, ssaid로 비교하도록 수정

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
