### PR TITLE
[AN] 사용자 식별자 조회 기능 구현

### DIFF
--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSourceImpl.kt
@@ -9,8 +9,7 @@ class MemberIdentifierLocalDataSourceImpl : MemberIdentifierLocalDataSource {
 
     override fun getMemberIdentifier(): Result<String> =
         runCatching {
-            cachedMemberIdentifier
-                ?: initialize().also { cachedMemberIdentifier = it }
+            cachedMemberIdentifier ?: initialize().also { cachedMemberIdentifier = it }
         }
 
     private fun initialize(): String = Tasks.await(FirebaseInstallations.getInstance().id, 10, TimeUnit.SECONDS)

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -170,5 +170,50 @@ class MemberRepositoryImplTest {
                 getOrThrow().id shouldBe 1
                 getOrThrow().name shouldBe "test"
             }
+
+            // verify
+            coVerify(exactly = 1) { remoteDataSource.checkRegisteredMember() }
+        }
+
+    @DisplayName("사용자 식별자 조회를 성공하면 Success를 반환한다")
+    @Test
+    fun getMemberIdentifierReturnsSuccess() =
+        runTest {
+            // given
+            val memberId = "test_member_id"
+            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns
+                Result.success(
+                    memberId,
+                )
+
+            // when
+            val result = repository.getMemberIdentifier()
+
+            // then
+            assertSoftly(result) {
+                shouldBeSuccess()
+                getOrThrow() shouldBe memberId
+            }
+
+            // verify
+            coVerify(exactly = 1) { userInfoLocalDataSource.getMemberIdentifier() }
+        }
+
+    @DisplayName("사용자 식별자 조회를 실패하면 Failure를 반환한다")
+    @Test
+    fun getMemberIdentifierReturnsFailure() =
+        runTest {
+            // given
+            val exception = Exception()
+            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.failure(exception)
+
+            // when
+            val result = repository.getMemberIdentifier()
+
+            // then
+            result.shouldBeFailure { error -> error shouldBe exception }
+
+            // verify
+            coVerify(exactly = 1) { userInfoLocalDataSource.getMemberIdentifier() }
         }
 }

--- a/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
@@ -17,6 +17,7 @@ import com.bottari.domain.usecase.item.FetchChecklistUseCase
 import com.bottari.domain.usecase.item.SaveBottariItemsUseCase
 import com.bottari.domain.usecase.item.UnCheckBottariItemUseCase
 import com.bottari.domain.usecase.member.CheckRegisteredMemberUseCase
+import com.bottari.domain.usecase.member.GetMemberIdentifierUseCase
 import com.bottari.domain.usecase.member.RegisterMemberUseCase
 import com.bottari.domain.usecase.member.SaveMemberNicknameUseCase
 import com.bottari.domain.usecase.report.ReportTemplateUseCase
@@ -183,5 +184,8 @@ object UseCaseProvider {
     }
     val sendRemindByMemberMessageUseCase: SendRemindByMemberMessageUseCase by lazy {
         SendRemindByMemberMessageUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val getMemberIdentifierUseCase: GetMemberIdentifierUseCase by lazy {
+        GetMemberIdentifierUseCase(RepositoryProvider.memberRepository)
     }
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
@@ -9,4 +9,6 @@ interface MemberRepository {
     suspend fun saveMemberNickname(nickname: Nickname): Result<Unit>
 
     suspend fun checkRegisteredMember(): Result<RegisteredMember>
+
+    suspend fun getMemberIdentifier(): Result<String>
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetMemberIdentifierUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetMemberIdentifierUseCase.kt
@@ -1,0 +1,9 @@
+package com.bottari.domain.usecase.member
+
+import com.bottari.domain.repository.MemberRepository
+
+class GetMemberIdentifierUseCase(
+    private val memberRepository: MemberRepository,
+) {
+    suspend operator fun invoke(): Result<String> = memberRepository.getMemberIdentifier()
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 사용자 식별자 조회 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #399 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
`GetMemberIndenifierUseCase()`로 사용자 식별자를 조회하는 기능을 구현했습니다.

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
