### PR TITLE
[AN] 팀 보따리 개인 물품 수정 화면 구현

### DIFF
--- a/android/Bottari/data/src/main/java/com/bottari/data/model/team/CreateTeamBottariAssignedItemRequest.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/team/CreateTeamBottariAssignedItemRequest.kt
@@ -1,0 +1,12 @@
+package com.bottari.data.model.team
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateTeamBottariAssignedItemRequest(
+    @SerialName("name")
+    val name: String,
+    @SerialName("teamMemberNames")
+    val teamMemberNames: List<String>,
+)

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/team/CreateTeamBottariPersonalItemRequest.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/team/CreateTeamBottariPersonalItemRequest.kt
@@ -1,0 +1,10 @@
+package com.bottari.data.model.team
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateTeamBottariPersonalItemRequest(
+    @SerialName("name")
+    val name: String,
+)

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/team/CreateTeamBottariSharedItemRequest.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/team/CreateTeamBottariSharedItemRequest.kt
@@ -1,0 +1,10 @@
+package com.bottari.data.model.team
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateTeamBottariSharedItemRequest(
+    @SerialName("name")
+    val name: String,
+)

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/team/DeleteTeamBottariItemRequest.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/team/DeleteTeamBottariItemRequest.kt
@@ -1,0 +1,10 @@
+package com.bottari.data.model.team
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeleteTeamBottariItemRequest(
+    @SerialName("type")
+    val type: String,
+)

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/TeamBottariRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/TeamBottariRepositoryImpl.kt
@@ -110,7 +110,6 @@ class TeamBottariRepositoryImpl(
             DeleteTeamBottariItemRequest(bottariItemType),
         )
     }
-    override suspend fun deleteTeamBottariItem(id: Long): Result<Unit> = teamBottariRemoteDataSource.deleteTeamBottariItem(id)
 
     override suspend fun sendRemindByMemberMessage(
         teamBottariId: Long,

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/TeamBottariRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/TeamBottariRepositoryImpl.kt
@@ -7,8 +7,10 @@ import com.bottari.data.model.team.CreateTeamBottariAssignedItemRequest
 import com.bottari.data.model.team.CreateTeamBottariPersonalItemRequest
 import com.bottari.data.model.team.CreateTeamBottariRequest
 import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
+import com.bottari.data.model.team.DeleteTeamBottariItemRequest
 import com.bottari.data.model.team.ItemTypeRequest
 import com.bottari.data.source.remote.TeamBottariRemoteDataSource
+import com.bottari.domain.model.bottari.BottariItemType
 import com.bottari.domain.model.bottari.TeamBottari
 import com.bottari.domain.model.team.TeamBottariCheckList
 import com.bottari.domain.model.team.TeamBottariDetail
@@ -98,6 +100,16 @@ class TeamBottariRepositoryImpl(
             CreateTeamBottariAssignedItemRequest(name, teamMemberNames),
         )
 
+    override suspend fun deleteTeamBottariItem(
+        id: Long,
+        type: BottariItemType,
+    ): Result<Unit> {
+        val bottariItemType = type.toString()
+        return teamBottariRemoteDataSource.deleteTeamBottariItem(
+            id,
+            DeleteTeamBottariItemRequest(bottariItemType),
+        )
+    }
     override suspend fun deleteTeamBottariItem(id: Long): Result<Unit> = teamBottariRemoteDataSource.deleteTeamBottariItem(id)
 
     override suspend fun sendRemindByMemberMessage(

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/TeamBottariRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/TeamBottariRepositoryImpl.kt
@@ -3,7 +3,10 @@ package com.bottari.data.repository
 import com.bottari.data.mapper.TeamBottariMapper.toDomain
 import com.bottari.data.mapper.TeamMapper.toDomain
 import com.bottari.data.mapper.TeamMembersMapper.toDomain
+import com.bottari.data.model.team.CreateTeamBottariAssignedItemRequest
+import com.bottari.data.model.team.CreateTeamBottariPersonalItemRequest
 import com.bottari.data.model.team.CreateTeamBottariRequest
+import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
 import com.bottari.data.model.team.ItemTypeRequest
 import com.bottari.data.source.remote.TeamBottariRemoteDataSource
 import com.bottari.domain.model.bottari.TeamBottari
@@ -66,6 +69,36 @@ class TeamBottariRepositoryImpl(
         teamBottariRemoteDataSource
             .fetchTeamMembersStatus(id)
             .mapCatching { responses -> responses.map { response -> response.toDomain() } }
+
+    override suspend fun createTeamBottariSharedItem(
+        id: Long,
+        name: String,
+    ): Result<Unit> =
+        teamBottariRemoteDataSource.createTeamBottariSharedItem(
+            id,
+            CreateTeamBottariSharedItemRequest(name),
+        )
+
+    override suspend fun createTeamBottariPersonalItem(
+        id: Long,
+        name: String,
+    ): Result<Unit> =
+        teamBottariRemoteDataSource.createTeamBottariPersonalItem(
+            id,
+            CreateTeamBottariPersonalItemRequest(name),
+        )
+
+    override suspend fun createTeamBottariAssignedItem(
+        id: Long,
+        name: String,
+        teamMemberNames: List<String>,
+    ): Result<Unit> =
+        teamBottariRemoteDataSource.createTeamBottariAssignedItem(
+            id,
+            CreateTeamBottariAssignedItemRequest(name, teamMemberNames),
+        )
+
+    override suspend fun deleteTeamBottariItem(id: Long): Result<Unit> = teamBottariRemoteDataSource.deleteTeamBottariItem(id)
 
     override suspend fun sendRemindByMemberMessage(
         teamBottariId: Long,

--- a/android/Bottari/data/src/main/java/com/bottari/data/service/TeamBottariService.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/service/TeamBottariService.kt
@@ -4,6 +4,7 @@ import com.bottari.data.model.team.CreateTeamBottariAssignedItemRequest
 import com.bottari.data.model.team.CreateTeamBottariPersonalItemRequest
 import com.bottari.data.model.team.CreateTeamBottariRequest
 import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
+import com.bottari.data.model.team.DeleteTeamBottariItemRequest
 import com.bottari.data.model.team.FetchTeamBottariChecklistResponse
 import com.bottari.data.model.team.FetchTeamBottariDetailResponse
 import com.bottari.data.model.team.FetchTeamBottariResponse
@@ -13,8 +14,8 @@ import com.bottari.data.model.team.FetchTeamMembersResponse
 import com.bottari.data.model.team.ItemTypeRequest
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -89,9 +90,10 @@ interface TeamBottariService {
         @Body request: CreateTeamBottariAssignedItemRequest,
     ): Response<Unit>
 
-    @DELETE("/team-items/{id}")
+    @HTTP(method = "DELETE", path = "team-items/{id}", hasBody = true)
     suspend fun deleteTeamBottariItem(
         @Path("id") id: Long,
+        @Body request: DeleteTeamBottariItemRequest,
     ): Response<Unit>
 
     @POST("/team-bottaries/{teamBottariId}/members/{memberId}/remind")

--- a/android/Bottari/data/src/main/java/com/bottari/data/service/TeamBottariService.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/service/TeamBottariService.kt
@@ -71,19 +71,19 @@ interface TeamBottariService {
         @Path("teamBottariId") id: Long,
     ): Response<List<FetchTeamMemberStatusResponse>>
 
-    @GET("/team-bottaries/{teamBottariId}/shared-items")
+    @POST("/team-bottaries/{teamBottariId}/shared-items")
     suspend fun createTeamBottariSharedItem(
         @Path("teamBottariId") id: Long,
         @Body request: CreateTeamBottariSharedItemRequest,
     ): Response<Unit>
 
-    @GET("/team-bottaries/{teamBottariId}/personal-items")
+    @POST("/team-bottaries/{teamBottariId}/personal-items")
     suspend fun createTeamBottariPersonalItem(
         @Path("teamBottariId") id: Long,
         @Body request: CreateTeamBottariPersonalItemRequest,
     ): Response<Unit>
 
-    @GET("/team-bottaries/{teamBottariId}/assigned-items")
+    @POST("/team-bottaries/{teamBottariId}/assigned-items")
     suspend fun createTeamBottariAssignedItem(
         @Path("teamBottariId") id: Long,
         @Body request: CreateTeamBottariAssignedItemRequest,

--- a/android/Bottari/data/src/main/java/com/bottari/data/service/TeamBottariService.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/service/TeamBottariService.kt
@@ -1,6 +1,9 @@
 package com.bottari.data.service
 
+import com.bottari.data.model.team.CreateTeamBottariAssignedItemRequest
+import com.bottari.data.model.team.CreateTeamBottariPersonalItemRequest
 import com.bottari.data.model.team.CreateTeamBottariRequest
+import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
 import com.bottari.data.model.team.FetchTeamBottariChecklistResponse
 import com.bottari.data.model.team.FetchTeamBottariDetailResponse
 import com.bottari.data.model.team.FetchTeamBottariResponse
@@ -10,6 +13,7 @@ import com.bottari.data.model.team.FetchTeamMembersResponse
 import com.bottari.data.model.team.ItemTypeRequest
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -66,6 +70,29 @@ interface TeamBottariService {
     suspend fun fetchTeamMembersStatus(
         @Path("teamBottariId") id: Long,
     ): Response<List<FetchTeamMemberStatusResponse>>
+
+    @GET("/team-bottaries/{teamBottariId}/shared-items")
+    suspend fun createTeamBottariSharedItem(
+        @Path("teamBottariId") id: Long,
+        @Body request: CreateTeamBottariSharedItemRequest,
+    ): Response<Unit>
+
+    @GET("/team-bottaries/{teamBottariId}/personal-items")
+    suspend fun createTeamBottariPersonalItem(
+        @Path("teamBottariId") id: Long,
+        @Body request: CreateTeamBottariPersonalItemRequest,
+    ): Response<Unit>
+
+    @GET("/team-bottaries/{teamBottariId}/assigned-items")
+    suspend fun createTeamBottariAssignedItem(
+        @Path("teamBottariId") id: Long,
+        @Body request: CreateTeamBottariAssignedItemRequest,
+    ): Response<Unit>
+
+    @DELETE("/team-items/{id}")
+    suspend fun deleteTeamBottariItem(
+        @Path("id") id: Long,
+    ): Response<Unit>
 
     @POST("/team-bottaries/{teamBottariId}/members/{memberId}/remind")
     suspend fun sendRemindByMemberMessage(

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSource.kt
@@ -62,7 +62,6 @@ interface TeamBottariRemoteDataSource {
         id: Long,
         type: DeleteTeamBottariItemRequest,
     ): Result<Unit>
-    suspend fun deleteTeamBottariItem(id: Long): Result<Unit>
 
     suspend fun sendRemindByMemberMessage(
         teamBottariId: Long,

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSource.kt
@@ -1,6 +1,9 @@
 package com.bottari.data.source.remote
 
+import com.bottari.data.model.team.CreateTeamBottariAssignedItemRequest
+import com.bottari.data.model.team.CreateTeamBottariPersonalItemRequest
 import com.bottari.data.model.team.CreateTeamBottariRequest
+import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
 import com.bottari.data.model.team.FetchTeamBottariChecklistResponse
 import com.bottari.data.model.team.FetchTeamBottariDetailResponse
 import com.bottari.data.model.team.FetchTeamBottariResponse
@@ -38,6 +41,23 @@ interface TeamBottariRemoteDataSource {
     suspend fun fetchTeamMembers(id: Long): Result<FetchTeamMembersResponse>
 
     suspend fun fetchTeamMembersStatus(id: Long): Result<List<FetchTeamMemberStatusResponse>>
+
+    suspend fun createTeamBottariSharedItem(
+        id: Long,
+        request: CreateTeamBottariSharedItemRequest,
+    ): Result<Unit>
+
+    suspend fun createTeamBottariPersonalItem(
+        id: Long,
+        request: CreateTeamBottariPersonalItemRequest,
+    ): Result<Unit>
+
+    suspend fun createTeamBottariAssignedItem(
+        id: Long,
+        request: CreateTeamBottariAssignedItemRequest,
+    ): Result<Unit>
+
+    suspend fun deleteTeamBottariItem(id: Long): Result<Unit>
 
     suspend fun sendRemindByMemberMessage(
         teamBottariId: Long,

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.bottari.data.model.team.CreateTeamBottariAssignedItemRequest
 import com.bottari.data.model.team.CreateTeamBottariPersonalItemRequest
 import com.bottari.data.model.team.CreateTeamBottariRequest
 import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
+import com.bottari.data.model.team.DeleteTeamBottariItemRequest
 import com.bottari.data.model.team.FetchTeamBottariChecklistResponse
 import com.bottari.data.model.team.FetchTeamBottariDetailResponse
 import com.bottari.data.model.team.FetchTeamBottariResponse
@@ -57,6 +58,10 @@ interface TeamBottariRemoteDataSource {
         request: CreateTeamBottariAssignedItemRequest,
     ): Result<Unit>
 
+    suspend fun deleteTeamBottariItem(
+        id: Long,
+        type: DeleteTeamBottariItemRequest,
+    ): Result<Unit>
     suspend fun deleteTeamBottariItem(id: Long): Result<Unit>
 
     suspend fun sendRemindByMemberMessage(

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSourceImpl.kt
@@ -3,7 +3,10 @@ package com.bottari.data.source.remote
 import com.bottari.data.common.extension.extractIdFromHeader
 import com.bottari.data.common.util.safeApiCall
 import com.bottari.data.model.common.ErrorResponse
+import com.bottari.data.model.team.CreateTeamBottariAssignedItemRequest
+import com.bottari.data.model.team.CreateTeamBottariPersonalItemRequest
 import com.bottari.data.model.team.CreateTeamBottariRequest
+import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
 import com.bottari.data.model.team.FetchTeamBottariChecklistResponse
 import com.bottari.data.model.team.FetchTeamBottariDetailResponse
 import com.bottari.data.model.team.FetchTeamBottariResponse
@@ -76,6 +79,35 @@ class TeamBottariRemoteDataSourceImpl(
 
     override suspend fun fetchTeamMembersStatus(id: Long): Result<List<FetchTeamMemberStatusResponse>> =
         safeApiCall { teamBottariService.fetchTeamMembersStatus(id) }
+
+    override suspend fun createTeamBottariSharedItem(
+        id: Long,
+        request: CreateTeamBottariSharedItemRequest,
+    ): Result<Unit> =
+        safeApiCall {
+            teamBottariService.createTeamBottariSharedItem(id, request)
+        }
+
+    override suspend fun createTeamBottariPersonalItem(
+        id: Long,
+        request: CreateTeamBottariPersonalItemRequest,
+    ): Result<Unit> =
+        safeApiCall {
+            teamBottariService.createTeamBottariPersonalItem(id, request)
+        }
+
+    override suspend fun createTeamBottariAssignedItem(
+        id: Long,
+        request: CreateTeamBottariAssignedItemRequest,
+    ): Result<Unit> =
+        safeApiCall {
+            teamBottariService.createTeamBottariAssignedItem(id, request)
+        }
+
+    override suspend fun deleteTeamBottariItem(id: Long): Result<Unit> =
+        safeApiCall {
+            teamBottariService.deleteTeamBottariItem(id)
+        }
 
     override suspend fun sendRemindByMemberMessage(
         teamBottariId: Long,

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSourceImpl.kt
@@ -7,6 +7,7 @@ import com.bottari.data.model.team.CreateTeamBottariAssignedItemRequest
 import com.bottari.data.model.team.CreateTeamBottariPersonalItemRequest
 import com.bottari.data.model.team.CreateTeamBottariRequest
 import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
+import com.bottari.data.model.team.DeleteTeamBottariItemRequest
 import com.bottari.data.model.team.FetchTeamBottariChecklistResponse
 import com.bottari.data.model.team.FetchTeamBottariDetailResponse
 import com.bottari.data.model.team.FetchTeamBottariResponse
@@ -104,9 +105,12 @@ class TeamBottariRemoteDataSourceImpl(
             teamBottariService.createTeamBottariAssignedItem(id, request)
         }
 
-    override suspend fun deleteTeamBottariItem(id: Long): Result<Unit> =
+    override suspend fun deleteTeamBottariItem(
+        id: Long,
+        type: DeleteTeamBottariItemRequest,
+    ): Result<Unit> =
         safeApiCall {
-            teamBottariService.deleteTeamBottariItem(id)
+            teamBottariService.deleteTeamBottariItem(id, type)
         }
 
     override suspend fun sendRemindByMemberMessage(

--- a/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
@@ -22,12 +22,18 @@ import com.bottari.domain.usecase.member.RegisterMemberUseCase
 import com.bottari.domain.usecase.member.SaveMemberNicknameUseCase
 import com.bottari.domain.usecase.report.ReportTemplateUseCase
 import com.bottari.domain.usecase.team.CheckTeamBottariItemUseCase
+import com.bottari.domain.usecase.team.CreateTeamAssignedItemUseCase
 import com.bottari.domain.usecase.team.CreateTeamBottariUseCase
+import com.bottari.domain.usecase.team.CreateTeamPersonalItemUseCase
+import com.bottari.domain.usecase.team.CreateTeamSharedItemUseCase
+import com.bottari.domain.usecase.team.FetchTeamAssignedItemsUseCase
 import com.bottari.domain.usecase.team.FetchTeamBottariDetailUseCase
 import com.bottari.domain.usecase.team.FetchTeamBottariesUseCase
 import com.bottari.domain.usecase.team.FetchTeamChecklistUseCase
 import com.bottari.domain.usecase.team.FetchTeamMembersStatusUseCase
 import com.bottari.domain.usecase.team.FetchTeamMembersUseCase
+import com.bottari.domain.usecase.team.FetchTeamPersonalItemsUseCase
+import com.bottari.domain.usecase.team.FetchTeamSharedItemsUseCase
 import com.bottari.domain.usecase.team.FetchTeamStatusUseCase
 import com.bottari.domain.usecase.team.SendRemindByItemUseCase
 import com.bottari.domain.usecase.team.SendRemindByMemberMessageUseCase
@@ -186,6 +192,24 @@ object UseCaseProvider {
     }
     val fetchTeamMembersStatusUseCase: FetchTeamMembersStatusUseCase by lazy {
         FetchTeamMembersStatusUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val fetchTeamPersonalItemsUseCase: FetchTeamPersonalItemsUseCase by lazy {
+        FetchTeamPersonalItemsUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val fetchTeamAssignedItemsUseCase: FetchTeamAssignedItemsUseCase by lazy {
+        FetchTeamAssignedItemsUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val fetchTeamSharedItemsUseCase: FetchTeamSharedItemsUseCase by lazy {
+        FetchTeamSharedItemsUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val createTeamSharedItemUseCase: CreateTeamSharedItemUseCase by lazy {
+        CreateTeamSharedItemUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val createTeamPersonalItemUseCase: CreateTeamPersonalItemUseCase by lazy {
+        CreateTeamPersonalItemUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val createTeamAssignedItemUseCase: CreateTeamAssignedItemUseCase by lazy {
+        CreateTeamAssignedItemUseCase(RepositoryProvider.teamBottariRepository)
     }
     val saveFcmTokenUseCase: SaveFcmTokenUseCase by lazy {
         SaveFcmTokenUseCase(RepositoryProvider.fcmRepository)

--- a/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
@@ -26,6 +26,7 @@ import com.bottari.domain.usecase.team.CreateTeamAssignedItemUseCase
 import com.bottari.domain.usecase.team.CreateTeamBottariUseCase
 import com.bottari.domain.usecase.team.CreateTeamPersonalItemUseCase
 import com.bottari.domain.usecase.team.CreateTeamSharedItemUseCase
+import com.bottari.domain.usecase.team.DeleteTeamBottariItemUseCase
 import com.bottari.domain.usecase.team.FetchTeamAssignedItemsUseCase
 import com.bottari.domain.usecase.team.FetchTeamBottariDetailUseCase
 import com.bottari.domain.usecase.team.FetchTeamBottariesUseCase
@@ -210,6 +211,9 @@ object UseCaseProvider {
     }
     val createTeamAssignedItemUseCase: CreateTeamAssignedItemUseCase by lazy {
         CreateTeamAssignedItemUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val deleteTeamBottariItemUseCase: DeleteTeamBottariItemUseCase by lazy {
+        DeleteTeamBottariItemUseCase(RepositoryProvider.teamBottariRepository)
     }
     val saveFcmTokenUseCase: SaveFcmTokenUseCase by lazy {
         SaveFcmTokenUseCase(RepositoryProvider.fcmRepository)

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/TeamBottariRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/TeamBottariRepository.kt
@@ -58,7 +58,6 @@ interface TeamBottariRepository {
         id: Long,
         type: BottariItemType,
     ): Result<Unit>
-    suspend fun deleteTeamBottariItem(id: Long): Result<Unit>
 
     suspend fun sendRemindByMemberMessage(
         teamBottariId: Long,

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/TeamBottariRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/TeamBottariRepository.kt
@@ -1,5 +1,6 @@
 package com.bottari.domain.repository
 
+import com.bottari.domain.model.bottari.BottariItemType
 import com.bottari.domain.model.bottari.TeamBottari
 import com.bottari.domain.model.team.TeamBottariCheckList
 import com.bottari.domain.model.team.TeamBottariDetail
@@ -53,6 +54,10 @@ interface TeamBottariRepository {
         teamMemberNames: List<String>,
     ): Result<Unit>
 
+    suspend fun deleteTeamBottariItem(
+        id: Long,
+        type: BottariItemType,
+    ): Result<Unit>
     suspend fun deleteTeamBottariItem(id: Long): Result<Unit>
 
     suspend fun sendRemindByMemberMessage(

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/TeamBottariRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/TeamBottariRepository.kt
@@ -37,6 +37,24 @@ interface TeamBottariRepository {
 
     suspend fun fetchTeamMembersStatus(id: Long): Result<List<TeamMemberStatus>>
 
+    suspend fun createTeamBottariSharedItem(
+        id: Long,
+        name: String,
+    ): Result<Unit>
+
+    suspend fun createTeamBottariPersonalItem(
+        id: Long,
+        name: String,
+    ): Result<Unit>
+
+    suspend fun createTeamBottariAssignedItem(
+        id: Long,
+        name: String,
+        teamMemberNames: List<String>,
+    ): Result<Unit>
+
+    suspend fun deleteTeamBottariItem(id: Long): Result<Unit>
+
     suspend fun sendRemindByMemberMessage(
         teamBottariId: Long,
         memberId: Long,

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/CreateTeamAssignedItemUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/CreateTeamAssignedItemUseCase.kt
@@ -1,0 +1,13 @@
+package com.bottari.domain.usecase.team
+
+import com.bottari.domain.repository.TeamBottariRepository
+
+class CreateTeamAssignedItemUseCase(
+    private val teamBottariRepository: TeamBottariRepository,
+) {
+    suspend operator fun invoke(
+        bottariId: Long,
+        name: String,
+        teamMemberNames: List<String>,
+    ): Result<Unit> = teamBottariRepository.createTeamBottariAssignedItem(bottariId, name, teamMemberNames)
+}

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/CreateTeamPersonalItemUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/CreateTeamPersonalItemUseCase.kt
@@ -1,0 +1,12 @@
+package com.bottari.domain.usecase.team
+
+import com.bottari.domain.repository.TeamBottariRepository
+
+class CreateTeamPersonalItemUseCase(
+    private val teamBottariRepository: TeamBottariRepository,
+) {
+    suspend operator fun invoke(
+        bottariId: Long,
+        name: String,
+    ): Result<Unit> = teamBottariRepository.createTeamBottariPersonalItem(bottariId, name)
+}

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/CreateTeamSharedItemUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/CreateTeamSharedItemUseCase.kt
@@ -1,0 +1,12 @@
+package com.bottari.domain.usecase.team
+
+import com.bottari.domain.repository.TeamBottariRepository
+
+class CreateTeamSharedItemUseCase(
+    private val teamBottariRepository: TeamBottariRepository,
+) {
+    suspend operator fun invoke(
+        bottariId: Long,
+        name: String,
+    ): Result<Unit> = teamBottariRepository.createTeamBottariSharedItem(bottariId, name)
+}

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/DeleteTeamBottariItemUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/DeleteTeamBottariItemUseCase.kt
@@ -1,0 +1,13 @@
+package com.bottari.domain.usecase.team
+
+import com.bottari.domain.model.bottari.BottariItemType
+import com.bottari.domain.repository.TeamBottariRepository
+
+class DeleteTeamBottariItemUseCase(
+    private val teamBottariRepository: TeamBottariRepository,
+) {
+    suspend operator fun invoke(
+        itemId: Long,
+        type: BottariItemType,
+    ) = teamBottariRepository.deleteTeamBottariItem(itemId, type)
+}

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/FetchTeamAssignedItemsUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/FetchTeamAssignedItemsUseCase.kt
@@ -1,0 +1,11 @@
+package com.bottari.domain.usecase.team
+
+import com.bottari.domain.model.bottari.BottariItem
+import com.bottari.domain.repository.TeamBottariRepository
+
+class FetchTeamAssignedItemsUseCase(
+    private val teamBottariRepository: TeamBottariRepository,
+) {
+    suspend operator fun invoke(bottariId: Long): Result<List<BottariItem>> =
+        teamBottariRepository.fetchTeamBottariDetail(bottariId).mapCatching { it.assignedItems }
+}

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/FetchTeamPersonalItemsUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/FetchTeamPersonalItemsUseCase.kt
@@ -1,0 +1,11 @@
+package com.bottari.domain.usecase.team
+
+import com.bottari.domain.model.bottari.BottariItem
+import com.bottari.domain.repository.TeamBottariRepository
+
+class FetchTeamPersonalItemsUseCase(
+    private val teamBottariRepository: TeamBottariRepository,
+) {
+    suspend operator fun invoke(bottariId: Long): Result<List<BottariItem>> =
+        teamBottariRepository.fetchTeamBottariDetail(bottariId).mapCatching { it.personalItems }
+}

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/FetchTeamSharedItemsUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/FetchTeamSharedItemsUseCase.kt
@@ -1,0 +1,11 @@
+package com.bottari.domain.usecase.team
+
+import com.bottari.domain.model.bottari.BottariItem
+import com.bottari.domain.repository.TeamBottariRepository
+
+class FetchTeamSharedItemsUseCase(
+    private val teamBottariRepository: TeamBottariRepository,
+) {
+    suspend operator fun invoke(bottariId: Long): Result<List<BottariItem>> =
+        teamBottariRepository.fetchTeamBottariDetail(bottariId).mapCatching { it.sharedItems }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/base/BaseFragment.kt
@@ -16,7 +16,7 @@ abstract class BaseFragment<VB : ViewBinding>(
     private var _binding: VB? = null
     val binding: VB get() = _binding!!
 
-    private val loadingDialog: LoadingDialog by lazy { LoadingDialog() }
+    private var loadingDialog: LoadingDialog? = null
     private var enterTime: Long = System.currentTimeMillis()
     private val stayDuration: Long get() = System.currentTimeMillis() - enterTime
 
@@ -76,6 +76,8 @@ abstract class BaseFragment<VB : ViewBinding>(
     override fun onDestroyView() {
         super.onDestroyView()
         BottariLogger.lifecycle(javaClass.simpleName)
+        loadingDialog?.dismiss()
+        loadingDialog = null
         _binding = null
     }
 
@@ -85,15 +87,16 @@ abstract class BaseFragment<VB : ViewBinding>(
     }
 
     protected fun toggleLoadingIndicator(isShow: Boolean) {
-        if (isShow) {
-            if (loadingDialog.isAdded || loadingDialog.isVisible || loadingDialog.isRemoving) return
-            if (childFragmentManager.isStateSaved) return
-
-            loadingDialog.show(childFragmentManager, LoadingDialog::class.java.name)
-            return
+        if (loadingDialog?.context != requireContext()) {
+            loadingDialog?.dismiss()
+            loadingDialog = LoadingDialog(requireContext())
         }
 
-        if (!loadingDialog.isAdded) return
-        loadingDialog.dismissAllowingStateLoss()
+        val dialog = loadingDialog ?: return
+        if (isShow) {
+            if (dialog.isShowing.not()) dialog.show()
+            return
+        }
+        if (dialog.isShowing) dialog.dismiss()
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/EditTextExtension.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/EditTextExtension.kt
@@ -1,0 +1,8 @@
+package com.bottari.presentation.common.extension
+
+import android.widget.EditText
+
+fun EditText.setTextIfDifferent(newText: CharSequence?) {
+    if (text.toString() == newText?.toString()) return
+    setText(newText)
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/checklist/adapter/TeamChecklistTypeViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/checklist/adapter/TeamChecklistTypeViewHolder.kt
@@ -33,9 +33,9 @@ class TeamChecklistTypeViewHolder(
     @StringRes
     private fun BottariItemTypeUiModel.getStringResId(): Int =
         when (this) {
-            BottariItemTypeUiModel.SHARED -> R.string.team_checklist_type_shared_text
-            is BottariItemTypeUiModel.ASSIGNED -> R.string.team_checklist_type_assigned_text
-            BottariItemTypeUiModel.PERSONAL -> R.string.team_checklist_type_personal_text
+            BottariItemTypeUiModel.SHARED -> R.string.bottari_item_type_shared_text
+            is BottariItemTypeUiModel.ASSIGNED -> R.string.bottari_item_type_assigned_text
+            BottariItemTypeUiModel.PERSONAL -> R.string.bottari_item_type_personal_text
         }
 
     interface OnTeamChecklistTypeClickListener {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/status/adapter/TeamBottariProductTypeViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/status/adapter/TeamBottariProductTypeViewHolder.kt
@@ -19,9 +19,9 @@ class TeamBottariProductTypeViewHolder private constructor(
     @StringRes
     private fun BottariItemTypeUiModel.getStringResId(): Int =
         when (this) {
-            BottariItemTypeUiModel.SHARED -> R.string.team_checklist_type_shared_text
-            is BottariItemTypeUiModel.ASSIGNED -> R.string.team_checklist_type_assigned_text
-            BottariItemTypeUiModel.PERSONAL -> R.string.team_checklist_type_personal_text
+            BottariItemTypeUiModel.SHARED -> R.string.bottari_item_type_shared_text
+            is BottariItemTypeUiModel.ASSIGNED -> R.string.bottari_item_type_assigned_text
+            BottariItemTypeUiModel.PERSONAL -> R.string.bottari_item_type_personal_text
         }
 
     companion object {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/common/LoadingDialog.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/common/LoadingDialog.kt
@@ -1,24 +1,24 @@
 package com.bottari.presentation.view.common
 
 import android.app.Dialog
-import android.os.Bundle
+import android.content.Context
 import android.view.ViewGroup
-import androidx.fragment.app.DialogFragment
 import com.bottari.presentation.R
 
-class LoadingDialog : DialogFragment() {
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
-        Dialog(requireContext()).apply {
-            setContentView(R.layout.dialog_loading)
-            setCancelable(false)
-
-            window?.apply {
-                setBackgroundDrawableResource(android.R.color.transparent)
-                setLayout(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                )
-                setDimAmount(0f)
-            }
+class LoadingDialog(
+    context: Context,
+) : Dialog(context) {
+    init {
+        window?.apply {
+            setBackgroundDrawableResource(android.R.color.transparent)
+            setLayout(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            setDimAmount(0f)
         }
+
+        setContentView(R.layout.dialog_loading)
+        setCancelable(false)
+    }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
@@ -20,7 +20,6 @@ import com.bottari.presentation.common.extension.getParcelableArrayListCompat
 import com.bottari.presentation.common.extension.showSnackbar
 import com.bottari.presentation.databinding.FragmentPersonalItemEditBinding
 import com.bottari.presentation.model.BottariItemUiModel
-import com.bottari.presentation.model.ChecklistItemUiModel
 import com.bottari.presentation.view.common.alart.CustomAlertDialog
 import com.bottari.presentation.view.common.alart.DialogListener
 import com.bottari.presentation.view.common.alart.DialogPresetType
@@ -154,7 +153,7 @@ class PersonalItemEditFragment :
         binding.tvBottariTitle.text = title
     }
 
-    private fun handleItemState(bottariItems: List<ChecklistItemUiModel>) {
+    private fun handleItemState(bottariItems: List<BottariItemUiModel>) {
         adapter.submitList(bottariItems)
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
@@ -1,12 +1,12 @@
 package com.bottari.presentation.view.edit.personal.item
 
-import com.bottari.presentation.model.ChecklistItemUiModel
+import com.bottari.presentation.model.BottariItemUiModel
 
 data class PersonalItemEditUiState(
     val isLoading: Boolean = false,
     val bottariId: Long,
     val title: String,
-    var items: List<ChecklistItemUiModel>,
+    var items: List<BottariItemUiModel>,
 ) {
     val initialItems: List<String> = items.map { it.name }
     val initialItemIds: List<Long> = items.map { it.id }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
@@ -10,7 +10,8 @@ import com.bottari.domain.usecase.item.SaveBottariItemsUseCase
 import com.bottari.logger.BottariLogger
 import com.bottari.logger.model.UiEventType
 import com.bottari.presentation.common.base.BaseViewModel
-import com.bottari.presentation.model.ChecklistItemUiModel
+import com.bottari.presentation.model.BottariItemTypeUiModel
+import com.bottari.presentation.model.BottariItemUiModel
 
 class PersonalItemEditViewModel(
     stateHandle: SavedStateHandle,
@@ -23,7 +24,7 @@ class PersonalItemEditViewModel(
         ),
     ) {
     private val newItemNames = mutableSetOf<String>()
-    private val pendingDeleteItems = mutableSetOf<ChecklistItemUiModel>()
+    private val pendingDeleteItems = mutableSetOf<BottariItemUiModel>()
 
     fun addNewItemIfNeeded(itemName: String) {
         if (itemName.isBlank() || isDuplicateItem(itemName)) return
@@ -82,11 +83,11 @@ class PersonalItemEditViewModel(
         return true
     }
 
-    private fun generateNewItemUiModel(name: String): ChecklistItemUiModel =
-        ChecklistItemUiModel(
+    private fun generateNewItemUiModel(name: String): BottariItemUiModel =
+        BottariItemUiModel(
             id = nextGeneratedItemId(),
-            isChecked = false,
             name = name,
+            type = BottariItemTypeUiModel.PERSONAL,
         )
 
     private fun nextGeneratedItemId(): Long = (currentState.items.maxOfOrNull { it.id } ?: DEFAULT_ITEM_ID) + ITEM_ID_INCREMENT
@@ -103,7 +104,7 @@ class PersonalItemEditViewModel(
         fun Factory(
             bottariId: Long,
             title: String,
-            items: List<ChecklistItemUiModel>,
+            items: List<BottariItemUiModel>,
         ): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/adapter/PersonalItemEditAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/adapter/PersonalItemEditAdapter.kt
@@ -3,12 +3,12 @@ package com.bottari.presentation.view.edit.personal.item.adapter
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import com.bottari.presentation.model.ChecklistItemUiModel
+import com.bottari.presentation.model.BottariItemUiModel
 import com.bottari.presentation.view.edit.personal.item.listener.OnEditItemClickListener
 
 class PersonalItemEditAdapter(
     private val onEditItemClickListener: OnEditItemClickListener,
-) : ListAdapter<ChecklistItemUiModel, PersonalItemEditViewHolder>(DiffUtil) {
+) : ListAdapter<BottariItemUiModel, PersonalItemEditViewHolder>(DiffUtil) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -23,15 +23,15 @@ class PersonalItemEditAdapter(
 
     companion object {
         private val DiffUtil =
-            object : DiffUtil.ItemCallback<ChecklistItemUiModel>() {
+            object : DiffUtil.ItemCallback<BottariItemUiModel>() {
                 override fun areContentsTheSame(
-                    oldItem: ChecklistItemUiModel,
-                    newItem: ChecklistItemUiModel,
+                    oldItem: BottariItemUiModel,
+                    newItem: BottariItemUiModel,
                 ): Boolean = oldItem == newItem
 
                 override fun areItemsTheSame(
-                    oldItem: ChecklistItemUiModel,
-                    newItem: ChecklistItemUiModel,
+                    oldItem: BottariItemUiModel,
+                    newItem: BottariItemUiModel,
                 ): Boolean = oldItem.id == newItem.id
             }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/adapter/PersonalItemEditViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/adapter/PersonalItemEditViewHolder.kt
@@ -4,7 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bottari.presentation.databinding.ItemEditPersonalItemBinding
-import com.bottari.presentation.model.ChecklistItemUiModel
+import com.bottari.presentation.model.BottariItemUiModel
 import com.bottari.presentation.view.edit.personal.item.listener.OnEditItemClickListener
 
 class PersonalItemEditViewHolder(
@@ -19,7 +19,7 @@ class PersonalItemEditViewHolder(
         }
     }
 
-    fun bind(item: ChecklistItemUiModel) {
+    fun bind(item: BottariItemUiModel) {
         itemId = item.id
         binding.tvPersonalItemName.text = item.name
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/TeamBottariEditActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/TeamBottariEditActivity.kt
@@ -10,7 +10,7 @@ import com.bottari.presentation.common.base.BaseActivity
 import com.bottari.presentation.common.extension.showSnackbar
 import com.bottari.presentation.databinding.ActivityTeamBottariEditBinding
 import com.bottari.presentation.model.BottariItemTypeUiModel
-import com.bottari.presentation.view.edit.team.item.main.TeamBottariItemEditFragment
+import com.bottari.presentation.view.edit.team.item.main.TeamItemEditFragment
 import com.bottari.presentation.view.edit.team.main.TeamBottariEditFragment
 import com.bottari.presentation.view.edit.team.management.TeamManagementFragment
 
@@ -49,7 +49,7 @@ class TeamBottariEditActivity :
         supportFragmentManager.commit {
             replace(
                 R.id.fcv_team_edit,
-                TeamBottariItemEditFragment.newInstance(teamBottariId, requireTabType),
+                TeamItemEditFragment.newInstance(teamBottariId, requireTabType),
             )
             addToBackStack(null)
         }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/TeamBottariEditActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/TeamBottariEditActivity.kt
@@ -9,6 +9,8 @@ import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseActivity
 import com.bottari.presentation.common.extension.showSnackbar
 import com.bottari.presentation.databinding.ActivityTeamBottariEditBinding
+import com.bottari.presentation.model.BottariItemTypeUiModel
+import com.bottari.presentation.view.edit.team.item.main.TeamBottariItemEditFragment
 import com.bottari.presentation.view.edit.team.main.TeamBottariEditFragment
 import com.bottari.presentation.view.edit.team.management.TeamManagementFragment
 
@@ -36,6 +38,19 @@ class TeamBottariEditActivity :
     override fun navigateToMemberEdit(teamBottariId: Long) {
         supportFragmentManager.commit {
             replace(R.id.fcv_team_edit, TeamManagementFragment.newInstance(teamBottariId))
+            addToBackStack(null)
+        }
+    }
+
+    override fun navigateToItemEdit(
+        teamBottariId: Long,
+        requireTabType: BottariItemTypeUiModel,
+    ) {
+        supportFragmentManager.commit {
+            replace(
+                R.id.fcv_team_edit,
+                TeamBottariItemEditFragment.newInstance(teamBottariId, requireTabType),
+            )
             addToBackStack(null)
         }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/TeamBottariEditNavigator.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/TeamBottariEditNavigator.kt
@@ -1,7 +1,14 @@
 package com.bottari.presentation.view.edit.team
 
+import com.bottari.presentation.model.BottariItemTypeUiModel
+
 interface TeamBottariEditNavigator {
     fun navigateBack()
 
     fun navigateToMemberEdit(teamBottariId: Long)
+
+    fun navigateToItemEdit(
+        teamBottariId: Long,
+        requireTabType: BottariItemTypeUiModel,
+    )
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
@@ -1,0 +1,17 @@
+package com.bottari.presentation.view.edit.team.item.assigned
+
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+
+class TeamAssignedItemEditFragment : Fragment() {
+    private val bottariId: Long by lazy { requireArguments().getLong(ARG_BOTTARI_ID) }
+
+    companion object {
+        private const val ARG_BOTTARI_ID = "ARG_BOTTARI_ID"
+
+        fun newInstance(bottariId: Long): TeamAssignedItemEditFragment =
+            TeamAssignedItemEditFragment().apply {
+                arguments = bundleOf(ARG_BOTTARI_ID to bottariId)
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamBottariItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamBottariItemEditFragment.kt
@@ -1,0 +1,84 @@
+package com.bottari.presentation.view.edit.team.item.main
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.os.bundleOf
+import com.bottari.presentation.R
+import com.bottari.presentation.common.base.BaseFragment
+import com.bottari.presentation.common.extension.getParcelableCompat
+import com.bottari.presentation.databinding.FragmentTeamBottariItemEditBinding
+import com.bottari.presentation.model.BottariItemTypeUiModel
+import com.bottari.presentation.view.edit.team.TeamBottariEditNavigator
+import com.bottari.presentation.view.edit.team.item.main.adapter.TeamBottariItemEditFragmentAdapter
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayoutMediator
+
+class TeamBottariItemEditFragment : BaseFragment<FragmentTeamBottariItemEditBinding>(FragmentTeamBottariItemEditBinding::inflate) {
+    private val adapter: TeamBottariItemEditFragmentAdapter by lazy {
+        TeamBottariItemEditFragmentAdapter(this, requireArguments().getLong(ARG_BOTTARI_ID))
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObserver()
+        setupUI()
+        setupListener()
+    }
+
+    private fun setupObserver() {}
+
+    private fun setupUI() {
+        binding.vpTeamBottariItemEdit.adapter = adapter
+        binding.tlTeamBottariItemEdit
+        TabLayoutMediator(
+            binding.tlTeamBottariItemEdit,
+            binding.vpTeamBottariItemEdit,
+            ::setupTabs,
+        ).attach()
+        setRequireTab()
+    }
+
+    private fun setupListener() {
+        binding.btnPrevious.setOnClickListener {
+            (requireActivity() as? TeamBottariEditNavigator)?.navigateBack()
+        }
+    }
+
+    private fun setRequireTab() {
+        val tabType = requireArguments().getParcelableCompat<BottariItemTypeUiModel>(ARG_TAB_TYPE)
+        val tabPos =
+            when (tabType) {
+                BottariItemTypeUiModel.SHARED -> 0
+                is BottariItemTypeUiModel.ASSIGNED -> 1
+                BottariItemTypeUiModel.PERSONAL -> 2
+            }
+        binding.vpTeamBottariItemEdit.currentItem = tabPos
+    }
+
+    private fun setupTabs(
+        tab: TabLayout.Tab,
+        position: Int,
+    ) = when (position) {
+        0 -> getString(R.string.bottari_item_type_shared_text)
+        1 -> getString(R.string.bottari_item_type_assigned_text)
+        2 -> getString(R.string.bottari_item_type_personal_text)
+        else -> throw IllegalArgumentException(ERROR_UNKNOWN_TYPE)
+    }.also { tabName -> tab.text = tabName }
+
+    companion object {
+        private const val ARG_BOTTARI_ID = "ARG_BOTTARI_ID"
+        private const val ARG_TAB_TYPE = "ARG_TAB_TYPE"
+        private const val ERROR_UNKNOWN_TYPE = "[ERROR] 알 수 없는 타입입니다"
+
+        fun newInstance(
+            bottariId: Long,
+            requireTabType: BottariItemTypeUiModel,
+        ): TeamBottariItemEditFragment =
+            TeamBottariItemEditFragment().apply {
+                arguments = bundleOf(ARG_BOTTARI_ID to bottariId, ARG_TAB_TYPE to requireTabType)
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
-import androidx.activity.addCallback
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
@@ -135,9 +134,10 @@ class TeamItemEditFragment :
     }
 
     private fun handleSendButtonState(canSend: Boolean) {
-        binding.viewItemInput.btnPersonalItemSend.isEnabled = canSend
-        binding.viewItemInput.btnPersonalItemSend.alpha =
-            if (canSend) SEND_BUTTON_ENABLED_ALPHA else SEND_BUTTON_DISABLED_ALPHA
+        binding.viewItemInput.btnPersonalItemSend.run {
+            isEnabled = canSend
+            alpha = if (canSend) SEND_BUTTON_ENABLED_ALPHA else SEND_BUTTON_DISABLED_ALPHA
+        }
     }
 
     companion object {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
@@ -77,7 +78,7 @@ class TeamItemEditFragment :
     }
 
     private fun setupListener() {
-        binding.viewItemInput.btnPersonalItemSend.setOnClickListener { viewModel.createItem() }
+        binding.viewItemInput.btnPersonalItemSend.setOnClickListener { createItem() }
         binding.btnPrevious.setOnClickListener {
             (requireActivity() as? TeamBottariEditNavigator)?.navigateBack()
         }
@@ -89,6 +90,11 @@ class TeamItemEditFragment :
                 }
             },
         )
+        binding.viewItemInput.etItemInput.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId != EditorInfo.IME_ACTION_SEND) return@setOnEditorActionListener false
+            createItem()
+            true
+        }
     }
 
     private fun handleUiState(uiState: TeamItemEditUiState) {
@@ -138,6 +144,12 @@ class TeamItemEditFragment :
             isEnabled = canSend
             alpha = if (canSend) SEND_BUTTON_ENABLED_ALPHA else SEND_BUTTON_DISABLED_ALPHA
         }
+    }
+
+    private fun createItem() {
+        viewModel.createItem()
+        binding.viewItemInput.etItemInput.text
+            .clear()
     }
 
     companion object {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
@@ -9,13 +9,13 @@ import com.bottari.presentation.common.extension.getParcelableCompat
 import com.bottari.presentation.databinding.FragmentTeamBottariItemEditBinding
 import com.bottari.presentation.model.BottariItemTypeUiModel
 import com.bottari.presentation.view.edit.team.TeamBottariEditNavigator
-import com.bottari.presentation.view.edit.team.item.main.adapter.TeamBottariItemEditFragmentAdapter
+import com.bottari.presentation.view.edit.team.item.main.adapter.TeamItemEditFragmentAdapter
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 
-class TeamBottariItemEditFragment : BaseFragment<FragmentTeamBottariItemEditBinding>(FragmentTeamBottariItemEditBinding::inflate) {
-    private val adapter: TeamBottariItemEditFragmentAdapter by lazy {
-        TeamBottariItemEditFragmentAdapter(this, requireArguments().getLong(ARG_BOTTARI_ID))
+class TeamItemEditFragment : BaseFragment<FragmentTeamBottariItemEditBinding>(FragmentTeamBottariItemEditBinding::inflate) {
+    private val adapter: TeamItemEditFragmentAdapter by lazy {
+        TeamItemEditFragmentAdapter(this, requireArguments().getLong(ARG_BOTTARI_ID))
     }
 
     override fun onViewCreated(
@@ -76,8 +76,8 @@ class TeamBottariItemEditFragment : BaseFragment<FragmentTeamBottariItemEditBind
         fun newInstance(
             bottariId: Long,
             requireTabType: BottariItemTypeUiModel,
-        ): TeamBottariItemEditFragment =
-            TeamBottariItemEditFragment().apply {
+        ): TeamItemEditFragment =
+            TeamItemEditFragment().apply {
                 arguments = bundleOf(ARG_BOTTARI_ID to bottariId, ARG_TAB_TYPE to requireTabType)
             }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditUiEvent.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditUiEvent.kt
@@ -1,0 +1,9 @@
+package com.bottari.presentation.view.edit.team.item.main
+
+sealed interface TeamItemEditUiEvent {
+    data object CreateTeamPersonalItem : TeamItemEditUiEvent
+
+    data object CreateTeamSharedItem : TeamItemEditUiEvent
+
+    data object CreateTeamAssignedItem : TeamItemEditUiEvent
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditUiState.kt
@@ -1,0 +1,11 @@
+package com.bottari.presentation.view.edit.team.item.main
+
+import com.bottari.presentation.model.BottariItemTypeUiModel
+
+data class TeamItemEditUiState(
+    val itemInputText: String = "",
+    val isAlreadyExist: Boolean = false,
+    val currentTabType: BottariItemTypeUiModel,
+) {
+    val canSend: Boolean = itemInputText.isNotBlank() && isAlreadyExist.not()
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditViewModel.kt
@@ -1,0 +1,49 @@
+package com.bottari.presentation.view.edit.team.item.main
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.bottari.logger.BottariLogger
+import com.bottari.presentation.common.base.BaseViewModel
+import com.bottari.presentation.model.BottariItemTypeUiModel
+
+class TeamItemEditViewModel(
+    stateHandle: SavedStateHandle,
+) : BaseViewModel<TeamItemEditUiState, TeamItemEditUiEvent>(
+        TeamItemEditUiState(
+            currentTabType = stateHandle[KEY_TAB_TYPE] ?: error(ERROR_TYPE_NULL),
+        ),
+    ) {
+    fun updateInput(input: String) = updateState { copy(itemInputText = input) }
+
+    fun updateIsAlreadyExistState(isAlreadyExist: Boolean) {
+        if (currentState.isAlreadyExist == isAlreadyExist) return
+        updateState { copy(isAlreadyExist = isAlreadyExist) }
+    }
+
+    fun updateTabType(type: BottariItemTypeUiModel) = updateState { copy(currentTabType = type) }
+
+    fun createItem() {
+        when (currentState.currentTabType) {
+            BottariItemTypeUiModel.SHARED -> emitEvent(TeamItemEditUiEvent.CreateTeamSharedItem)
+            BottariItemTypeUiModel.PERSONAL -> emitEvent(TeamItemEditUiEvent.CreateTeamPersonalItem)
+            is BottariItemTypeUiModel.ASSIGNED -> emitEvent(TeamItemEditUiEvent.CreateTeamAssignedItem)
+        }
+    }
+
+    companion object {
+        private const val KEY_TAB_TYPE = "KEY_TAB_TYPE"
+        private const val ERROR_TYPE_NULL = "[ERROR] type이 null입니다"
+
+        fun Factory(initialTabType: BottariItemTypeUiModel): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    val stateHandle = createSavedStateHandle()
+                    stateHandle[KEY_TAB_TYPE] = initialTabType
+                    TeamItemEditViewModel(stateHandle)
+                }
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.bottari.logger.BottariLogger
 import com.bottari.presentation.common.base.BaseViewModel
 import com.bottari.presentation.model.BottariItemTypeUiModel
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/adapter/TabInfo.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/adapter/TabInfo.kt
@@ -1,0 +1,8 @@
+package com.bottari.presentation.view.edit.team.item.main.adapter
+
+import androidx.fragment.app.Fragment
+
+data class TabInfo(
+    val titleRes: Int,
+    val fragmentProvider: (Long) -> Fragment,
+)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/adapter/TeamBottariItemEditFragmentAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/adapter/TeamBottariItemEditFragmentAdapter.kt
@@ -1,0 +1,26 @@
+package com.bottari.presentation.view.edit.team.item.main.adapter
+
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.bottari.presentation.view.edit.team.item.assigned.TeamAssignedItemEditFragment
+import com.bottari.presentation.view.edit.team.item.personal.TeamPersonalItemEditFragment
+import com.bottari.presentation.view.edit.team.item.shared.TeamSharedItemEditFragment
+
+class TeamBottariItemEditFragmentAdapter(
+    fragment: Fragment,
+    private val bottariId: Long,
+) : FragmentStateAdapter(fragment) {
+    override fun getItemCount(): Int = 3
+
+    override fun createFragment(position: Int): Fragment =
+        when (position) {
+            0 -> TeamSharedItemEditFragment.newInstance(bottariId)
+            1 -> TeamAssignedItemEditFragment.newInstance(bottariId)
+            2 -> TeamPersonalItemEditFragment.newInstance(bottariId)
+            else -> throw IllegalArgumentException(ERROR_UNKNOWN_FRAGMENT)
+        }
+
+    companion object {
+        private const val ERROR_UNKNOWN_FRAGMENT = "[ERROR] 알 수 없는 프래그먼트입니다"
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/adapter/TeamItemEditFragmentAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/adapter/TeamItemEditFragmentAdapter.kt
@@ -6,7 +6,7 @@ import com.bottari.presentation.view.edit.team.item.assigned.TeamAssignedItemEdi
 import com.bottari.presentation.view.edit.team.item.personal.TeamPersonalItemEditFragment
 import com.bottari.presentation.view.edit.team.item.shared.TeamSharedItemEditFragment
 
-class TeamBottariItemEditFragmentAdapter(
+class TeamItemEditFragmentAdapter(
     fragment: Fragment,
     private val bottariId: Long,
 ) : FragmentStateAdapter(fragment) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/adapter/TeamItemEditFragmentAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/adapter/TeamItemEditFragmentAdapter.kt
@@ -1,7 +1,10 @@
 package com.bottari.presentation.view.edit.team.item.main.adapter
 
+import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.bottari.presentation.R
+import com.bottari.presentation.model.BottariItemTypeUiModel
 import com.bottari.presentation.view.edit.team.item.assigned.TeamAssignedItemEditFragment
 import com.bottari.presentation.view.edit.team.item.personal.TeamPersonalItemEditFragment
 import com.bottari.presentation.view.edit.team.item.shared.TeamSharedItemEditFragment
@@ -10,17 +13,57 @@ class TeamItemEditFragmentAdapter(
     fragment: Fragment,
     private val bottariId: Long,
 ) : FragmentStateAdapter(fragment) {
-    override fun getItemCount(): Int = 3
+    override fun getItemCount(): Int = TAB_INFO.size
 
-    override fun createFragment(position: Int): Fragment =
-        when (position) {
-            0 -> TeamSharedItemEditFragment.newInstance(bottariId)
-            1 -> TeamAssignedItemEditFragment.newInstance(bottariId)
-            2 -> TeamPersonalItemEditFragment.newInstance(bottariId)
-            else -> throw IllegalArgumentException(ERROR_UNKNOWN_FRAGMENT)
-        }
+    override fun createFragment(position: Int): Fragment {
+        val tabInfo = TAB_INFO.getOrNull(position)
+        return tabInfo?.fragmentProvider?.invoke(bottariId) ?: error(ERROR_UNKNOWN_FRAGMENT)
+    }
 
     companion object {
         private const val ERROR_UNKNOWN_FRAGMENT = "[ERROR] 알 수 없는 프래그먼트입니다"
+
+        private const val POSITION_SHARED = 0
+        private const val POSITION_ASSIGNED = 1
+        private const val POSITION_PERSONAL = 2
+
+        private val TAB_INFO =
+            listOf(
+                TabInfo(
+                    titleRes = R.string.bottari_item_type_shared_text,
+                    fragmentProvider = { id -> TeamSharedItemEditFragment.newInstance(id) },
+                ),
+                TabInfo(
+                    titleRes = R.string.bottari_item_type_assigned_text,
+                    fragmentProvider = { id -> TeamAssignedItemEditFragment.newInstance(id) },
+                ),
+                TabInfo(
+                    titleRes = R.string.bottari_item_type_personal_text,
+                    fragmentProvider = { id -> TeamPersonalItemEditFragment.newInstance(id) },
+                ),
+            )
+
+        fun tabTitleFromPosition(
+            position: Int,
+            context: Context,
+        ): String =
+            context.getString(
+                TAB_INFO.getOrNull(position)?.titleRes ?: error(ERROR_UNKNOWN_FRAGMENT),
+            )
+
+        fun positionFromType(type: BottariItemTypeUiModel): Int =
+            when (type) {
+                BottariItemTypeUiModel.SHARED -> POSITION_SHARED
+                is BottariItemTypeUiModel.ASSIGNED -> POSITION_ASSIGNED
+                BottariItemTypeUiModel.PERSONAL -> POSITION_PERSONAL
+            }
+
+        fun typeFromPosition(position: Int): BottariItemTypeUiModel =
+            when (position) {
+                POSITION_SHARED -> BottariItemTypeUiModel.SHARED
+                POSITION_ASSIGNED -> BottariItemTypeUiModel.ASSIGNED(emptyList())
+                POSITION_PERSONAL -> BottariItemTypeUiModel.PERSONAL
+                else -> error(ERROR_UNKNOWN_FRAGMENT)
+            }
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditEvent.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditEvent.kt
@@ -1,0 +1,9 @@
+package com.bottari.presentation.view.edit.team.item.personal
+
+sealed interface TeamPersonalItemEditEvent {
+    data object FetchTeamPersonalItemsFailure : TeamPersonalItemEditEvent
+
+    data object DeleteItemFailure : TeamPersonalItemEditEvent
+
+    data object AddItemFailure : TeamPersonalItemEditEvent
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
@@ -1,0 +1,17 @@
+package com.bottari.presentation.view.edit.team.item.personal
+
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+
+class TeamPersonalItemEditFragment : Fragment() {
+    private val bottariId: Long by lazy { requireArguments().getLong(ARG_BOTTARI_ID) }
+
+    companion object {
+        private const val ARG_BOTTARI_ID = "ARG_BOTTARI_ID"
+
+        fun newInstance(bottariId: Long): TeamPersonalItemEditFragment =
+            TeamPersonalItemEditFragment().apply {
+                arguments = bundleOf(ARG_BOTTARI_ID to bottariId)
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
@@ -6,7 +6,6 @@ import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.bottari.logger.BottariLogger
 import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseFragment
 import com.bottari.presentation.common.extension.showSnackbar
@@ -53,7 +52,6 @@ class TeamPersonalItemEditFragment :
     }
 
     private fun handleParentUiState(uiState: TeamItemEditUiState) {
-        BottariLogger.debug(uiState.itemInputText)
         viewModel.updateInput(uiState.itemInputText)
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
@@ -1,10 +1,81 @@
 package com.bottari.presentation.view.edit.team.item.personal
 
+import android.os.Bundle
+import android.view.View
 import androidx.core.os.bundleOf
-import androidx.fragment.app.Fragment
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.bottari.logger.BottariLogger
+import com.bottari.presentation.R
+import com.bottari.presentation.common.base.BaseFragment
+import com.bottari.presentation.common.extension.showSnackbar
+import com.bottari.presentation.databinding.FragmentTeamPersonalItemEditBinding
+import com.bottari.presentation.view.edit.team.item.main.TeamItemEditUiEvent
+import com.bottari.presentation.view.edit.team.item.main.TeamItemEditUiState
+import com.bottari.presentation.view.edit.team.item.main.TeamItemEditViewModel
+import com.bottari.presentation.view.edit.team.item.personal.adapter.TeamPersonalItemEditAdapter
 
-class TeamPersonalItemEditFragment : Fragment() {
-    private val bottariId: Long by lazy { requireArguments().getLong(ARG_BOTTARI_ID) }
+class TeamPersonalItemEditFragment :
+    BaseFragment<FragmentTeamPersonalItemEditBinding>(FragmentTeamPersonalItemEditBinding::inflate),
+    TeamPersonalItemEditAdapter.TeamPersonalItemEditEventListener {
+    private val parentViewModel: TeamItemEditViewModel by viewModels(
+        ownerProducer = { requireParentFragment() },
+    )
+    private val viewModel: TeamPersonalItemEditViewModel by viewModels {
+        TeamPersonalItemEditViewModel.Factory(
+            requireArguments().getLong(ARG_BOTTARI_ID),
+        )
+    }
+    private val adapter: TeamPersonalItemEditAdapter by lazy { TeamPersonalItemEditAdapter(this) }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObserver()
+        setupUI()
+    }
+
+    override fun onClickDelete(itemId: Long) {}
+
+    private fun setupObserver() {
+        parentViewModel.uiEvent.observe(viewLifecycleOwner, ::handleParentUiEvent)
+        parentViewModel.uiState.observe(viewLifecycleOwner, ::handleParentUiState)
+        viewModel.uiState.observe(viewLifecycleOwner, ::handleUiState)
+        viewModel.uiEvent.observe(viewLifecycleOwner, ::handleUiEvent)
+    }
+
+    private fun setupUI() {
+        binding.rvTeamPersonalItemEdit.adapter = adapter
+        binding.rvTeamPersonalItemEdit.layoutManager = LinearLayoutManager(requireContext())
+    }
+
+    private fun handleParentUiState(uiState: TeamItemEditUiState) {
+        BottariLogger.debug(uiState.itemInputText)
+        viewModel.updateInput(uiState.itemInputText)
+    }
+
+    private fun handleParentUiEvent(uiEvent: TeamItemEditUiEvent) {
+        if (uiEvent !is TeamItemEditUiEvent.CreateTeamPersonalItem) return
+        viewModel.createItem()
+    }
+
+    private fun handleUiState(uiState: TeamPersonalItemEditUiState) {
+        toggleLoadingIndicator(uiState.isLoading)
+        parentViewModel.updateIsAlreadyExistState(uiState.isAlreadyExist)
+        binding.emptyView.root.isVisible = uiState.isEmpty
+        adapter.submitList(uiState.personalItems)
+    }
+
+    private fun handleUiEvent(uiEvent: TeamPersonalItemEditEvent) {
+        when (uiEvent) {
+            TeamPersonalItemEditEvent.FetchTeamPersonalItemsFailure -> requireView().showSnackbar(R.string.common_fetch_failure_text)
+            TeamPersonalItemEditEvent.AddItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
+            TeamPersonalItemEditEvent.DeleteItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
+        }
+    }
 
     companion object {
         private const val ARG_BOTTARI_ID = "ARG_BOTTARI_ID"

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
@@ -37,7 +37,9 @@ class TeamPersonalItemEditFragment :
         setupUI()
     }
 
-    override fun onClickDelete(itemId: Long) {}
+    override fun onClickDelete(itemId: Long) {
+        viewModel.deleteItem(itemId)
+    }
 
     private fun setupObserver() {
         parentViewModel.uiEvent.observe(viewLifecycleOwner, ::handleParentUiEvent)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditUiState.kt
@@ -1,0 +1,13 @@
+package com.bottari.presentation.view.edit.team.item.personal
+
+import com.bottari.presentation.model.BottariItemUiModel
+
+data class TeamPersonalItemEditUiState(
+    val isLoading: Boolean = false,
+    val isFetched: Boolean = false,
+    val personalItems: List<BottariItemUiModel> = emptyList(),
+    val inputText: String = "",
+) {
+    val isEmpty: Boolean = isFetched && personalItems.isEmpty()
+    val isAlreadyExist: Boolean = personalItems.any { it.name == inputText }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditViewModel.kt
@@ -6,7 +6,9 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.bottari.di.UseCaseProvider
+import com.bottari.domain.model.bottari.BottariItemType
 import com.bottari.domain.usecase.team.CreateTeamPersonalItemUseCase
+import com.bottari.domain.usecase.team.DeleteTeamBottariItemUseCase
 import com.bottari.domain.usecase.team.FetchTeamPersonalItemsUseCase
 import com.bottari.presentation.common.base.BaseViewModel
 import com.bottari.presentation.mapper.TeamBottariMapper.toUiModel
@@ -15,6 +17,7 @@ class TeamPersonalItemEditViewModel(
     stateHandle: SavedStateHandle,
     private val fetchTeamPersonalItemsUseCase: FetchTeamPersonalItemsUseCase,
     private val createTeamPersonalItemUseCase: CreateTeamPersonalItemUseCase,
+    private val deleteTeamBottariItemUseCase: DeleteTeamBottariItemUseCase,
 ) : BaseViewModel<TeamPersonalItemEditUiState, TeamPersonalItemEditEvent>(
         TeamPersonalItemEditUiState(),
     ) {
@@ -34,6 +37,18 @@ class TeamPersonalItemEditViewModel(
             createTeamPersonalItemUseCase(bottariId, currentState.inputText)
                 .onSuccess { fetchPersonalItems() }
                 .onFailure { emitEvent(TeamPersonalItemEditEvent.AddItemFailure) }
+
+            updateState { copy(isLoading = false) }
+        }
+    }
+
+    fun deleteItem(itemId: Long) {
+        updateState { copy(isLoading = true) }
+
+        launch {
+            deleteTeamBottariItemUseCase(itemId, BottariItemType.PERSONAL)
+                .onSuccess { fetchPersonalItems() }
+                .onFailure { emitEvent(TeamPersonalItemEditEvent.DeleteItemFailure) }
 
             updateState { copy(isLoading = false) }
         }
@@ -64,6 +79,7 @@ class TeamPersonalItemEditViewModel(
                         stateHandle,
                         UseCaseProvider.fetchTeamPersonalItemsUseCase,
                         UseCaseProvider.createTeamPersonalItemUseCase,
+                        UseCaseProvider.deleteTeamBottariItemUseCase,
                     )
                 }
             }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.bottari.di.UseCaseProvider
 import com.bottari.domain.usecase.team.CreateTeamPersonalItemUseCase
 import com.bottari.domain.usecase.team.FetchTeamPersonalItemsUseCase
-import com.bottari.logger.BottariLogger
 import com.bottari.presentation.common.base.BaseViewModel
 import com.bottari.presentation.mapper.TeamBottariMapper.toUiModel
 
@@ -25,10 +24,7 @@ class TeamPersonalItemEditViewModel(
         fetchPersonalItems()
     }
 
-    fun updateInput(input: String) {
-        BottariLogger.debug(input)
-        updateState { copy(inputText = input) }
-    }
+    fun updateInput(input: String) = updateState { copy(inputText = input) }
 
     fun createItem() {
         if (currentState.isAlreadyExist) return

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditViewModel.kt
@@ -1,0 +1,75 @@
+package com.bottari.presentation.view.edit.team.item.personal
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.bottari.di.UseCaseProvider
+import com.bottari.domain.usecase.team.CreateTeamPersonalItemUseCase
+import com.bottari.domain.usecase.team.FetchTeamPersonalItemsUseCase
+import com.bottari.logger.BottariLogger
+import com.bottari.presentation.common.base.BaseViewModel
+import com.bottari.presentation.mapper.TeamBottariMapper.toUiModel
+
+class TeamPersonalItemEditViewModel(
+    stateHandle: SavedStateHandle,
+    private val fetchTeamPersonalItemsUseCase: FetchTeamPersonalItemsUseCase,
+    private val createTeamPersonalItemUseCase: CreateTeamPersonalItemUseCase,
+) : BaseViewModel<TeamPersonalItemEditUiState, TeamPersonalItemEditEvent>(
+        TeamPersonalItemEditUiState(),
+    ) {
+    private val bottariId: Long = stateHandle[KEY_BOTTARI_ID] ?: error(ERROR_BOTTARI_ID)
+
+    init {
+        fetchPersonalItems()
+    }
+
+    fun updateInput(input: String) {
+        BottariLogger.debug(input)
+        updateState { copy(inputText = input) }
+    }
+
+    fun createItem() {
+        if (currentState.isAlreadyExist) return
+        updateState { copy(isLoading = true) }
+
+        launch {
+            createTeamPersonalItemUseCase(bottariId, currentState.inputText)
+                .onSuccess { fetchPersonalItems() }
+                .onFailure { emitEvent(TeamPersonalItemEditEvent.AddItemFailure) }
+
+            updateState { copy(isLoading = false) }
+        }
+    }
+
+    private fun fetchPersonalItems() {
+        updateState { copy(isLoading = true) }
+
+        launch {
+            fetchTeamPersonalItemsUseCase(bottariId)
+                .onSuccess { items -> updateState { copy(personalItems = items.map { it.toUiModel() }) } }
+                .onFailure { emitEvent(TeamPersonalItemEditEvent.FetchTeamPersonalItemsFailure) }
+
+            updateState { copy(isLoading = false, isFetched = true) }
+        }
+    }
+
+    companion object {
+        private const val KEY_BOTTARI_ID = "KEY_BOTTARI_ID"
+        private const val ERROR_BOTTARI_ID = "[ERROR] bottariId가 존재하지 않습니다"
+
+        fun Factory(bottariId: Long): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    val stateHandle = createSavedStateHandle()
+                    stateHandle[KEY_BOTTARI_ID] = bottariId
+                    TeamPersonalItemEditViewModel(
+                        stateHandle,
+                        UseCaseProvider.fetchTeamPersonalItemsUseCase,
+                        UseCaseProvider.createTeamPersonalItemUseCase,
+                    )
+                }
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/adapter/TeamPersonalItemEditAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/adapter/TeamPersonalItemEditAdapter.kt
@@ -1,0 +1,37 @@
+package com.bottari.presentation.view.edit.team.item.personal.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.bottari.presentation.model.BottariItemUiModel
+
+class TeamPersonalItemEditAdapter(
+    private val eventListener: TeamPersonalItemEditEventListener,
+) : ListAdapter<BottariItemUiModel, TeamPersonalItemEditViewHolder>(DiffUtil) {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): TeamPersonalItemEditViewHolder = TeamPersonalItemEditViewHolder.from(parent, eventListener)
+
+    override fun onBindViewHolder(
+        holder: TeamPersonalItemEditViewHolder,
+        position: Int,
+    ) = holder.bind(getItem(position))
+
+    interface TeamPersonalItemEditEventListener : TeamPersonalItemEditViewHolder.OnEditItemClickListener
+
+    companion object {
+        private val DiffUtil =
+            object : DiffUtil.ItemCallback<BottariItemUiModel>() {
+                override fun areContentsTheSame(
+                    oldItem: BottariItemUiModel,
+                    newItem: BottariItemUiModel,
+                ): Boolean = oldItem == newItem
+
+                override fun areItemsTheSame(
+                    oldItem: BottariItemUiModel,
+                    newItem: BottariItemUiModel,
+                ): Boolean = oldItem.id == newItem.id
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/adapter/TeamPersonalItemEditViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/adapter/TeamPersonalItemEditViewHolder.kt
@@ -1,0 +1,40 @@
+package com.bottari.presentation.view.edit.team.item.personal.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bottari.presentation.databinding.ItemEditPersonalItemBinding
+import com.bottari.presentation.model.BottariItemUiModel
+
+class TeamPersonalItemEditViewHolder(
+    private val binding: ItemEditPersonalItemBinding,
+    eventListener: OnEditItemClickListener,
+) : RecyclerView.ViewHolder(binding.root) {
+    private var itemId: Long? = null
+
+    init {
+        binding.btnPersonalItemDelete.setOnClickListener {
+            itemId?.let(eventListener::onClickDelete)
+        }
+    }
+
+    fun bind(item: BottariItemUiModel) {
+        itemId = item.id
+        binding.tvPersonalItemName.text = item.name
+    }
+
+    interface OnEditItemClickListener {
+        fun onClickDelete(itemId: Long)
+    }
+
+    companion object {
+        fun from(
+            parent: ViewGroup,
+            eventListener: OnEditItemClickListener,
+        ): TeamPersonalItemEditViewHolder {
+            val layoutInflater = LayoutInflater.from(parent.context)
+            val binding = ItemEditPersonalItemBinding.inflate(layoutInflater, parent, false)
+            return TeamPersonalItemEditViewHolder(binding, eventListener)
+        }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
@@ -1,0 +1,17 @@
+package com.bottari.presentation.view.edit.team.item.shared
+
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+
+class TeamSharedItemEditFragment : Fragment() {
+    private val bottariId: Long by lazy { requireArguments().getLong(ARG_BOTTARI_ID) }
+
+    companion object {
+        private const val ARG_BOTTARI_ID = "ARG_BOTTARI_ID"
+
+        fun newInstance(bottariId: Long): TeamSharedItemEditFragment =
+            TeamSharedItemEditFragment().apply {
+                arguments = bundleOf(ARG_BOTTARI_ID to bottariId)
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditFragment.kt
@@ -46,6 +46,11 @@ class TeamBottariEditFragment : BaseFragment<FragmentTeamBottariEditBinding>(Fra
         setupListener()
     }
 
+    override fun onStart() {
+        super.onStart()
+        viewModel.fetchTeamBottariDetail()
+    }
+
     private fun setupObserver() {
         viewModel.uiState.observe(viewLifecycleOwner, ::handleUiState)
         viewModel.uiEvent.observe(viewLifecycleOwner, ::handleUiEvent)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditFragment.kt
@@ -67,6 +67,25 @@ class TeamBottariEditFragment : BaseFragment<FragmentTeamBottariEditBinding>(Fra
         binding.viewTeamMemberEdit.root.setOnClickListener {
             (requireActivity() as? TeamBottariEditNavigator)?.navigateToMemberEdit(teamBottariId)
         }
+        binding.viewTeamPersonalItemEdit.root.setOnClickListener {
+            navigateToItemEdit(
+                BottariItemTypeUiModel.PERSONAL,
+            )
+        }
+        binding.viewTeamSharedItemEdit.root.setOnClickListener {
+            navigateToItemEdit(
+                BottariItemTypeUiModel.SHARED,
+            )
+        }
+        binding.viewTeamAssignedItemEdit.root.setOnClickListener {
+            navigateToItemEdit(
+                BottariItemTypeUiModel.ASSIGNED(),
+            )
+        }
+    }
+
+    private fun navigateToItemEdit(type: BottariItemTypeUiModel) {
+        (requireActivity() as? TeamBottariEditNavigator)?.navigateToItemEdit(teamBottariId, type)
     }
 
     private fun handleUiState(uiState: TeamBottariEditUiState) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditViewModel.kt
@@ -19,8 +19,16 @@ class TeamBottariEditViewModel(
 ) : BaseViewModel<TeamBottariEditUiState, TeamBottariEditUiEvent>(TeamBottariEditUiState()) {
     private val bottariId: Long = createHandle[KEY_BOTTARI_ID] ?: error(ERROR_BOTTARI_ID)
 
-    init {
-        fetchTeamBottariDetail()
+    fun fetchTeamBottariDetail() {
+        updateState { copy(isLoading = true) }
+
+        launch {
+            fetchTeamBottariDetailUseCase(bottariId)
+                .onSuccess { handleFetchTeamBottariDetail(it) }
+                .onFailure { emitEvent(TeamBottariEditUiEvent.FetchTeamBottariDetailFailure) }
+
+            updateState { copy(isLoading = false, isFetched = true) }
+        }
     }
 
     fun toggleAlarmState() {
@@ -38,18 +46,6 @@ class TeamBottariEditViewModel(
                 .onSuccess { updateState { copy(alarmSwitchState = newAlarmSwitchState) } }
                 .onFailure { emitEvent(TeamBottariEditUiEvent.ToggleAlarmStateFailure) }
             updateState { copy(isLoading = false) }
-        }
-    }
-
-    private fun fetchTeamBottariDetail() {
-        updateState { copy(isLoading = true) }
-
-        launch {
-            fetchTeamBottariDetailUseCase(bottariId)
-                .onSuccess { handleFetchTeamBottariDetail(it) }
-                .onFailure { emitEvent(TeamBottariEditUiEvent.FetchTeamBottariDetailFailure) }
-
-            updateState { copy(isLoading = false, isFetched = true) }
         }
     }
 

--- a/android/Bottari/presentation/src/main/res/layout/activity_team_checklist.xml
+++ b/android/Bottari/presentation/src/main/res/layout/activity_team_checklist.xml
@@ -43,7 +43,6 @@
 
     </androidx.appcompat.widget.Toolbar>
 
-
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tl_team_bottari"
         android:layout_width="match_parent"

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_bottari_item_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_bottari_item_edit.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Toolbar
+        android:id="@+id/toolbar_team_bottari_item_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:contentInsetStart="0dp"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/btn_previous"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/common_previous_btn_description"
+            android:padding="@dimen/space_small"
+            android:src="@drawable/btn_previous" />
+
+        <TextView
+            android:id="@+id/tv_bottari_title"
+            style="@style/Pretendard_Bold_20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="물건 목록"
+            android:textColor="@color/black" />
+
+        <TextView
+            android:id="@+id/btn_confirm"
+            style="@style/Pretendard_SemiBold_16"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="end"
+            android:gravity="center"
+            android:text="@string/common_confirm_btn_text"
+            android:textColor="@color/black" />
+    </Toolbar>
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tl_team_bottari_item_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_team_bottari_item_edit"
+        app:tabIndicatorColor="@color/black"
+        app:tabSelectedTextColor="@color/black"
+        app:tabTextAppearance="@style/CustomTabText"
+        app:tabSelectedTextAppearance="@style/CustomTabText"
+        app:tabTextColor="@color/gray_c4c4c4" />
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/vp_team_bottari_item_edit"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tl_team_bottari_item_edit" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_bottari_item_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_bottari_item_edit.xml
@@ -25,17 +25,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="물건 목록"
-            android:textColor="@color/black" />
-
-        <TextView
-            android:id="@+id/btn_confirm"
-            style="@style/Pretendard_SemiBold_16"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_gravity="end"
-            android:gravity="center"
-            android:text="@string/common_confirm_btn_text"
+            android:text="@string/team_bottari_item_edit_title_text"
             android:textColor="@color/black" />
     </Toolbar>
 
@@ -47,16 +37,23 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/toolbar_team_bottari_item_edit"
         app:tabIndicatorColor="@color/black"
+        app:tabSelectedTextAppearance="@style/CustomTabText"
         app:tabSelectedTextColor="@color/black"
         app:tabTextAppearance="@style/CustomTabText"
-        app:tabSelectedTextAppearance="@style/CustomTabText"
         app:tabTextColor="@color/gray_c4c4c4" />
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/vp_team_bottari_item_edit"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:paddingVertical="@dimen/space_small"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tl_team_bottari_item_edit" />
 
+    <include
+        android:id="@+id/view_item_input"
+        layout="@layout/view_item_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_bottari_item_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_bottari_item_edit.xml
@@ -46,8 +46,8 @@
         android:id="@+id/vp_team_bottari_item_edit"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:paddingVertical="@dimen/space_small"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:paddingTop="@dimen/space_small"
+        app:layout_constraintBottom_toTopOf="@id/view_item_input"
         app:layout_constraintTop_toBottomOf="@id/tl_team_bottari_item_edit" />
 
     <include

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_personal_item_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_personal_item_edit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_team_personal_item_edit"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fadingEdgeLength="8dp"
+        android:requiresFadingEdge="vertical"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:listitem="@layout/item_edit_personal_item" />
+
+    <include
+        android:id="@+id/empty_view"
+        layout="@layout/view_bottari_item_empty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/rv_team_personal_item_edit"
+        app:layout_constraintTop_toTopOf="@id/rv_team_personal_item_edit" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Bottari/presentation/src/main/res/layout/view_item_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/view_item_edit.xml
@@ -24,7 +24,8 @@
         android:textColorHint="@color/gray_a6a6a6"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/btn_personal_item_send"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/btn_personal_item_send"

--- a/android/Bottari/presentation/src/main/res/layout/view_item_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/view_item_edit.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/et_item_input"
+        style="@style/Pretendard_Regular_16"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/space_median"
+        android:layout_marginStart="@dimen/space_median"
+        android:background="@drawable/bg_gray_radius_12dp_transparent_stroke"
+        android:hint="@string/bottari_personal_item_edit_hint_text"
+        android:imeOptions="actionSend"
+        android:importantForAutofill="no"
+        android:inputType="text"
+        android:maxLength="20"
+        android:maxLines="1"
+        android:paddingHorizontal="@dimen/space_median"
+        android:paddingVertical="@dimen/space_small"
+        android:textColor="@color/black"
+        android:textColorHint="@color/gray_a6a6a6"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_personal_item_send"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/btn_personal_item_send"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:contentDescription="@string/bottari_personal_item_add_btn_description"
+        android:padding="@dimen/space_small"
+        android:src="@drawable/btn_send"
+        app:layout_constraintBottom_toBottomOf="@id/et_item_input"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/et_item_input" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -210,6 +210,7 @@
 
     <!-- Team Bottari Edit -->
     <string name="team_bottari_member_edit_title">팀원 관리</string>
+    <string name="team_bottari_item_edit_title_text">물건 목록</string>
 
     <!--  Team Members Status  -->
     <string name="team_members_status_hurry_up_btn_text">보채기</string>

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -194,10 +194,10 @@
     <string name="team_checklist_tap_team_current_text">팀 보따리 현황</string>
     <string name="team_checklist_tap_member_checklist_text">멤버 현황</string>
 
-    <!-- Team Checklist -->
-    <string name="team_checklist_type_shared_text">공통</string>
-    <string name="team_checklist_type_assigned_text">담당</string>
-    <string name="team_checklist_type_personal_text">개인</string>
+    <!-- Bottari Item Type -->
+    <string name="bottari_item_type_shared_text">공통</string>
+    <string name="bottari_item_type_assigned_text">담당</string>
+    <string name="bottari_item_type_personal_text">개인</string>
 
     <!--  Team Management  -->
     <string name="team_management_title_text">팀원 관리</string>

--- a/android/Bottari/presentation/src/main/res/values/styles.xml
+++ b/android/Bottari/presentation/src/main/res/values/styles.xml
@@ -55,4 +55,11 @@
     <style name="CustomCalendarSundayText">
         <item name="android:textColor">@color/calendar_sunday_selector</item>
     </style>
+
+    <style name="CustomTabText" parent="TextAppearance.AppCompat" >
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:fontFamily">@font/pretendard</item>
+        <item name="android:textFontWeight">600</item>
+    </style>
 </resources>


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 개인 물품 수정 화면 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #367 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 팀 보따리 개인 물품 수정 화면 구현

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
[Screen_recording_20250816_215446.webm](https://github.com/user-attachments/assets/6ce100c9-439d-4ae4-90e1-13870606ca91)


<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
