### PR TITLE
[BE] 팀 보따리 물품 타입별 조회 기능 구현

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemApiDocs.java
@@ -5,6 +5,7 @@ import com.bottari.error.ErrorCode;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
 import com.bottari.teambottari.dto.ReadAssignedItemResponse;
+import com.bottari.teambottari.dto.ReadPersonalItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemTypeRequest;
@@ -44,6 +45,20 @@ public interface TeamBottariItemApiDocs {
             ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI
     })
     ResponseEntity<List<ReadAssignedItemResponse>> readAssignedItems(
+            final Long teamBottariId,
+            @Parameter(hidden = true) final String ssaid
+    );
+
+    @Operation(summary = "팀 보따리 개인 물품 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 보따리 개인 물품 조회 성공"),
+    })
+    @ApiErrorCodes({
+            ErrorCode.TEAM_BOTTARI_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI
+    })
+    ResponseEntity<List<ReadPersonalItemResponse>> readPersonalItems(
             final Long teamBottariId,
             @Parameter(hidden = true) final String ssaid
     );

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemApiDocs.java
@@ -4,6 +4,7 @@ import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadAssignedItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemTypeRequest;
@@ -29,6 +30,20 @@ public interface TeamBottariItemApiDocs {
             ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI
     })
     ResponseEntity<List<ReadSharedItemResponse>> readSharedItems(
+            final Long teamBottariId,
+            @Parameter(hidden = true) final String ssaid
+    );
+
+    @Operation(summary = "팀 보따리 담당 물품 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 보따리 담당 물품 조회 성공"),
+    })
+    @ApiErrorCodes({
+            ErrorCode.TEAM_BOTTARI_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI
+    })
+    ResponseEntity<List<ReadAssignedItemResponse>> readAssignedItems(
             final Long teamBottariId,
             @Parameter(hidden = true) final String ssaid
     );

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemApiDocs.java
@@ -4,6 +4,7 @@ import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemTypeRequest;
 import com.bottari.teambottari.dto.TeamMemberChecklistResponse;
@@ -12,10 +13,25 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Team Bottari Item", description = "팀 보따리 물품 API")
 public interface TeamBottariItemApiDocs {
+
+    @Operation(summary = "팀 보따리 공통 물품 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 보따리 공통 물품 조회 성공"),
+    })
+    @ApiErrorCodes({
+            ErrorCode.TEAM_BOTTARI_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI
+    })
+    ResponseEntity<List<ReadSharedItemResponse>> readSharedItems(
+            final Long teamBottariId,
+            @Parameter(hidden = true) final String ssaid
+    );
 
     @Operation(summary = "팀 보따리 공통 물품 생성")
     @ApiResponses(value = {

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemController.java
@@ -3,6 +3,7 @@ package com.bottari.teambottari.controller;
 import com.bottari.config.MemberIdentifier;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadAssignedItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemTypeRequest;
@@ -33,6 +34,17 @@ public class TeamBottariItemController implements TeamBottariItemApiDocs {
             @MemberIdentifier final String ssaid
     ) {
         final List<ReadSharedItemResponse> responses = teamItemFacade.getSharedItems(teamBottariId, ssaid);
+
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/team-bottaries/{teamBottariId}/assigned-items")
+    @Override
+    public ResponseEntity<List<ReadAssignedItemResponse>> readAssignedItems(
+            @PathVariable final Long teamBottariId,
+            @MemberIdentifier final String ssaid
+    ) {
+        final List<ReadAssignedItemResponse> responses = teamItemFacade.getAssignedItems(teamBottariId, ssaid);
 
         return ResponseEntity.ok(responses);
     }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemController.java
@@ -3,11 +3,13 @@ package com.bottari.teambottari.controller;
 import com.bottari.config.MemberIdentifier;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemTypeRequest;
 import com.bottari.teambottari.dto.TeamMemberChecklistResponse;
 import com.bottari.teambottari.service.TeamItemFacade;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,6 +25,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class TeamBottariItemController implements TeamBottariItemApiDocs {
 
     private final TeamItemFacade teamItemFacade;
+
+    @GetMapping("/team-bottaries/{teamBottariId}/shared-items")
+    @Override
+    public ResponseEntity<List<ReadSharedItemResponse>> readSharedItems(
+            @PathVariable final Long teamBottariId,
+            @MemberIdentifier final String ssaid
+    ) {
+        final List<ReadSharedItemResponse> responses = teamItemFacade.getSharedItems(teamBottariId, ssaid);
+
+        return ResponseEntity.ok(responses);
+    }
 
     @PostMapping("/team-bottaries/{teamBottariId}/shared-items")
     @Override

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariItemController.java
@@ -4,6 +4,7 @@ import com.bottari.config.MemberIdentifier;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
 import com.bottari.teambottari.dto.ReadAssignedItemResponse;
+import com.bottari.teambottari.dto.ReadPersonalItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemTypeRequest;
@@ -45,6 +46,17 @@ public class TeamBottariItemController implements TeamBottariItemApiDocs {
             @MemberIdentifier final String ssaid
     ) {
         final List<ReadAssignedItemResponse> responses = teamItemFacade.getAssignedItems(teamBottariId, ssaid);
+
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/team-bottaries/{teamBottariId}/personal-items")
+    @Override
+    public ResponseEntity<List<ReadPersonalItemResponse>> readPersonalItems(
+            @PathVariable final Long teamBottariId,
+            @MemberIdentifier final String ssaid
+    ) {
+        final List<ReadPersonalItemResponse> responses = teamItemFacade.getPersonalItems(teamBottariId, ssaid);
 
         return ResponseEntity.ok(responses);
     }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadAssignedItemResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadAssignedItemResponse.java
@@ -1,0 +1,39 @@
+package com.bottari.teambottari.dto;
+
+import com.bottari.member.domain.Member;
+import com.bottari.teambottari.domain.TeamAssignedItemInfo;
+import java.util.List;
+
+public record ReadAssignedItemResponse(
+        Long id,
+        String name,
+        List<Assignee> assignees
+) {
+
+    public static ReadAssignedItemResponse from(
+            final
+            TeamAssignedItemInfo teamAssignedItemInfo,
+            final List<Member> members
+    ) {
+        return new ReadAssignedItemResponse(
+                teamAssignedItemInfo.getId(),
+                teamAssignedItemInfo.getName(),
+                members.stream()
+                        .map(Assignee::from)
+                        .toList()
+        );
+    }
+
+    public record Assignee(
+            Long memberId,
+            String name
+    ) {
+
+        public static Assignee from(final Member member) {
+            return new Assignee(
+                    member.getId(),
+                    member.getName()
+            );
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadPersonalItemResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadPersonalItemResponse.java
@@ -1,0 +1,16 @@
+package com.bottari.teambottari.dto;
+
+import com.bottari.teambottari.domain.TeamPersonalItem;
+
+public record ReadPersonalItemResponse(
+        Long id,
+        String name
+) {
+
+    public static ReadPersonalItemResponse from(final TeamPersonalItem teamPersonalItem) {
+        return new ReadPersonalItemResponse(
+                teamPersonalItem.getId(),
+                teamPersonalItem.getName()
+        );
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadSharedItemResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/dto/ReadSharedItemResponse.java
@@ -1,0 +1,16 @@
+package com.bottari.teambottari.dto;
+
+import com.bottari.teambottari.domain.TeamSharedItemInfo;
+
+public record ReadSharedItemResponse(
+        Long id,
+        String name
+) {
+
+    public static ReadSharedItemResponse from(final TeamSharedItemInfo teamSharedItemInfo) {
+        return new ReadSharedItemResponse(
+                teamSharedItemInfo.getId(),
+                teamSharedItemInfo.getName()
+        );
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
@@ -22,4 +22,15 @@ public interface TeamPersonalItemRepository extends JpaRepository<TeamPersonalIt
             final Long teamMemberId,
             final String name
     );
+
+    @Query("""
+            SELECT tpi
+            FROM TeamPersonalItem tpi
+            WHERE tpi.teamMember.teamBottari.id = :teamBottariId
+              AND tpi.teamMember.member.id = :memberId
+            """)
+    List<TeamPersonalItem> findAllByTeamBottariIdAndMemberId(
+            final Long teamBottariId,
+            final Long memberId
+    );
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
@@ -47,7 +47,7 @@ public class TeamBottariService {
 
     @Transactional(readOnly = true)
     public List<ReadTeamBottariPreviewResponse> getAllBySsaid(final String ssaid) {
-        final Member member = findMemberBySsaid(ssaid);
+        final Member member = getMemberBySsaid(ssaid);
         final List<TeamMember> teamMembers = teamMemberRepository.findAllByMemberId(member.getId());
 
         return buildReadTeamBottariPreviewResponses(teamMembers);
@@ -60,7 +60,7 @@ public class TeamBottariService {
     ) {
         final TeamBottari teamBottari = teamBottariRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND));
-        final Member member = findMemberBySsaid(ssaid);
+        final Member member = getMemberBySsaid(ssaid);
         final TeamMember teamMember = findTeamMemberByTeamBottariAndMember(teamBottari, member);
         final List<TeamSharedItemInfo> sharedItems = findSharedItemsByTeam(teamBottari.getId());
         final List<TeamAssignedItemInfo> assignedItems = findAssignedItemsByTeam(teamBottari.getId());
@@ -80,7 +80,7 @@ public class TeamBottariService {
             final String ssaid,
             final CreateTeamBottariRequest request
     ) {
-        final Member member = findMemberBySsaid(ssaid);
+        final Member member = getMemberBySsaid(ssaid);
         try {
             final String inviteCode = InviteCodeGenerator.generate();
             final TeamBottari teamBottari = new TeamBottari(request.title(), member, inviteCode);
@@ -94,7 +94,7 @@ public class TeamBottariService {
         }
     }
 
-    private Member findMemberBySsaid(final String ssaid) {
+    private Member getMemberBySsaid(final String ssaid) {
         return memberRepository.findBySsaid(ssaid)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
     }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
@@ -4,9 +4,11 @@ import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.member.domain.Member;
 import com.bottari.member.repository.MemberRepository;
+import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemTypeRequest;
@@ -29,6 +31,19 @@ public class TeamItemFacade {
     private final TeamMemberRepository teamMemberRepository;
     private final TeamBottariRepository teamBottariRepository;
     private final MemberRepository memberRepository;
+
+    public List<ReadSharedItemResponse> getSharedItems(
+            final Long teamBottariId,
+            final String ssaid
+    ) {
+        final TeamBottari teamBottari = teamBottariRepository.findById(teamBottariId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND, "존재하지 않는 팀 보따리입니다."));
+        final Member member = memberRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        validateMemberInTeam(teamBottari.getId(), member);
+
+        return teamSharedItemService.getAllByTeamBottariId(teamBottariId);
+    }
 
     @Transactional
     public Long createSharedItem(

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
@@ -9,6 +9,7 @@ import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
 import com.bottari.teambottari.dto.ReadAssignedItemResponse;
+import com.bottari.teambottari.dto.ReadPersonalItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
@@ -57,6 +58,19 @@ public class TeamItemFacade {
         validateMemberInTeam(teamBottari.getId(), member);
 
         return teamAssignedItemService.getAllByTeamBottariId(teamBottariId);
+    }
+
+    public List<ReadPersonalItemResponse> getPersonalItems(
+            final Long teamBottariId,
+            final String ssaid
+    ) {
+        final TeamBottari teamBottari = teamBottariRepository.findById(teamBottariId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND, "존재하지 않는 팀 보따리입니다."));
+        final Member member = memberRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        validateMemberInTeam(teamBottari.getId(), member);
+
+        return teamPersonalItemService.getAllByTeamBottariId(teamBottariId, member.getId());
     }
 
     @Transactional

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
@@ -38,10 +38,8 @@ public class TeamItemFacade {
             final Long teamBottariId,
             final String ssaid
     ) {
-        final TeamBottari teamBottari = teamBottariRepository.findById(teamBottariId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND, "존재하지 않는 팀 보따리입니다."));
-        final Member member = memberRepository.findBySsaid(ssaid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        final TeamBottari teamBottari = getTeamBottariById(teamBottariId);
+        final Member member = getMemberBySsaid(ssaid);
         validateMemberInTeam(teamBottari.getId(), member);
 
         return teamSharedItemService.getAllByTeamBottariId(teamBottariId);
@@ -51,10 +49,8 @@ public class TeamItemFacade {
             final Long teamBottariId,
             final String ssaid
     ) {
-        final TeamBottari teamBottari = teamBottariRepository.findById(teamBottariId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND, "존재하지 않는 팀 보따리입니다."));
-        final Member member = memberRepository.findBySsaid(ssaid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        final TeamBottari teamBottari = getTeamBottariById(teamBottariId);
+        final Member member = getMemberBySsaid(ssaid);
         validateMemberInTeam(teamBottari.getId(), member);
 
         return teamAssignedItemService.getAllByTeamBottariId(teamBottariId);
@@ -64,10 +60,8 @@ public class TeamItemFacade {
             final Long teamBottariId,
             final String ssaid
     ) {
-        final TeamBottari teamBottari = teamBottariRepository.findById(teamBottariId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND, "존재하지 않는 팀 보따리입니다."));
-        final Member member = memberRepository.findBySsaid(ssaid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        final TeamBottari teamBottari = getTeamBottariById(teamBottariId);
+        final Member member = getMemberBySsaid(ssaid);
         validateMemberInTeam(teamBottari.getId(), member);
 
         return teamPersonalItemService.getAllByTeamBottariId(teamBottariId, member.getId());
@@ -80,8 +74,7 @@ public class TeamItemFacade {
             final String ssaid
     ) {
         validateTeamBottari(teamBottariId);
-        final Member member = memberRepository.findBySsaid(ssaid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        final Member member = getMemberBySsaid(ssaid);
         validateMemberInTeam(teamBottariId, member);
         final TeamMember teamMember = getTeamMemberByTeamBottariIdAndSsaid(teamBottariId, ssaid);
 
@@ -107,8 +100,7 @@ public class TeamItemFacade {
             final String ssaid
     ) {
         validateTeamBottari(teamBottariId);
-        final Member member = memberRepository.findBySsaid(ssaid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        final Member member = getMemberBySsaid(ssaid);
         validateMemberInTeam(teamBottariId, member);
         final TeamMember teamMember = getTeamMemberByTeamBottariIdAndSsaid(teamBottariId, ssaid);
 
@@ -132,8 +124,7 @@ public class TeamItemFacade {
             final String ssaid
     ) {
         validateTeamBottari(teamBottariId);
-        final Member member = memberRepository.findBySsaid(ssaid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        final Member member = getMemberBySsaid(ssaid);
         validateMemberInTeam(teamBottariId, member);
         final List<TeamItemStatusResponse> sharedItemResponses = teamSharedItemService.getAllWithMemberStatusByTeamBottariId(
                 teamBottariId);
@@ -190,6 +181,16 @@ public class TeamItemFacade {
             case PERSONAL -> throw new BusinessException(
                     ErrorCode.TEAM_BOTTARI_ITEM_INAPPROPRIATE_TYPE, "보채기 알람은 공통/담당 물품만 가능합니다.");
         }
+    }
+
+    private TeamBottari getTeamBottariById(final Long teamBottariId) {
+        return teamBottariRepository.findById(teamBottariId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND));
+    }
+
+    private Member getMemberBySsaid(final String ssaid) {
+        return memberRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
     }
 
     private TeamMember getTeamMemberByTeamBottariIdAndSsaid(

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamItemFacade.java
@@ -8,6 +8,7 @@ import com.bottari.teambottari.domain.TeamBottari;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadAssignedItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
@@ -43,6 +44,19 @@ public class TeamItemFacade {
         validateMemberInTeam(teamBottari.getId(), member);
 
         return teamSharedItemService.getAllByTeamBottariId(teamBottariId);
+    }
+
+    public List<ReadAssignedItemResponse> getAssignedItems(
+            final Long teamBottariId,
+            final String ssaid
+    ) {
+        final TeamBottari teamBottari = teamBottariRepository.findById(teamBottariId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_NOT_FOUND, "존재하지 않는 팀 보따리입니다."));
+        final Member member = memberRepository.findBySsaid(ssaid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
+        validateMemberInTeam(teamBottari.getId(), member);
+
+        return teamAssignedItemService.getAllByTeamBottariId(teamBottariId);
     }
 
     @Transactional

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamPersonalItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamPersonalItemService.java
@@ -5,6 +5,7 @@ import com.bottari.error.ErrorCode;
 import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamPersonalItem;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadPersonalItemResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
 import com.bottari.teambottari.repository.TeamPersonalItemRepository;
 import java.util.List;
@@ -17,6 +18,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class TeamPersonalItemService {
 
     private final TeamPersonalItemRepository teamPersonalItemRepository;
+
+    public List<ReadPersonalItemResponse> getAllByTeamBottariId(
+            final Long teamBottariId,
+            final Long memberId
+    ) {
+        final List<TeamPersonalItem> items = teamPersonalItemRepository.findAllByTeamBottariIdAndMemberId(
+                teamBottariId,
+                memberId
+        );
+
+        return items.stream()
+                .map(ReadPersonalItemResponse::from)
+                .toList();
+    }
 
     @Transactional
     public Long create(

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamSharedItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamSharedItemService.java
@@ -13,6 +13,7 @@ import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamSharedItem;
 import com.bottari.teambottari.domain.TeamSharedItemInfo;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
 import com.bottari.teambottari.repository.TeamMemberRepository;
@@ -36,6 +37,16 @@ public class TeamSharedItemService {
     private final TeamSharedItemInfoRepository teamSharedItemInfoRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
+
+    public List<ReadSharedItemResponse> getAllByTeamBottariId(final Long teamBottariId) {
+        final List<TeamSharedItemInfo> sharedItemInfos = teamSharedItemInfoRepository.findAllByTeamBottariId(
+                teamBottariId
+        );
+
+        return sharedItemInfos.stream()
+                .map(ReadSharedItemResponse::from)
+                .toList();
+    }
 
     @Transactional
     public Long create(

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
@@ -15,6 +15,7 @@ import com.bottari.log.LogFormatter;
 import com.bottari.teambottari.domain.TeamItemType;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse.MemberCheckStatusResponse;
@@ -27,7 +28,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -48,6 +48,28 @@ class TeamBottariItemControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @DisplayName("팀 보따리 공통 물품을 성공적으로 조회한다.")
+    @Test
+    void readSharedItems() throws Exception {
+        // given
+        final Long teamBottariId = 1L;
+        final String ssaid = "test-ssaid";
+
+        final List<ReadSharedItemResponse> responses = List.of(
+                new ReadSharedItemResponse(1L, "공통 물품1"),
+                new ReadSharedItemResponse(2L, "공통 물품2")
+        );
+
+        given(teamItemFacade.getSharedItems(teamBottariId, ssaid))
+                .willReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/team-bottaries/{teamBottariId}/shared-items", teamBottariId)
+                        .header("ssaid", ssaid))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(responses)));
+    }
 
     @DisplayName("팀 보따리 공통 물품을 성공적으로 생성한다.")
     @Test

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
@@ -15,6 +15,7 @@ import com.bottari.log.LogFormatter;
 import com.bottari.teambottari.domain.TeamItemType;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadAssignedItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
@@ -66,6 +67,42 @@ class TeamBottariItemControllerTest {
 
         // when & then
         mockMvc.perform(get("/team-bottaries/{teamBottariId}/shared-items", teamBottariId)
+                        .header("ssaid", ssaid))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(responses)));
+    }
+
+    @DisplayName("팀 보따리 담당 물품을 성공적으로 조회한다.")
+    @Test
+    void readAssignedItems() throws Exception {
+        // given
+        final Long teamBottariId = 1L;
+        final String ssaid = "test-ssaid";
+
+        final List<ReadAssignedItemResponse> responses = List.of(
+                new ReadAssignedItemResponse(
+                        1L,
+                        "담당 물품1",
+                        List.of(
+                                new ReadAssignedItemResponse.Assignee(1L, "다이스"),
+                                new ReadAssignedItemResponse.Assignee(2L, "방벨로")
+                        )
+                ),
+                new ReadAssignedItemResponse(
+                        2L,
+                        "담당 물품2",
+                        List.of(
+                                new ReadAssignedItemResponse.Assignee(1L, "이오이"),
+                                new ReadAssignedItemResponse.Assignee(2L, "방벨로")
+                        )
+                )
+        );
+
+        given(teamItemFacade.getAssignedItems(teamBottariId, ssaid))
+                .willReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/team-bottaries/{teamBottariId}/assigned-items", teamBottariId)
                         .header("ssaid", ssaid))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(responses)));

--- a/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/controller/TeamBottariItemControllerTest.java
@@ -16,6 +16,7 @@ import com.bottari.teambottari.domain.TeamItemType;
 import com.bottari.teambottari.dto.CreateTeamAssignedItemRequest;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
 import com.bottari.teambottari.dto.ReadAssignedItemResponse;
+import com.bottari.teambottari.dto.ReadPersonalItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.ReadTeamItemStatusResponse;
 import com.bottari.teambottari.dto.TeamItemStatusResponse;
@@ -103,6 +104,28 @@ class TeamBottariItemControllerTest {
 
         // when & then
         mockMvc.perform(get("/team-bottaries/{teamBottariId}/assigned-items", teamBottariId)
+                        .header("ssaid", ssaid))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(responses)));
+    }
+
+    @DisplayName("팀 보따리 개인 물품을 성공적으로 조회한다.")
+    @Test
+    void readPersonalItems() throws Exception {
+        // given
+        final Long teamBottariId = 1L;
+        final String ssaid = "test-ssaid";
+
+        final List<ReadPersonalItemResponse> responses = List.of(
+                new ReadPersonalItemResponse(1L, "개인 물품1"),
+                new ReadPersonalItemResponse(2L, "개인 물품2")
+        );
+
+        given(teamItemFacade.getPersonalItems(teamBottariId, ssaid))
+                .willReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/team-bottaries/{teamBottariId}/personal-items", teamBottariId)
                         .header("ssaid", ssaid))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(responses)));

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
@@ -154,7 +154,7 @@ public class TeamItemFacadeTest {
             // when & then
             assertThatThrownBy(() -> teamItemFacade.getSharedItems(invalid_teamBottariId, ssaid))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage("팀 보따리를 찾을 수 없습니다. - 존재하지 않는 팀 보따리입니다.");
+                    .hasMessage("팀 보따리를 찾을 수 없습니다.");
         }
 
         @DisplayName("공통 물품을 조회할 때, 가입되지 않은 멤버의 ssaid를 입력하면 예외를 던진다.")
@@ -263,7 +263,7 @@ public class TeamItemFacadeTest {
             // when & then
             assertThatThrownBy(() -> teamItemFacade.getAssignedItems(invalid_teamBottariId, ssaid))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage("팀 보따리를 찾을 수 없습니다. - 존재하지 않는 팀 보따리입니다.");
+                    .hasMessage("팀 보따리를 찾을 수 없습니다.");
         }
 
         @DisplayName("담당 물품을 조회할 때, 가입되지 않은 멤버의 ssaid를 입력하면 예외를 던진다.")
@@ -361,7 +361,7 @@ public class TeamItemFacadeTest {
             // when & then
             assertThatThrownBy(() -> teamItemFacade.getPersonalItems(invalid_teamBottariId, ssaid))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage("팀 보따리를 찾을 수 없습니다. - 존재하지 않는 팀 보따리입니다.");
+                    .hasMessage("팀 보따리를 찾을 수 없습니다.");
         }
 
         @DisplayName("개인 물품을 조회할 때, 가입되지 않은 멤버의 ssaid를 입력하면 예외를 던진다.")

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
@@ -21,6 +21,7 @@ import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamSharedItem;
 import com.bottari.teambottari.domain.TeamSharedItemInfo;
 import com.bottari.teambottari.dto.CreateTeamItemRequest;
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -48,6 +49,44 @@ class TeamSharedItemServiceTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Nested
+    class GetAllByTeamBottariIdTest {
+
+        @DisplayName("팀 보따리 ID로 팀 보따리 공통 물품을 조회한다.")
+        @Test
+        void getAllByTeamBottariId() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final TeamSharedItemInfo teamSharedItemInfo = new TeamSharedItemInfo("공통 물품", teamBottari);
+            entityManager.persist(teamSharedItemInfo);
+
+            final TeamSharedItem teamSharedItem = new TeamSharedItem(teamSharedItemInfo, teamMember);
+            entityManager.persist(teamSharedItem);
+
+            // when
+            final List<ReadSharedItemResponse> actual = teamSharedItemService.getAllByTeamBottariId(teamBottari.getId());
+
+            // then
+            final List<ReadSharedItemResponse> expected = List.of(
+                    new ReadSharedItemResponse(
+                            teamSharedItemInfo.getId(),
+                            teamSharedItemInfo.getName()
+                    )
+            );
+            assertAll(
+                    () -> assertThat(actual).hasSize(1),
+                    () -> assertThat(actual).isEqualTo(expected)
+            );
+        }
+    }
 
     @Nested
     class CreateTest {


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 물품 타입별 조회 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #382 
- Closed #383 
- Closed #384 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->

- 팀 보따리 물품 타입별 조회 기능 구현
  - 공통: 팀의 공통 물품 조회 `GET /team-bottaries/{teamBottariId}/shared-items`
  - 담당: 팀의 담당 물품 및 해당 물품의 담당자 목록 조회 `GET /team-bottaries/{teamBottariId}/assigned-items`
  - 개인: 팀 보따리에 추가해둔 개인적 물품 조회 `GET /team-bottaries/{teamBottariId}/personal-items`

<img width="208" height="22" alt="image" src="https://github.com/user-attachments/assets/9a00cced-9628-456e-b68a-d06fc9e4442e" />

- 테스트 결과

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
