### PR TITLE
[AN] 팀 보따리 공통 물품 수정 화면 구현

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
@@ -10,6 +10,7 @@ import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseFragment
 import com.bottari.presentation.common.extension.showSnackbar
 import com.bottari.presentation.databinding.FragmentTeamPersonalItemEditBinding
+import com.bottari.presentation.model.BottariItemTypeUiModel
 import com.bottari.presentation.view.edit.team.item.main.TeamItemEditUiEvent
 import com.bottari.presentation.view.edit.team.item.main.TeamItemEditUiState
 import com.bottari.presentation.view.edit.team.item.main.TeamItemEditViewModel
@@ -54,6 +55,7 @@ class TeamPersonalItemEditFragment :
     }
 
     private fun handleParentUiState(uiState: TeamItemEditUiState) {
+        if (uiState.currentTabType != BottariItemTypeUiModel.PERSONAL) return
         viewModel.updateInput(uiState.itemInputText)
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditEvent.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditEvent.kt
@@ -1,0 +1,9 @@
+package com.bottari.presentation.view.edit.team.item.shared
+
+sealed interface TeamSharedItemEditEvent {
+    data object FetchTeamPersonalItemsFailure : TeamSharedItemEditEvent
+
+    data object DeleteItemFailure : TeamSharedItemEditEvent
+
+    data object AddItemFailure : TeamSharedItemEditEvent
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
@@ -1,10 +1,81 @@
 package com.bottari.presentation.view.edit.team.item.shared
 
+import android.os.Bundle
+import android.view.View
 import androidx.core.os.bundleOf
-import androidx.fragment.app.Fragment
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.bottari.presentation.R
+import com.bottari.presentation.common.base.BaseFragment
+import com.bottari.presentation.common.extension.showSnackbar
+import com.bottari.presentation.databinding.FragmentTeamSharedItemEditBinding
+import com.bottari.presentation.view.edit.team.item.main.TeamItemEditUiEvent
+import com.bottari.presentation.view.edit.team.item.main.TeamItemEditUiState
+import com.bottari.presentation.view.edit.team.item.main.TeamItemEditViewModel
+import com.bottari.presentation.view.edit.team.item.shared.adapter.TeamSharedItemEditAdapter
 
-class TeamSharedItemEditFragment : Fragment() {
-    private val bottariId: Long by lazy { requireArguments().getLong(ARG_BOTTARI_ID) }
+class TeamSharedItemEditFragment :
+    BaseFragment<FragmentTeamSharedItemEditBinding>(FragmentTeamSharedItemEditBinding::inflate),
+    TeamSharedItemEditAdapter.TeamSharedItemEditEventListener {
+    private val parentViewModel: TeamItemEditViewModel by viewModels(
+        ownerProducer = { requireParentFragment() },
+    )
+    private val viewModel: TeamSharedItemEditViewModel by viewModels {
+        TeamSharedItemEditViewModel.Factory(
+            requireArguments().getLong(ARG_BOTTARI_ID),
+        )
+    }
+    private val adapter: TeamSharedItemEditAdapter by lazy { TeamSharedItemEditAdapter(this) }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObserver()
+        setupUI()
+    }
+
+    override fun onClickDelete(itemId: Long) {
+        viewModel.deleteItem(itemId)
+    }
+
+    private fun setupObserver() {
+        parentViewModel.uiEvent.observe(viewLifecycleOwner, ::handleParentUiEvent)
+        parentViewModel.uiState.observe(viewLifecycleOwner, ::handleParentUiState)
+        viewModel.uiState.observe(viewLifecycleOwner, ::handleUiState)
+        viewModel.uiEvent.observe(viewLifecycleOwner, ::handleUiEvent)
+    }
+
+    private fun setupUI() {
+        binding.rvTeamSharedItemEdit.adapter = adapter
+        binding.rvTeamSharedItemEdit.layoutManager = LinearLayoutManager(requireContext())
+    }
+
+    private fun handleParentUiState(uiState: TeamItemEditUiState) {
+        viewModel.updateInput(uiState.itemInputText)
+    }
+
+    private fun handleParentUiEvent(uiEvent: TeamItemEditUiEvent) {
+        if (uiEvent !is TeamItemEditUiEvent.CreateTeamSharedItem) return
+        viewModel.createItem()
+    }
+
+    private fun handleUiState(uiState: TeamSharedItemEditUiState) {
+        toggleLoadingIndicator(uiState.isLoading)
+        parentViewModel.updateIsAlreadyExistState(uiState.isAlreadyExist)
+        binding.emptyView.root.isVisible = uiState.isEmpty
+        adapter.submitList(uiState.personalItems)
+    }
+
+    private fun handleUiEvent(uiEvent: TeamSharedItemEditEvent) {
+        when (uiEvent) {
+            TeamSharedItemEditEvent.FetchTeamPersonalItemsFailure -> requireView().showSnackbar(R.string.common_fetch_failure_text)
+            TeamSharedItemEditEvent.AddItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
+            TeamSharedItemEditEvent.DeleteItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
+        }
+    }
 
     companion object {
         private const val ARG_BOTTARI_ID = "ARG_BOTTARI_ID"

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
@@ -10,6 +10,7 @@ import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseFragment
 import com.bottari.presentation.common.extension.showSnackbar
 import com.bottari.presentation.databinding.FragmentTeamSharedItemEditBinding
+import com.bottari.presentation.model.BottariItemTypeUiModel
 import com.bottari.presentation.view.edit.team.item.main.TeamItemEditUiEvent
 import com.bottari.presentation.view.edit.team.item.main.TeamItemEditUiState
 import com.bottari.presentation.view.edit.team.item.main.TeamItemEditViewModel
@@ -54,6 +55,7 @@ class TeamSharedItemEditFragment :
     }
 
     private fun handleParentUiState(uiState: TeamItemEditUiState) {
+        if (uiState.currentTabType != BottariItemTypeUiModel.SHARED) return
         viewModel.updateInput(uiState.itemInputText)
     }
 
@@ -66,7 +68,7 @@ class TeamSharedItemEditFragment :
         toggleLoadingIndicator(uiState.isLoading)
         parentViewModel.updateIsAlreadyExistState(uiState.isAlreadyExist)
         binding.emptyView.root.isVisible = uiState.isEmpty
-        adapter.submitList(uiState.personalItems)
+        adapter.submitList(uiState.sharedItems)
     }
 
     private fun handleUiEvent(uiEvent: TeamSharedItemEditEvent) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditUiState.kt
@@ -1,0 +1,13 @@
+package com.bottari.presentation.view.edit.team.item.shared
+
+import com.bottari.presentation.model.BottariItemUiModel
+
+data class TeamSharedItemEditUiState(
+    val isLoading: Boolean = false,
+    val isFetched: Boolean = false,
+    val personalItems: List<BottariItemUiModel> = emptyList(),
+    val inputText: String = "",
+) {
+    val isEmpty: Boolean = isFetched && personalItems.isEmpty()
+    val isAlreadyExist: Boolean = personalItems.any { it.name == inputText }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditUiState.kt
@@ -5,9 +5,9 @@ import com.bottari.presentation.model.BottariItemUiModel
 data class TeamSharedItemEditUiState(
     val isLoading: Boolean = false,
     val isFetched: Boolean = false,
-    val personalItems: List<BottariItemUiModel> = emptyList(),
+    val sharedItems: List<BottariItemUiModel> = emptyList(),
     val inputText: String = "",
 ) {
-    val isEmpty: Boolean = isFetched && personalItems.isEmpty()
-    val isAlreadyExist: Boolean = personalItems.any { it.name == inputText }
+    val isEmpty: Boolean = isFetched && sharedItems.isEmpty()
+    val isAlreadyExist: Boolean = sharedItems.any { it.name == inputText }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
@@ -1,0 +1,87 @@
+package com.bottari.presentation.view.edit.team.item.shared
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.bottari.di.UseCaseProvider
+import com.bottari.domain.model.bottari.BottariItemType
+import com.bottari.domain.usecase.team.CreateTeamSharedItemUseCase
+import com.bottari.domain.usecase.team.DeleteTeamBottariItemUseCase
+import com.bottari.domain.usecase.team.FetchTeamSharedItemsUseCase
+import com.bottari.presentation.common.base.BaseViewModel
+import com.bottari.presentation.mapper.TeamBottariMapper.toUiModel
+
+class TeamSharedItemEditViewModel(
+    stateHandle: SavedStateHandle,
+    private val fetchTeamSharedItemsUseCase: FetchTeamSharedItemsUseCase,
+    private val createTeamSharedItemUseCase: CreateTeamSharedItemUseCase,
+    private val deleteTeamBottariItemUseCase: DeleteTeamBottariItemUseCase,
+) : BaseViewModel<TeamSharedItemEditUiState, TeamSharedItemEditEvent>(
+        TeamSharedItemEditUiState(),
+    ) {
+    private val bottariId: Long = stateHandle[KEY_BOTTARI_ID] ?: error(ERROR_BOTTARI_ID)
+
+    init {
+        fetchPersonalItems()
+    }
+
+    fun updateInput(input: String) = updateState { copy(inputText = input) }
+
+    fun createItem() {
+        if (currentState.isAlreadyExist) return
+        updateState { copy(isLoading = true) }
+
+        launch {
+            createTeamSharedItemUseCase(bottariId, currentState.inputText)
+                .onSuccess { fetchPersonalItems() }
+                .onFailure { emitEvent(TeamSharedItemEditEvent.AddItemFailure) }
+
+            updateState { copy(isLoading = false) }
+        }
+    }
+
+    fun deleteItem(itemId: Long) {
+        updateState { copy(isLoading = true) }
+
+        launch {
+            deleteTeamBottariItemUseCase(itemId, BottariItemType.SHARED)
+                .onSuccess { fetchPersonalItems() }
+                .onFailure { emitEvent(TeamSharedItemEditEvent.DeleteItemFailure) }
+
+            updateState { copy(isLoading = false) }
+        }
+    }
+
+    private fun fetchPersonalItems() {
+        updateState { copy(isLoading = true) }
+
+        launch {
+            fetchTeamSharedItemsUseCase(bottariId)
+                .onSuccess { items -> updateState { copy(personalItems = items.map { it.toUiModel() }) } }
+                .onFailure { emitEvent(TeamSharedItemEditEvent.FetchTeamPersonalItemsFailure) }
+
+            updateState { copy(isLoading = false, isFetched = true) }
+        }
+    }
+
+    companion object {
+        private const val KEY_BOTTARI_ID = "KEY_BOTTARI_ID"
+        private const val ERROR_BOTTARI_ID = "[ERROR] bottariId가 존재하지 않습니다"
+
+        fun Factory(bottariId: Long): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    val stateHandle = createSavedStateHandle()
+                    stateHandle[KEY_BOTTARI_ID] = bottariId
+                    TeamSharedItemEditViewModel(
+                        stateHandle,
+                        UseCaseProvider.fetchTeamSharedItemsUseCase,
+                        UseCaseProvider.createTeamSharedItemUseCase,
+                        UseCaseProvider.deleteTeamBottariItemUseCase,
+                    )
+                }
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
@@ -59,7 +59,7 @@ class TeamSharedItemEditViewModel(
 
         launch {
             fetchTeamSharedItemsUseCase(bottariId)
-                .onSuccess { items -> updateState { copy(personalItems = items.map { it.toUiModel() }) } }
+                .onSuccess { items -> updateState { copy(sharedItems = items.map { it.toUiModel() }) } }
                 .onFailure { emitEvent(TeamSharedItemEditEvent.FetchTeamPersonalItemsFailure) }
 
             updateState { copy(isLoading = false, isFetched = true) }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/adapter/TeamSharedItemEditAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/adapter/TeamSharedItemEditAdapter.kt
@@ -1,0 +1,37 @@
+package com.bottari.presentation.view.edit.team.item.shared.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.bottari.presentation.model.BottariItemUiModel
+
+class TeamSharedItemEditAdapter(
+    private val eventListener: TeamSharedItemEditEventListener,
+) : ListAdapter<BottariItemUiModel, TeamSharedItemEditViewHolder>(DiffUtil) {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): TeamSharedItemEditViewHolder = TeamSharedItemEditViewHolder.from(parent, eventListener)
+
+    override fun onBindViewHolder(
+        holder: TeamSharedItemEditViewHolder,
+        position: Int,
+    ) = holder.bind(getItem(position))
+
+    interface TeamSharedItemEditEventListener : TeamSharedItemEditViewHolder.OnEditItemClickListener
+
+    companion object {
+        private val DiffUtil =
+            object : DiffUtil.ItemCallback<BottariItemUiModel>() {
+                override fun areContentsTheSame(
+                    oldItem: BottariItemUiModel,
+                    newItem: BottariItemUiModel,
+                ): Boolean = oldItem == newItem
+
+                override fun areItemsTheSame(
+                    oldItem: BottariItemUiModel,
+                    newItem: BottariItemUiModel,
+                ): Boolean = oldItem.id == newItem.id
+            }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/adapter/TeamSharedItemEditViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/adapter/TeamSharedItemEditViewHolder.kt
@@ -1,0 +1,40 @@
+package com.bottari.presentation.view.edit.team.item.shared.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bottari.presentation.databinding.ItemEditPersonalItemBinding
+import com.bottari.presentation.model.BottariItemUiModel
+
+class TeamSharedItemEditViewHolder(
+    private val binding: ItemEditPersonalItemBinding,
+    eventListener: OnEditItemClickListener,
+) : RecyclerView.ViewHolder(binding.root) {
+    private var itemId: Long? = null
+
+    init {
+        binding.btnPersonalItemDelete.setOnClickListener {
+            itemId?.let(eventListener::onClickDelete)
+        }
+    }
+
+    fun bind(item: BottariItemUiModel) {
+        itemId = item.id
+        binding.tvPersonalItemName.text = item.name
+    }
+
+    interface OnEditItemClickListener {
+        fun onClickDelete(itemId: Long)
+    }
+
+    companion object {
+        fun from(
+            parent: ViewGroup,
+            eventListener: OnEditItemClickListener,
+        ): TeamSharedItemEditViewHolder {
+            val layoutInflater = LayoutInflater.from(parent.context)
+            val binding = ItemEditPersonalItemBinding.inflate(layoutInflater, parent, false)
+            return TeamSharedItemEditViewHolder(binding, eventListener)
+        }
+    }
+}

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_shared_item_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_shared_item_edit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_team_shared_item_edit"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fadingEdgeLength="8dp"
+        android:requiresFadingEdge="vertical"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:listitem="@layout/item_edit_personal_item" />
+
+    <include
+        android:id="@+id/empty_view"
+        layout="@layout/view_bottari_item_empty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/rv_team_shared_item_edit"
+        app:layout_constraintTop_toTopOf="@id/rv_team_shared_item_edit" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 공유 물품 수정 화면을 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #368 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
--> 

- 팀 공유 물품 수정 화면을 구현
- 현재 보고 있는 타입에서만 중복 체크를 진행하도록 수정

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->

[Screen_recording_20250817_212139.webm](https://github.com/user-attachments/assets/49b995e9-5bd6-4b39-8081-f8e12f315cb5)


<br>
