### PR TITLE
[AN] 팀 보따리 담당 물건 수정 기능 구현

### DIFF
--- a/android/Bottari/data/src/main/java/com/bottari/data/model/team/SaveTeamBottariAssignedItemRequest.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/team/SaveTeamBottariAssignedItemRequest.kt
@@ -1,0 +1,12 @@
+package com.bottari.data.model.team
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SaveTeamBottariAssignedItemRequest(
+    @SerialName("name")
+    val name: String,
+    @SerialName("assigneeIds")
+    val assigneeIds: List<Long>,
+)

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/TeamBottariRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/TeamBottariRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.bottari.data.model.team.CreateTeamBottariSharedItemRequest
 import com.bottari.data.model.team.DeleteTeamBottariItemRequest
 import com.bottari.data.model.team.ItemTypeRequest
 import com.bottari.data.model.team.JoinTeamBottariRequest
+import com.bottari.data.model.team.SaveTeamBottariAssignedItemRequest
 import com.bottari.data.source.remote.TeamBottariRemoteDataSource
 import com.bottari.domain.model.bottari.BottariItem
 import com.bottari.domain.model.bottari.BottariItemType
@@ -147,4 +148,16 @@ class TeamBottariRepositoryImpl(
         teamBottariRemoteDataSource
             .fetchTeamPersonalItems(teamBottariId)
             .mapCatching { personalItems -> personalItems.map { personalItem -> personalItem.toDomain() } }
+
+    override suspend fun saveTeamBottariAssignedItem(
+        teamBottariId: Long,
+        assignedItemId: Long,
+        name: String,
+        assigneeIds: List<Long>,
+    ): Result<Unit> =
+        teamBottariRemoteDataSource.saveTeamBottariAssignedItem(
+            teamBottariId,
+            assignedItemId,
+            SaveTeamBottariAssignedItemRequest(name, assigneeIds),
+        )
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/service/TeamBottariService.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/service/TeamBottariService.kt
@@ -14,6 +14,7 @@ import com.bottari.data.model.team.FetchTeamMemberStatusResponse
 import com.bottari.data.model.team.FetchTeamMembersResponse
 import com.bottari.data.model.team.ItemTypeRequest
 import com.bottari.data.model.team.JoinTeamBottariRequest
+import com.bottari.data.model.team.SaveTeamBottariAssignedItemRequest
 import com.bottari.data.model.teamItem.FetchTeamAssignedItemResponse
 import com.bottari.data.model.teamItem.FetchTeamPersonalItemResponse
 import com.bottari.data.model.teamItem.FetchTeamSharedItemResponse
@@ -23,6 +24,7 @@ import retrofit2.http.GET
 import retrofit2.http.HTTP
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface TeamBottariService {
@@ -131,4 +133,11 @@ interface TeamBottariService {
     suspend fun fetchTeamPersonalItems(
         @Path("teamBottariId") teamBottariId: Long,
     ): Response<List<FetchTeamPersonalItemResponse>>
+
+    @PUT("/team-bottaries/{teamBottariId}/assigned-items/{assignedItemId}")
+    suspend fun saveTeamAssignedItem(
+        @Path("teamBottariId") teamBottariId: Long,
+        @Path("assignedItemId") assignedItemId: Long,
+        @Body request: SaveTeamBottariAssignedItemRequest,
+    ): Response<Unit>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSource.kt
@@ -14,6 +14,7 @@ import com.bottari.data.model.team.FetchTeamMemberStatusResponse
 import com.bottari.data.model.team.FetchTeamMembersResponse
 import com.bottari.data.model.team.ItemTypeRequest
 import com.bottari.data.model.team.JoinTeamBottariRequest
+import com.bottari.data.model.team.SaveTeamBottariAssignedItemRequest
 import com.bottari.data.model.teamItem.FetchTeamAssignedItemResponse
 import com.bottari.data.model.teamItem.FetchTeamPersonalItemResponse
 import com.bottari.data.model.teamItem.FetchTeamSharedItemResponse
@@ -82,4 +83,10 @@ interface TeamBottariRemoteDataSource {
     suspend fun fetchTeamSharedItems(teamBottariId: Long): Result<List<FetchTeamSharedItemResponse>>
 
     suspend fun fetchTeamPersonalItems(teamBottariId: Long): Result<List<FetchTeamPersonalItemResponse>>
+
+    suspend fun saveTeamBottariAssignedItem(
+        teamBottariId: Long,
+        assignedItemId: Long,
+        request: SaveTeamBottariAssignedItemRequest,
+    ): Result<Unit>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/remote/TeamBottariRemoteDataSourceImpl.kt
@@ -17,6 +17,7 @@ import com.bottari.data.model.team.FetchTeamMemberStatusResponse
 import com.bottari.data.model.team.FetchTeamMembersResponse
 import com.bottari.data.model.team.ItemTypeRequest
 import com.bottari.data.model.team.JoinTeamBottariRequest
+import com.bottari.data.model.team.SaveTeamBottariAssignedItemRequest
 import com.bottari.data.model.teamItem.FetchTeamAssignedItemResponse
 import com.bottari.data.model.teamItem.FetchTeamPersonalItemResponse
 import com.bottari.data.model.teamItem.FetchTeamSharedItemResponse
@@ -137,6 +138,15 @@ class TeamBottariRemoteDataSourceImpl(
 
     override suspend fun fetchTeamPersonalItems(teamBottariId: Long): Result<List<FetchTeamPersonalItemResponse>> =
         safeApiCall { teamBottariService.fetchTeamPersonalItems(teamBottariId) }
+
+    override suspend fun saveTeamBottariAssignedItem(
+        teamBottariId: Long,
+        assignedItemId: Long,
+        request: SaveTeamBottariAssignedItemRequest,
+    ): Result<Unit> =
+        safeApiCall {
+            teamBottariService.saveTeamAssignedItem(teamBottariId, assignedItemId, request)
+        }
 
     companion object {
         private const val HEADER_TEAM_BOTTARI_ID_PREFIX = "/team-bottaries/"

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/TeamBottariRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/TeamBottariRepositoryImplTest.kt
@@ -16,6 +16,7 @@ import com.bottari.data.testFixture.BOTTARI_PERSONAL_ITEM_FIXTURE
 import com.bottari.data.testFixture.BOTTARI_PERSONAL_ITEM_RESPONSE_FIXTURE
 import com.bottari.data.testFixture.BOTTARI_SHARED_ITEM_FIXTURE
 import com.bottari.data.testFixture.BOTTARI_SHARED_ITEM_RESPONSE_FIXTURE
+import com.bottari.data.testFixture.SAVE_TEAM_BOTTARI_ASSIGNED_ITEM_REQUEST_FIXTURE
 import com.bottari.data.testFixture.TEAM_BOTTARI
 import com.bottari.data.testFixture.TEAM_BOTTARI_DETAIL
 import com.bottari.data.testFixture.TEAM_BOTTARI_DETAIL_RESPONSE
@@ -794,7 +795,10 @@ class TeamBottariRepositoryImplTest {
             // given
             val teamBottariId = 1L
             val assignedItems = listOf(BOTTARI_ASSIGNED_ITEM_RESPONSE_FIXTURE)
-            coEvery { dataSource.fetchTeamAssignedItems(teamBottariId) } returns Result.success(assignedItems)
+            coEvery { dataSource.fetchTeamAssignedItems(teamBottariId) } returns
+                Result.success(
+                    assignedItems,
+                )
 
             // when
             val result = repository.fetchTeamAssignedItems(teamBottariId)
@@ -816,7 +820,10 @@ class TeamBottariRepositoryImplTest {
             // given
             val teamBottariId = 1L
             val exception = HttpException(Response.error<Unit>(400, errorResponseBody))
-            coEvery { dataSource.fetchTeamAssignedItems(teamBottariId) } returns Result.failure(exception)
+            coEvery { dataSource.fetchTeamAssignedItems(teamBottariId) } returns
+                Result.failure(
+                    exception,
+                )
 
             // when
             val result = repository.fetchTeamAssignedItems(teamBottariId)
@@ -826,6 +833,76 @@ class TeamBottariRepositoryImplTest {
 
             // verify
             coVerify(exactly = 1) { dataSource.fetchTeamAssignedItems(teamBottariId) }
+        }
+
+    @DisplayName("팀 보따리 담당 물건 수정에 성공하면 Success를 반환한다")
+    @Test
+    fun saveTeamBottariAssignedItemReturnsSuccessTest() =
+        runTest {
+            // given
+            val teamBottariId = 1L
+            val itemId = 1L
+            val newName = "new name"
+
+            coEvery {
+                dataSource.saveTeamBottariAssignedItem(
+                    teamBottariId,
+                    itemId,
+                    SAVE_TEAM_BOTTARI_ASSIGNED_ITEM_REQUEST_FIXTURE,
+                )
+            } returns Result.success(Unit)
+
+            // when
+            val result =
+                repository.saveTeamBottariAssignedItem(teamBottariId, itemId, newName, listOf(1L, 2L))
+
+            // then
+            result.shouldBeSuccess()
+
+            // verify
+            coVerify(exactly = 1) {
+                dataSource.saveTeamBottariAssignedItem(
+                    teamBottariId,
+                    itemId,
+                    SAVE_TEAM_BOTTARI_ASSIGNED_ITEM_REQUEST_FIXTURE,
+                )
+            }
+        }
+
+    @DisplayName("팀 보따리 담당 물건 수정에 실패하면 Failure를 반환한다")
+    @Test
+    fun saveTeamBottariAssignedItemReturnsFailureTest() =
+        runTest {
+            // given
+            val teamBottariId = 1L
+            val itemId = 1L
+            val newName = "new name"
+
+            val exception = HttpException(Response.error<Unit>(400, errorResponseBody))
+
+            coEvery {
+                dataSource.saveTeamBottariAssignedItem(
+                    teamBottariId,
+                    itemId,
+                    SAVE_TEAM_BOTTARI_ASSIGNED_ITEM_REQUEST_FIXTURE,
+                )
+            } returns Result.failure(exception)
+
+            // when
+            val result =
+                repository.saveTeamBottariAssignedItem(teamBottariId, itemId, newName, listOf(1L, 2L))
+
+            // then
+            result.shouldBeFailure { error -> error shouldBe exception }
+
+            // verify
+            coVerify(exactly = 1) {
+                dataSource.saveTeamBottariAssignedItem(
+                    teamBottariId,
+                    itemId,
+                    SAVE_TEAM_BOTTARI_ASSIGNED_ITEM_REQUEST_FIXTURE,
+                )
+            }
         }
 
     @DisplayName("팀 보따리 물건 체크에 성공하면 Success를 반환한다")

--- a/android/Bottari/data/src/test/java/com/bottari/data/testFixture/BottariFixture.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/testFixture/BottariFixture.kt
@@ -4,6 +4,7 @@ import com.bottari.data.model.bottari.AlarmResponse
 import com.bottari.data.model.bottari.BottariResponse
 import com.bottari.data.model.bottari.FetchBottariesResponse
 import com.bottari.data.model.bottari.RoutineResponse
+import com.bottari.data.model.team.SaveTeamBottariAssignedItemRequest
 import com.bottari.data.model.teamItem.FetchTeamAssignedItemResponse
 import com.bottari.data.model.teamItem.FetchTeamPersonalItemResponse
 import com.bottari.data.model.teamItem.FetchTeamSharedItemResponse
@@ -106,4 +107,10 @@ val BOTTARI_ASSIGNED_ITEM_FIXTURE =
                 TeamMember(2L, "member 2"),
             ),
         ),
+    )
+
+val SAVE_TEAM_BOTTARI_ASSIGNED_ITEM_REQUEST_FIXTURE =
+    SaveTeamBottariAssignedItemRequest(
+        name = "new name",
+        assigneeIds = listOf(1L, 2L),
     )

--- a/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
@@ -40,6 +40,7 @@ import com.bottari.domain.usecase.team.FetchTeamPersonalItemsUseCase
 import com.bottari.domain.usecase.team.FetchTeamSharedItemsUseCase
 import com.bottari.domain.usecase.team.FetchTeamStatusUseCase
 import com.bottari.domain.usecase.team.JoinTeamBottariUseCase
+import com.bottari.domain.usecase.team.SaveTeamBottariAssignedItemUseCase
 import com.bottari.domain.usecase.team.SendRemindByItemUseCase
 import com.bottari.domain.usecase.team.SendRemindByMemberMessageUseCase
 import com.bottari.domain.usecase.team.UnCheckTeamBottariItemUseCase
@@ -248,5 +249,8 @@ object UseCaseProvider {
     }
     val fetchTeamBottariMembersUseCase: FetchTeamBottariMembersUseCase by lazy {
         FetchTeamBottariMembersUseCase(RepositoryProvider.teamBottariRepository)
+    }
+    val saveTeamBottariAssignedItemUseCase: SaveTeamBottariAssignedItemUseCase by lazy {
+        SaveTeamBottariAssignedItemUseCase(RepositoryProvider.teamBottariRepository)
     }
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/TeamBottariRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/TeamBottariRepository.kt
@@ -75,4 +75,11 @@ interface TeamBottariRepository {
     suspend fun fetchTeamSharedItems(teamBottariId: Long): Result<List<BottariItem>>
 
     suspend fun fetchTeamPersonalItems(teamBottariId: Long): Result<List<BottariItem>>
+
+    suspend fun saveTeamBottariAssignedItem(
+        teamBottariId: Long,
+        assignedItemId: Long,
+        name: String,
+        assigneeIds: List<Long>,
+    ): Result<Unit>
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/SaveTeamBottariAssignedItemUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/team/SaveTeamBottariAssignedItemUseCase.kt
@@ -1,0 +1,20 @@
+package com.bottari.domain.usecase.team
+
+import com.bottari.domain.repository.TeamBottariRepository
+
+class SaveTeamBottariAssignedItemUseCase(
+    private val teamBottariRepository: TeamBottariRepository,
+) {
+    suspend operator fun invoke(
+        teamBottariId: Long,
+        assignedItemId: Long,
+        name: String,
+        assigneeIds: List<Long>,
+    ): Result<Unit> =
+        teamBottariRepository.saveTeamBottariAssignedItem(
+            teamBottariId,
+            assignedItemId,
+            name,
+            assigneeIds,
+        )
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/KeyboardExtension.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/KeyboardExtension.kt
@@ -16,7 +16,7 @@ fun Activity.showKeyboard(target: View) {
     if (target.requestFocus().not()) return
     try {
         WindowInsetsControllerCompat(window, target).show(WindowInsetsCompat.Type.ime())
-    } catch (_: Throwable) {
+    } catch (_: Exception) {
         imm().showSoftInput(target, InputMethodManager.SHOW_IMPLICIT)
     }
 }
@@ -26,7 +26,7 @@ fun Activity.hideKeyboard() {
     val current = currentFocus ?: findViewById(android.R.id.content) ?: return
     try {
         WindowInsetsControllerCompat(window, current).hide(WindowInsetsCompat.Type.ime())
-    } catch (_: Throwable) {
+    } catch (_: Exception) {
         imm().hideSoftInputFromWindow(current.windowToken, 0)
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/KeyboardExtension.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/KeyboardExtension.kt
@@ -1,0 +1,56 @@
+@file:JvmName("KeyboardExtension")
+
+package com.bottari.presentation.common.extension
+
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import androidx.annotation.MainThread
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.fragment.app.Fragment
+
+@MainThread
+fun Activity.showKeyboard(target: View) {
+    if (target.requestFocus().not()) return
+    try {
+        WindowInsetsControllerCompat(window, target).show(WindowInsetsCompat.Type.ime())
+    } catch (_: Throwable) {
+        imm().showSoftInput(target, InputMethodManager.SHOW_IMPLICIT)
+    }
+}
+
+@MainThread
+fun Activity.hideKeyboard() {
+    val current = currentFocus ?: findViewById(android.R.id.content) ?: return
+    try {
+        WindowInsetsControllerCompat(window, current).hide(WindowInsetsCompat.Type.ime())
+    } catch (_: Throwable) {
+        imm().hideSoftInputFromWindow(current.windowToken, 0)
+    }
+}
+
+@MainThread
+fun Fragment.showKeyboard(target: View) {
+    activity?.showKeyboard(target)
+}
+
+@MainThread
+fun Fragment.hideKeyboard() {
+    activity?.hideKeyboard()
+}
+
+@MainThread
+fun View.showKeyboardFallback() {
+    if (requestFocus().not()) return
+    context.imm().showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+}
+
+@MainThread
+fun View.hideKeyboardFallback(clearFocus: Boolean = false) {
+    if (clearFocus) clearFocus()
+    context.imm().hideSoftInputFromWindow(windowToken, 0)
+}
+
+private fun Context.imm(): InputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/BottariItemUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/BottariItemUiModel.kt
@@ -8,4 +8,5 @@ data class BottariItemUiModel(
     val id: Long,
     val name: String,
     val type: BottariItemTypeUiModel,
+    val isSelected: Boolean = false,
 ) : Parcelable

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditEvent.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditEvent.kt
@@ -8,4 +8,12 @@ sealed interface TeamAssignedItemEditEvent {
     data object CreateItemFailure : TeamAssignedItemEditEvent
 
     data object CreateItemSuccess : TeamAssignedItemEditEvent
+
+    data object SaveItemSuccess : TeamAssignedItemEditEvent
+
+    data object SaveItemFailure : TeamAssignedItemEditEvent
+
+    data class SelectAssignedItem(
+        val itemName: String,
+    ) : TeamAssignedItemEditEvent
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
@@ -33,9 +33,7 @@ class TeamAssignedItemEditFragment :
     }
     private val itemAdapter: TeamAssignedItemEditAdapter by lazy { TeamAssignedItemEditAdapter(this) }
     private val memberAdapter: TeamAssignedItemEditMemberAdapter by lazy {
-        TeamAssignedItemEditMemberAdapter(
-            this,
-        )
+        TeamAssignedItemEditMemberAdapter(this)
     }
 
     override fun onViewCreated(
@@ -47,21 +45,11 @@ class TeamAssignedItemEditFragment :
         setupUI()
     }
 
-    override fun onClickDelete(itemId: Long) {
-        viewModel.deleteItem(itemId)
-    }
+    override fun onClickAssignedItemDelete(itemId: Long) = viewModel.deleteItem(itemId)
 
-    override fun onClickAssignedItem(
-        itemName: String,
-        itemId: Long,
-    ) {
-        viewModel.selectAssignedItem(itemId)
-        parentViewModel.updateInput(itemName)
-    }
+    override fun onClickAssignedItem(itemId: Long) = viewModel.toggleEditState(itemId)
 
-    override fun onClickMember(memberId: Long) {
-        viewModel.selectMember(memberId)
-    }
+    override fun onClickMember(memberId: Long) = viewModel.selectMember(memberId)
 
     private fun setupObserver() {
         parentViewModel.createItemEvent.observe(viewLifecycleOwner, ::handleParentUiEvent)
@@ -71,44 +59,64 @@ class TeamAssignedItemEditFragment :
     }
 
     private fun setupUI() {
-        binding.rvTeamAssignedItemEdit.adapter = itemAdapter
-        binding.rvTeamAssignedItemEdit.layoutManager = LinearLayoutManager(requireContext())
-        binding.rvTeamAssignedItemMember.adapter = memberAdapter
-        binding.rvTeamAssignedItemMember.layoutManager =
-            LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
-        binding.rvTeamAssignedItemMember.addItemDecoration(
-            ItemSpacingDecoration(
-                requireContext().dpToPx(ITEM_SPACING_VALUE),
-                true,
-            ),
-        )
+        setupRvMember()
+        setupRvAssignedItem()
+        binding.rvTeamAssignedItemMember.itemAnimator = null
+        binding.rvTeamAssignedItemEdit.itemAnimator = null
     }
 
     private fun handleParentUiState(uiState: TeamItemEditUiState) {
-        if (uiState.currentTabType !is BottariItemTypeUiModel.ASSIGNED) return
+        if (uiState.currentTabType !is BottariItemTypeUiModel.ASSIGNED) {
+            viewModel.saveSelectedState()
+            parentViewModel.updateSendCondition(true)
+            return
+        }
         viewModel.updateInput(uiState.itemInputText)
     }
 
     private fun handleParentUiEvent(uiEvent: TeamItemEditUiEvent?) {
         if (uiEvent !is TeamItemEditUiEvent.CreateTeamAssignedItem) return
-        viewModel.createItem()
+        viewModel.submitItem()
     }
 
     private fun handleUiState(uiState: TeamAssignedItemEditUiState) {
         toggleLoadingIndicator(uiState.isLoading)
-        parentViewModel.updateSendCondition(uiState.sendCondition)
         binding.emptyView.root.isVisible = uiState.isEmpty
+
+        parentViewModel.updateSendCondition(uiState.canSend)
+        parentViewModel.updateIsAlreadyExistState(uiState.isAlreadyExist)
+
         itemAdapter.submitList(uiState.assignedItems)
         memberAdapter.submitList(uiState.members)
     }
 
     private fun handleUiEvent(uiEvent: TeamAssignedItemEditEvent) {
         when (uiEvent) {
+            is TeamAssignedItemEditEvent.SelectAssignedItem -> parentViewModel.updateInput(uiEvent.itemName)
             TeamAssignedItemEditEvent.FetchTeamAssignedItemsFailure -> requireView().showSnackbar(R.string.common_fetch_failure_text)
-            TeamAssignedItemEditEvent.DeleteItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
-            TeamAssignedItemEditEvent.CreateItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
-            TeamAssignedItemEditEvent.CreateItemSuccess ->
-                parentViewModel.updateInput(RESET_INPUT_TEXT)
+            TeamAssignedItemEditEvent.DeleteItemFailure,
+            TeamAssignedItemEditEvent.CreateItemFailure,
+            TeamAssignedItemEditEvent.SaveItemFailure,
+            -> requireView().showSnackbar(R.string.common_save_failure_text)
+
+            TeamAssignedItemEditEvent.CreateItemSuccess,
+            TeamAssignedItemEditEvent.SaveItemSuccess,
+            -> parentViewModel.updateInput(RESET_INPUT_TEXT)
+        }
+    }
+
+    private fun setupRvAssignedItem() {
+        binding.rvTeamAssignedItemEdit.adapter = itemAdapter
+        binding.rvTeamAssignedItemEdit.layoutManager = LinearLayoutManager(requireContext())
+    }
+
+    private fun setupRvMember() {
+        val decoration = ItemSpacingDecoration(requireContext().dpToPx(ITEM_SPACING_VALUE), true)
+        binding.rvTeamAssignedItemMember.apply {
+            adapter = memberAdapter
+            layoutManager =
+                LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
+            addItemDecoration(decoration)
         }
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
@@ -101,7 +101,8 @@ class TeamAssignedItemEditFragment :
             TeamAssignedItemEditEvent.CreateItemSuccess,
             -> {
                 handleItemEditSuccess()
-                binding.rvTeamAssignedItemEdit.smoothScrollToPosition(itemAdapter.itemCount - 1)
+                val target = (itemAdapter.itemCount - 1).coerceAtLeast(0)
+                binding.rvTeamAssignedItemEdit.smoothScrollToPosition(target)
             }
         }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
@@ -61,8 +61,6 @@ class TeamAssignedItemEditFragment :
     private fun setupUI() {
         setupRvMember()
         setupRvAssignedItem()
-        binding.rvTeamAssignedItemMember.itemAnimator = null
-        binding.rvTeamAssignedItemEdit.itemAnimator = null
     }
 
     private fun handleParentUiState(uiState: TeamItemEditUiState) {
@@ -99,9 +97,12 @@ class TeamAssignedItemEditFragment :
             TeamAssignedItemEditEvent.SaveItemFailure,
             -> requireView().showSnackbar(R.string.common_save_failure_text)
 
+            TeamAssignedItemEditEvent.SaveItemSuccess -> handleItemEditSuccess()
             TeamAssignedItemEditEvent.CreateItemSuccess,
-            TeamAssignedItemEditEvent.SaveItemSuccess,
-            -> parentViewModel.updateInput(RESET_INPUT_TEXT)
+            -> {
+                handleItemEditSuccess()
+                binding.rvTeamAssignedItemEdit.smoothScrollToPosition(itemAdapter.itemCount - 1)
+            }
         }
     }
 
@@ -118,6 +119,11 @@ class TeamAssignedItemEditFragment :
                 LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
             addItemDecoration(decoration)
         }
+    }
+
+    private fun handleItemEditSuccess() {
+        requireView().showSnackbar(R.string.common_save_success_text)
+        parentViewModel.updateInput(RESET_INPUT_TEXT)
     }
 
     companion object {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditFragment.kt
@@ -107,14 +107,18 @@ class TeamAssignedItemEditFragment :
     }
 
     private fun setupRvAssignedItem() {
-        binding.rvTeamAssignedItemEdit.adapter = itemAdapter
-        binding.rvTeamAssignedItemEdit.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvTeamAssignedItemEdit.apply {
+            adapter = itemAdapter
+            itemAnimator = null
+            layoutManager = LinearLayoutManager(requireContext())
+        }
     }
 
     private fun setupRvMember() {
         val decoration = ItemSpacingDecoration(requireContext().dpToPx(ITEM_SPACING_VALUE), true)
         binding.rvTeamAssignedItemMember.apply {
             adapter = memberAdapter
+            itemAnimator = null
             layoutManager =
                 LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
             addItemDecoration(decoration)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditUiState.kt
@@ -6,15 +6,17 @@ import com.bottari.presentation.model.TeamMemberUiModel
 data class TeamAssignedItemEditUiState(
     val isLoading: Boolean = false,
     val isFetched: Boolean = false,
+    val hasRestoreState: Boolean = false,
+    val inputText: String = "",
     val assignedItems: List<BottariItemUiModel> = emptyList(),
     val members: List<TeamMemberUiModel> = emptyList(),
-    val inputText: String = "",
 ) {
     val isEmpty: Boolean = isFetched && assignedItems.isEmpty()
-    val matchingItem: BottariItemUiModel? = assignedItems.find { it.name == inputText }
-    val selectedMemberIds: List<Long> =
-        members
-            .filter { member -> member.isHost }
-            .mapNotNull { member -> member.id }
-    val sendCondition: Boolean = selectedMemberIds.isNotEmpty()
+    val isEditing: Boolean = assignedItems.any { it.isSelected }
+    val isAlreadyExist: Boolean =
+        isEditing.not() && hasRestoreState.not() && assignedItems.any { it.name == inputText }
+
+    val selectedAssignedItem: BottariItemUiModel? = assignedItems.find { it.isSelected }
+    val selectedMemberIds: List<Long> = members.filter { it.isHost }.mapNotNull { it.id }
+    val canSend: Boolean = selectedMemberIds.isNotEmpty()
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditViewModel.kt
@@ -57,7 +57,8 @@ class TeamAssignedItemEditViewModel(
     fun selectMember(memberId: Long) = updateState { copy(members = toggleMemberSelection(memberId)) }
 
     fun submitItem() {
-        if (currentState.isEditing) saveAssignedItem() else createAssignedItem()
+        if (currentState.isEditing) return saveAssignedItem()
+        createAssignedItem()
     }
 
     fun deleteItem(itemId: Long) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/adapter/TeamAssignedItemEditAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/adapter/TeamAssignedItemEditAdapter.kt
@@ -31,7 +31,7 @@ class TeamAssignedItemEditAdapter(
                 override fun areItemsTheSame(
                     oldItem: BottariItemUiModel,
                     newItem: BottariItemUiModel,
-                ): Boolean = oldItem.id == newItem.id
+                ): Boolean = oldItem.id == newItem.id && oldItem.isSelected == newItem.isSelected
             }
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/adapter/TeamAssignedItemEditMemberAdapter.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/adapter/TeamAssignedItemEditMemberAdapter.kt
@@ -31,7 +31,7 @@ class TeamAssignedItemEditMemberAdapter(
                 override fun areItemsTheSame(
                     oldItem: TeamMemberUiModel,
                     newItem: TeamMemberUiModel,
-                ): Boolean = oldItem.id == newItem.id
+                ): Boolean = oldItem.id == newItem.id && oldItem.isHost == newItem.isHost
             }
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/adapter/TeamAssignedItemEditViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/adapter/TeamAssignedItemEditViewHolder.kt
@@ -1,46 +1,60 @@
 package com.bottari.presentation.view.edit.team.item.assigned.adapter
 
+import android.graphics.drawable.GradientDrawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat.getColor
 import androidx.recyclerview.widget.RecyclerView
+import com.bottari.presentation.R
+import com.bottari.presentation.common.extension.dpToPx
 import com.bottari.presentation.databinding.ItemEditAssignedItemBinding
 import com.bottari.presentation.model.BottariItemTypeUiModel
 import com.bottari.presentation.model.BottariItemUiModel
 
 class TeamAssignedItemEditViewHolder(
     private val binding: ItemEditAssignedItemBinding,
-    eventListener: AssignedItemEventListener,
+    private val eventListener: AssignedItemEventListener,
 ) : RecyclerView.ViewHolder(binding.root) {
-    private var currentItem: BottariItemUiModel? = null
+    private var currentItemId: Long? = null
 
     init {
         binding.btnAssignedItemDelete.setOnClickListener {
-            currentItem?.let { item -> eventListener.onClickDelete(item.id) }
+            currentItemId?.let(eventListener::onClickAssignedItemDelete)
         }
         binding.root.setOnClickListener {
-            currentItem?.let { item -> eventListener.onClickAssignedItem(item.name, item.id) }
+            currentItemId?.let(eventListener::onClickAssignedItem)
         }
     }
 
     fun bind(item: BottariItemUiModel) {
-        currentItem = item
+        currentItemId = item.id
         binding.tvAssignedItemName.text = item.name
+        handleSelectedState(item.isSelected)
 
         if (item.type is BottariItemTypeUiModel.ASSIGNED) {
-            binding.tvAssignedItemMemberNames.text = item.type.members.joinToString { member -> member.nickname }
+            binding.tvAssignedItemMemberNames.text =
+                item.type.members.joinToString { member -> member.nickname }
+        }
+    }
+
+    private fun handleSelectedState(isSelected: Boolean) {
+        val background = binding.root.background.mutate()
+        if (background is GradientDrawable) {
+            val colorRes = if (isSelected) R.color.primary else R.color.white
+            val strokeColor = getColor(itemView.context, colorRes)
+            background.setStroke(itemView.context.dpToPx(DUPLICATE_BORDER_WIDTH_DP), strokeColor)
         }
     }
 
     interface AssignedItemEventListener {
-        fun onClickDelete(itemId: Long)
+        fun onClickAssignedItemDelete(itemId: Long)
 
-        fun onClickAssignedItem(
-            itemName: String,
-            itemId: Long,
-        )
+        fun onClickAssignedItem(itemId: Long)
     }
 
     companion object {
+        private const val DUPLICATE_BORDER_WIDTH_DP = 2
+
         fun from(
             parent: ViewGroup,
             eventListener: AssignedItemEventListener,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/adapter/TeamAssignedItemEditViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/adapter/TeamAssignedItemEditViewHolder.kt
@@ -31,10 +31,11 @@ class TeamAssignedItemEditViewHolder(
         binding.tvAssignedItemName.text = item.name
         handleSelectedState(item.isSelected)
 
-        if (item.type is BottariItemTypeUiModel.ASSIGNED) {
-            binding.tvAssignedItemMemberNames.text =
-                item.type.members.joinToString { member -> member.nickname }
+        if (item.type !is BottariItemTypeUiModel.ASSIGNED) {
+            binding.tvAssignedItemMemberNames.text = EMPTY_TEXT
+            return
         }
+        binding.tvAssignedItemMemberNames.text = item.type.members.joinToString { member -> member.nickname }
     }
 
     private fun handleSelectedState(isSelected: Boolean) {
@@ -54,6 +55,7 @@ class TeamAssignedItemEditViewHolder(
 
     companion object {
         private const val DUPLICATE_BORDER_WIDTH_DP = 2
+        private const val EMPTY_TEXT = ""
 
         fun from(
             parent: ViewGroup,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
@@ -14,7 +14,6 @@ import com.bottari.presentation.common.base.BaseFragment
 import com.bottari.presentation.common.extension.applyImeBottomPadding
 import com.bottari.presentation.common.extension.dpToPx
 import com.bottari.presentation.common.extension.getParcelableCompat
-import com.bottari.presentation.common.extension.hideKeyboard
 import com.bottari.presentation.common.extension.setTextIfDifferent
 import com.bottari.presentation.common.extension.showKeyboard
 import com.bottari.presentation.databinding.FragmentTeamBottariItemEditBinding

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
@@ -2,12 +2,11 @@ package com.bottari.presentation.view.edit.team.item.main
 
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.os.bundleOf
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.viewModels
 import androidx.viewpager2.widget.ViewPager2
 import com.bottari.presentation.R
@@ -16,6 +15,7 @@ import com.bottari.presentation.common.extension.applyImeBottomPadding
 import com.bottari.presentation.common.extension.dpToPx
 import com.bottari.presentation.common.extension.getParcelableCompat
 import com.bottari.presentation.common.extension.setTextIfDifferent
+import com.bottari.presentation.common.extension.showKeyboard
 import com.bottari.presentation.databinding.FragmentTeamBottariItemEditBinding
 import com.bottari.presentation.model.BottariItemTypeUiModel
 import com.bottari.presentation.view.edit.team.TeamBottariEditNavigator
@@ -26,8 +26,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 class TeamItemEditFragment :
     BaseFragment<FragmentTeamBottariItemEditBinding>(
         FragmentTeamBottariItemEditBinding::inflate,
-    ),
-    TextWatcher {
+    ) {
     private val viewModel: TeamItemEditViewModel by viewModels {
         TeamItemEditViewModel.Factory(
             requireArguments().getParcelableCompat(ARG_KEY_TAB_TYPE),
@@ -47,37 +46,19 @@ class TeamItemEditFragment :
         setupListener()
     }
 
-    override fun beforeTextChanged(
-        p0: CharSequence?,
-        p1: Int,
-        p2: Int,
-        p3: Int,
-    ) {
-    }
-
-    override fun onTextChanged(
-        p0: CharSequence?,
-        p1: Int,
-        p2: Int,
-        p3: Int,
-    ) {
-    }
-
-    override fun afterTextChanged(p0: Editable?) {
-        viewModel.updateInput(p0.toString())
-    }
-
     private fun setupObserver() {
         viewModel.uiState.observe(viewLifecycleOwner, ::handleUiState)
     }
 
     private fun setupUI() {
         binding.root.applyImeBottomPadding()
-        binding.viewItemInput.etItemInput.addTextChangedListener(this)
         setupTabLayout()
     }
 
     private fun setupListener() {
+        binding.viewItemInput.etItemInput.doAfterTextChanged { newText ->
+            viewModel.updateInput(newText.toString())
+        }
         binding.viewItemInput.btnPersonalItemSend.setOnClickListener { viewModel.createItem() }
         binding.btnPrevious.setOnClickListener {
             (requireActivity() as? TeamBottariEditNavigator)?.navigateBack()
@@ -98,7 +79,7 @@ class TeamItemEditFragment :
     }
 
     private fun handleUiState(uiState: TeamItemEditUiState) {
-        handleEditTextState(uiState.isAlreadyExist)
+        handleEditTextState(uiState)
         binding.viewItemInput.etItemInput.setTextIfDifferent(uiState.itemInputText)
         handleSendButtonState(uiState.canSend)
     }
@@ -124,20 +105,23 @@ class TeamItemEditFragment :
 
     private fun selectInitialTab() {
         val type = requireArguments().getParcelableCompat<BottariItemTypeUiModel>(ARG_KEY_TAB_TYPE)
-        with(binding.vpTeamBottariItemEdit) {
-            post { currentItem = TeamItemEditFragmentAdapter.positionFromType(type) }
-        }
+        binding.vpTeamBottariItemEdit
+            .setCurrentItem(TeamItemEditFragmentAdapter.positionFromType(type), false)
     }
 
-    private fun handleEditTextState(isAlreadyExist: Boolean) {
+    private fun handleEditTextState(uiState: TeamItemEditUiState) {
         val background =
             binding.viewItemInput.etItemInput.background
                 .mutate()
         if (background is GradientDrawable) {
-            val colorRes = if (isAlreadyExist) R.color.red else R.color.transparent
+            val colorRes = if (uiState.isAlreadyExist) R.color.red else R.color.transparent
             val strokeColor = getColor(requireContext(), colorRes)
             background.setStroke(requireContext().dpToPx(DUPLICATE_BORDER_WIDTH_DP), strokeColor)
         }
+
+        binding.viewItemInput.etItemInput.setTextIfDifferent(uiState.itemInputText)
+        showKeyboard(binding.viewItemInput.etItemInput)
+        binding.viewItemInput.etItemInput.setSelection(uiState.itemInputText.length)
     }
 
     private fun handleSendButtonState(canSend: Boolean) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditFragment.kt
@@ -14,6 +14,7 @@ import com.bottari.presentation.common.base.BaseFragment
 import com.bottari.presentation.common.extension.applyImeBottomPadding
 import com.bottari.presentation.common.extension.dpToPx
 import com.bottari.presentation.common.extension.getParcelableCompat
+import com.bottari.presentation.common.extension.hideKeyboard
 import com.bottari.presentation.common.extension.setTextIfDifferent
 import com.bottari.presentation.common.extension.showKeyboard
 import com.bottari.presentation.databinding.FragmentTeamBottariItemEditBinding
@@ -120,8 +121,12 @@ class TeamItemEditFragment :
         }
 
         binding.viewItemInput.etItemInput.setTextIfDifferent(uiState.itemInputText)
-        showKeyboard(binding.viewItemInput.etItemInput)
-        binding.viewItemInput.etItemInput.setSelection(uiState.itemInputText.length)
+        if (uiState.itemInputText.isNotBlank()) {
+            binding.viewItemInput.etItemInput.setSelection(uiState.itemInputText.length)
+            showKeyboard(binding.viewItemInput.etItemInput)
+            return
+        }
+        binding.viewItemInput.etItemInput.clearFocus()
     }
 
     private fun handleSendButtonState(canSend: Boolean) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditViewModel.kt
@@ -43,7 +43,7 @@ class TeamItemEditViewModel(
             BottariItemTypeUiModel.PERSONAL -> emitCreateEvent(TeamItemEditUiEvent.CreateTeamPersonalItem)
             is BottariItemTypeUiModel.ASSIGNED -> emitCreateEvent(TeamItemEditUiEvent.CreateTeamAssignedItem)
         }
-        updateState { copy(itemInputText = RESET_INPUT_VALUE) }
+        updateState { copy(itemInputText = EMPTY_INPUT) }
         resetCreateEvent()
     }
 
@@ -58,7 +58,7 @@ class TeamItemEditViewModel(
     companion object {
         private const val KEY_TAB_TYPE = "KEY_TAB_TYPE"
         private const val ERROR_TYPE_NULL = "[ERROR] type이 null입니다"
-        private const val RESET_INPUT_VALUE = ""
+        private const val EMPTY_INPUT = ""
 
         fun Factory(initialTabType: BottariItemTypeUiModel): ViewModelProvider.Factory =
             viewModelFactory {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/main/TeamItemEditViewModel.kt
@@ -43,6 +43,7 @@ class TeamItemEditViewModel(
             BottariItemTypeUiModel.PERSONAL -> emitCreateEvent(TeamItemEditUiEvent.CreateTeamPersonalItem)
             is BottariItemTypeUiModel.ASSIGNED -> emitCreateEvent(TeamItemEditUiEvent.CreateTeamAssignedItem)
         }
+        updateState { copy(itemInputText = RESET_INPUT_VALUE) }
         resetCreateEvent()
     }
 
@@ -57,6 +58,7 @@ class TeamItemEditViewModel(
     companion object {
         private const val KEY_TAB_TYPE = "KEY_TAB_TYPE"
         private const val ERROR_TYPE_NULL = "[ERROR] type이 null입니다"
+        private const val RESET_INPUT_VALUE = ""
 
         fun Factory(initialTabType: BottariItemTypeUiModel): ViewModelProvider.Factory =
             viewModelFactory {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
@@ -75,10 +75,15 @@ class TeamPersonalItemEditFragment :
     private fun handleUiEvent(uiEvent: TeamPersonalItemEditEvent) {
         when (uiEvent) {
             TeamPersonalItemEditEvent.FetchTeamPersonalItemsFailure -> requireView().showSnackbar(R.string.common_fetch_failure_text)
-            TeamPersonalItemEditEvent.CreateItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
-            TeamPersonalItemEditEvent.DeleteItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
-            TeamPersonalItemEditEvent.CreateItemSuccess ->
+            TeamPersonalItemEditEvent.CreateItemFailure,
+            TeamPersonalItemEditEvent.DeleteItemFailure,
+            -> requireView().showSnackbar(R.string.common_save_failure_text)
+
+            TeamPersonalItemEditEvent.CreateItemSuccess -> {
+                requireView().showSnackbar(R.string.common_save_success_text)
                 parentViewModel.updateInput(RESET_INPUT_TEXT)
+                binding.rvTeamPersonalItemEdit.smoothScrollToPosition(adapter.itemCount - 1)
+            }
         }
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/personal/TeamPersonalItemEditFragment.kt
@@ -82,7 +82,8 @@ class TeamPersonalItemEditFragment :
             TeamPersonalItemEditEvent.CreateItemSuccess -> {
                 requireView().showSnackbar(R.string.common_save_success_text)
                 parentViewModel.updateInput(RESET_INPUT_TEXT)
-                binding.rvTeamPersonalItemEdit.smoothScrollToPosition(adapter.itemCount - 1)
+                val target = (adapter.itemCount - 1).coerceAtLeast(0)
+                binding.rvTeamPersonalItemEdit.smoothScrollToPosition(target)
             }
         }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditEvent.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditEvent.kt
@@ -1,7 +1,7 @@
 package com.bottari.presentation.view.edit.team.item.shared
 
 sealed interface TeamSharedItemEditEvent {
-    data object FetchTeamPersonalItemsFailure : TeamSharedItemEditEvent
+    data object FetchTeamSharedItemsFailure : TeamSharedItemEditEvent
 
     data object DeleteItemFailure : TeamSharedItemEditEvent
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
@@ -82,7 +82,8 @@ class TeamSharedItemEditFragment :
             TeamSharedItemEditEvent.CreateItemSuccuss -> {
                 requireView().showSnackbar(R.string.common_save_success_text)
                 parentViewModel.updateInput(RESET_INPUT_TEXT)
-                binding.rvTeamSharedItemEdit.smoothScrollToPosition(adapter.itemCount - 1)
+                val target = (adapter.itemCount - 1).coerceAtLeast(0)
+                binding.rvTeamSharedItemEdit.smoothScrollToPosition(target)
             }
         }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
@@ -74,7 +74,7 @@ class TeamSharedItemEditFragment :
 
     private fun handleUiEvent(uiEvent: TeamSharedItemEditEvent) {
         when (uiEvent) {
-            TeamSharedItemEditEvent.FetchTeamPersonalItemsFailure -> requireView().showSnackbar(R.string.common_fetch_failure_text)
+            TeamSharedItemEditEvent.FetchTeamSharedItemsFailure -> requireView().showSnackbar(R.string.common_fetch_failure_text)
             TeamSharedItemEditEvent.DeleteItemFailure,
             TeamSharedItemEditEvent.CreateItemFailure,
             -> requireView().showSnackbar(R.string.common_save_failure_text)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditFragment.kt
@@ -75,10 +75,15 @@ class TeamSharedItemEditFragment :
     private fun handleUiEvent(uiEvent: TeamSharedItemEditEvent) {
         when (uiEvent) {
             TeamSharedItemEditEvent.FetchTeamPersonalItemsFailure -> requireView().showSnackbar(R.string.common_fetch_failure_text)
-            TeamSharedItemEditEvent.DeleteItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
-            TeamSharedItemEditEvent.CreateItemFailure -> requireView().showSnackbar(R.string.common_save_failure_text)
-            TeamSharedItemEditEvent.CreateItemSuccuss ->
+            TeamSharedItemEditEvent.DeleteItemFailure,
+            TeamSharedItemEditEvent.CreateItemFailure,
+            -> requireView().showSnackbar(R.string.common_save_failure_text)
+
+            TeamSharedItemEditEvent.CreateItemSuccuss -> {
+                requireView().showSnackbar(R.string.common_save_success_text)
                 parentViewModel.updateInput(RESET_INPUT_TEXT)
+                binding.rvTeamSharedItemEdit.smoothScrollToPosition(adapter.itemCount - 1)
+            }
         }
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
@@ -66,7 +66,7 @@ class TeamSharedItemEditViewModel(
         launch {
             fetchTeamSharedItemsUseCase(bottariId)
                 .onSuccess { items -> updateState { copy(sharedItems = items.map { it.toUiModel() }) } }
-                .onFailure { emitEvent(TeamSharedItemEditEvent.FetchTeamPersonalItemsFailure) }
+                .onFailure { emitEvent(TeamSharedItemEditEvent.FetchTeamSharedItemsFailure) }
 
             updateState { copy(isLoading = false, isFetched = true) }
         }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditFragment.kt
@@ -71,17 +71,17 @@ class TeamBottariEditFragment : BaseFragment<FragmentTeamBottariEditBinding>(Fra
         binding.viewTeamMemberEdit.root.setOnClickListener {
             (requireActivity() as? TeamBottariEditNavigator)?.navigateToMemberEdit(teamBottariId)
         }
-        binding.viewTeamPersonalItemEdit.root.setOnClickListener {
+        binding.viewTeamPersonalItemEdit.btnRoot.setOnClickListener {
             navigateToItemEdit(
                 BottariItemTypeUiModel.PERSONAL,
             )
         }
-        binding.viewTeamSharedItemEdit.root.setOnClickListener {
+        binding.viewTeamSharedItemEdit.btnRoot.setOnClickListener {
             navigateToItemEdit(
                 BottariItemTypeUiModel.SHARED,
             )
         }
-        binding.viewTeamAssignedItemEdit.root.setOnClickListener {
+        binding.viewTeamAssignedItemEdit.btnRoot.setOnClickListener {
             navigateToItemEdit(
                 BottariItemTypeUiModel.ASSIGNED(),
             )

--- a/android/Bottari/presentation/src/main/res/layout/view_bottari_item_edit.xml
+++ b/android/Bottari/presentation/src/main/res/layout/view_bottari_item_edit.xml
@@ -9,6 +9,15 @@
     android:elevation="2dp"
     android:padding="@dimen/space_median">
 
+    <View
+        android:id="@+id/btn_root"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:background="@color/transparent"
+        android:translationZ="1dp"/>
+
     <TextView
         android:id="@+id/tv_item_edit_title"
         style="@style/Pretendard_Bold_20"


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 담당 물건 수정 기능 구현

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #423 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
-  팀 보따리 담당 물건 수정 기능 구현


<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Edit and save assigned team items, including selecting an item to update and assigning members.
  - Visual selection state for assigned items with highlighted styling.
- Improvements
  - More reliable keyboard show/hide behavior across screens.
  - Smoother text input handling and automatic cursor placement.
  - Success/failure messages unified; on success, input resets and lists scroll to the newest item.
  - Larger, more accessible tap targets for navigating to item edit sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->