### PR TITLE
[AN] 알람 스와이프 화면 버그 수정

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistUiState.kt
@@ -26,6 +26,9 @@ data class ChecklistUiState(
     val isAllSwiped: Boolean
         get() = bottariItems.isNotEmpty() && nonSwipedItems.isEmpty()
 
+    val isDone: Boolean
+        get() = isAllSwiped || isAllChecked
+
     private val nonCheckedItems: List<ChecklistItemUiModel> by lazy {
         bottariItems.filterNot { it.isChecked }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistUiState.kt
@@ -27,7 +27,7 @@ data class ChecklistUiState(
         get() = bottariItems.isNotEmpty() && nonSwipedItems.isEmpty()
 
     val isDone: Boolean
-        get() = isAllSwiped || isAllChecked
+        get() = isAllSwiped || isItemsEmpty
 
     private val nonCheckedItems: List<ChecklistItemUiModel> by lazy {
         bottariItems.filterNot { it.isChecked }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/swipe/SwipeChecklistFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/swipe/SwipeChecklistFragment.kt
@@ -76,6 +76,7 @@ class SwipeChecklistFragment :
             updateSwipeList(uiState.nonSwipedItems)
             handleCompleteView(uiState)
             handleEmptyView(uiState.isItemsEmpty)
+            showDoneButton(uiState.isDone)
         }
         viewModel.uiEvent.observe(viewLifecycleOwner) { uiEvent ->
             when (uiEvent) {
@@ -119,25 +120,22 @@ class SwipeChecklistFragment :
     }
 
     private fun handleEmptyView(isEmpty: Boolean) {
-        if (!isEmpty) return
-        showDoneButton()
-        showEmptyView()
+        showEmptyView(isEmpty)
     }
 
     private fun showCompleteState(isComplete: Boolean) {
-        showDoneButton()
         binding.viewSwipeCompleteNotAll.clSwipeCompleteNotAll.isVisible = !isComplete
         binding.viewSwipeCompleteAll.clSwipeCompleteAll.isVisible = isComplete
     }
 
-    private fun showDoneButton() {
-        binding.btnSwipeChecklistNot.isVisible = false
-        binding.btnSwipeChecklistYes.isVisible = false
-        binding.btnSwipeChecklistReturn.isVisible = true
+    private fun showDoneButton(isDone: Boolean) {
+        binding.btnSwipeChecklistNot.isVisible = !isDone
+        binding.btnSwipeChecklistYes.isVisible = !isDone
+        binding.btnSwipeChecklistReturn.isVisible = isDone
     }
 
-    private fun showEmptyView() {
-        binding.viewSwipeEmpty.clSwipeEmpty.isVisible = true
+    private fun showEmptyView(isEmpty: Boolean) {
+        binding.viewSwipeEmpty.clSwipeEmpty.isVisible = isEmpty
     }
 
     private fun setupCardStackView() {


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 알람을 통해 접근한 스와이프 뷰가 
- 완료되지 않았음에도 done 버튼이 나타나는 경우 수정
- 전부 체크 된 상태일 경우 emptyView가 겹쳐서 나타나는 경우 수정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #396 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
-

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
| Before | After |
|--------|-------|
| (이전 화면) | (변경된 화면) |

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>
