### PR TITLE
[AN] 체크리스트 내용이 같아도 변경 다이얼로그가 뜨는 오류 수정

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistUiState.kt
@@ -4,7 +4,7 @@ import com.bottari.presentation.model.ChecklistItemUiModel
 
 data class ChecklistUiState(
     val isLoading: Boolean = false,
-    val originalBottariItems: List<ChecklistItemUiModel> = emptyList(),
+    val initialItems: List<ChecklistItemUiModel> = emptyList(),
     val bottariItems: List<ChecklistItemUiModel> = emptyList(),
     val swipedItemIds: Set<Long> = emptySet(),
 ) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistUiState.kt
@@ -4,6 +4,7 @@ import com.bottari.presentation.model.ChecklistItemUiModel
 
 data class ChecklistUiState(
     val isLoading: Boolean = false,
+    val originalBottariItems: List<ChecklistItemUiModel> = emptyList(),
     val bottariItems: List<ChecklistItemUiModel> = emptyList(),
     val swipedItemIds: Set<Long> = emptySet(),
 ) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
@@ -112,15 +112,14 @@ class ChecklistViewModel(
     private fun revertItemCheckStatus(failedItemId: Long) {
         val originalItem =
             currentState.initialItems.find { it.id == failedItemId } ?: return
-
-        updateState {
-            val revertedItems =
-                bottariItems.map { uiItem ->
-                    if (uiItem.id == failedItemId) {
-                        return@map uiItem.copy(isChecked = originalItem.isChecked)
-                    }
-                    uiItem
+        val revertedItems =
+            currentState.bottariItems.map { uiItem ->
+                if (uiItem.id == failedItemId) {
+                    return@map uiItem.copy(isChecked = originalItem.isChecked)
                 }
+                uiItem
+            }
+        updateState {
             copy(bottariItems = revertedItems)
         }
     }
@@ -131,7 +130,6 @@ class ChecklistViewModel(
         if (index != -1) {
             currentOriginals[index] = updatedItem
         }
-
         updateState { copy(initialItems = currentOriginals) }
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
@@ -74,21 +74,24 @@ class ChecklistViewModel(
 
     private fun setChecklist(items: List<ChecklistItem>) {
         val itemUiModels = items.map { it.toUiModel() }
-        updateState { copy(bottariItems = itemUiModels, originalBottariItems = itemUiModels) }
+        updateState {
+            copy(
+                bottariItems = itemUiModels,
+                originalBottariItems = itemUiModels.toList(),
+            )
+        }
     }
 
     private fun performCheck(items: List<ChecklistItemUiModel>) {
         launch {
-            val originalItems = currentState.originalBottariItems
-            val itemsToUpdate = mutableListOf<ChecklistItemUiModel>()
+            val originalItemsById = currentState.originalBottariItems.associateBy { it.id }
 
             val jobs =
                 items.mapNotNull { pendingItem ->
-                    val originalItem = originalItems.find { it.id == pendingItem.id }
+                    val originalItem = originalItemsById[pendingItem.id]
                     if (originalItem == null || originalItem.isChecked == pendingItem.isChecked) {
                         return@mapNotNull null
                     }
-                    itemsToUpdate.add(pendingItem)
                     async { processItemCheck(pendingItem) }
                 }
             jobs.awaitAll()

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
@@ -104,8 +104,25 @@ class ChecklistViewModel(
             .onSuccess {
                 updateOriginalItem(item)
             }.onFailure {
+                revertItemCheckStatus(item.id)
                 emitEvent(ChecklistUiEvent.CheckItemFailure)
             }
+    }
+
+    private fun revertItemCheckStatus(failedItemId: Long) {
+        val originalItem =
+            currentState.originalBottariItems.find { it.id == failedItemId } ?: return
+
+        updateState {
+            val revertedItems =
+                bottariItems.map { uiItem ->
+                    if (uiItem.id == failedItemId) {
+                        return@map uiItem.copy(isChecked = originalItem.isChecked)
+                    }
+                    uiItem
+                }
+            copy(bottariItems = revertedItems)
+        }
     }
 
     private fun updateOriginalItem(updatedItem: ChecklistItemUiModel) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
@@ -77,14 +77,14 @@ class ChecklistViewModel(
         updateState {
             copy(
                 bottariItems = itemUiModels,
-                originalBottariItems = itemUiModels.toList(),
+                initialItems = itemUiModels.toList(),
             )
         }
     }
 
     private fun performCheck(items: List<ChecklistItemUiModel>) {
         launch {
-            val originalItemsById = currentState.originalBottariItems.associateBy { it.id }
+            val originalItemsById = currentState.initialItems.associateBy { it.id }
 
             val jobs =
                 items.mapNotNull { pendingItem ->
@@ -111,7 +111,7 @@ class ChecklistViewModel(
 
     private fun revertItemCheckStatus(failedItemId: Long) {
         val originalItem =
-            currentState.originalBottariItems.find { it.id == failedItemId } ?: return
+            currentState.initialItems.find { it.id == failedItemId } ?: return
 
         updateState {
             val revertedItems =
@@ -126,13 +126,13 @@ class ChecklistViewModel(
     }
 
     private fun updateOriginalItem(updatedItem: ChecklistItemUiModel) {
-        val currentOriginals = currentState.originalBottariItems.toMutableList()
+        val currentOriginals = currentState.initialItems.toMutableList()
         val index = currentOriginals.indexOfFirst { it.id == updatedItem.id }
         if (index != -1) {
             currentOriginals[index] = updatedItem
         }
 
-        updateState { copy(originalBottariItems = currentOriginals) }
+        updateState { copy(initialItems = currentOriginals) }
     }
 
     private suspend fun executeCheckUseCase(item: ChecklistItemUiModel) =

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/personal/ChecklistViewModel.kt
@@ -87,13 +87,13 @@ class ChecklistViewModel(
             val originalItemsById = currentState.initialItems.associateBy { it.id }
 
             val jobs =
-                items.mapNotNull { pendingItem ->
-                    val originalItem = originalItemsById[pendingItem.id]
-                    if (originalItem == null || originalItem.isChecked == pendingItem.isChecked) {
-                        return@mapNotNull null
+                items
+                    .filter { pendingItem ->
+                        val originalItem = originalItemsById[pendingItem.id]
+                        originalItem != null && originalItem.isChecked != pendingItem.isChecked
+                    }.map { changedItem ->
+                        async { processItemCheck(changedItem) }
                     }
-                    async { processItemCheck(pendingItem) }
-                }
             jobs.awaitAll()
             pendingCheckStatusMap.clear()
         }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusFragment.kt
@@ -46,8 +46,7 @@ class TeamBottariStatusFragment :
     private fun setupObserver() {
         viewModel.uiState.observe(viewLifecycleOwner) { state ->
             teamBottariProductStatusDetailAdapter.submitList(state.selectedProduct?.memberCheckStatus)
-            binding.tvTeamBottariItemStatusTitle.text =
-                getString(R.string.team_product_status_title_format, state.selectedProduct?.name)
+            binding.tvTeamBottariItemStatusTitle.text = state.selectedProduct?.name ?: ""
             teamBottariProductStatusAdapter.submitList(state.teamChecklistItems)
         }
         viewModel.uiEvent.observe(viewLifecycleOwner) { event ->

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
@@ -82,6 +82,7 @@ class PersonalItemEditFragment :
             handleBottariNameState(uiState.title)
             handleItemState(uiState.items)
             handleEmptyView(uiState.items.isEmpty())
+            handleDialog(uiState.isNotEqual)
         }
         viewModel.uiEvent.observe(viewLifecycleOwner) { event ->
             when (event) {
@@ -118,13 +119,11 @@ class PersonalItemEditFragment :
             requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
                 showExitConfirmationDialog()
             }
-        onBackPressedCallback.isEnabled = false
     }
 
     private fun addItemFromInput() {
         viewModel.addNewItemIfNeeded(binding.etPersonalItem.text.toString())
         binding.etPersonalItem.text.clear()
-        onBackPressedCallback.isEnabled = true
     }
 
     private fun updateDuplicateStateUI(text: String) {
@@ -159,6 +158,10 @@ class PersonalItemEditFragment :
 
     private fun handleEmptyView(isEmpty: Boolean) {
         binding.emptyView.clPersonalBottariItemEmptyView.isVisible = isEmpty
+    }
+
+    private fun handleDialog(isNotEqual: Boolean) {
+        onBackPressedCallback.isEnabled = isNotEqual
     }
 
     private fun showExitConfirmationDialog() {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
@@ -82,7 +82,7 @@ class PersonalItemEditFragment :
             handleBottariNameState(uiState.title)
             handleItemState(uiState.items)
             handleEmptyView(uiState.items.isEmpty())
-            handleDialog(uiState.isNotEqual)
+            handleDialog(uiState.isDifferent)
         }
         viewModel.uiEvent.observe(viewLifecycleOwner) { event ->
             when (event) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditFragment.kt
@@ -99,6 +99,10 @@ class PersonalItemEditFragment :
         binding.rvPersonalItemEdit.adapter = adapter
         binding.rvPersonalItemEdit.layoutManager = LinearLayoutManager(requireContext())
         binding.root.applyImeBottomPadding()
+        onBackPressedCallback =
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, false) {
+                showExitConfirmationDialog()
+            }
     }
 
     private fun setupListener() {
@@ -115,10 +119,6 @@ class PersonalItemEditFragment :
             addItemFromInput()
             true
         }
-        onBackPressedCallback =
-            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
-                showExitConfirmationDialog()
-            }
     }
 
     private fun addItemFromInput() {
@@ -161,7 +161,9 @@ class PersonalItemEditFragment :
     }
 
     private fun handleDialog(isNotEqual: Boolean) {
-        onBackPressedCallback.isEnabled = isNotEqual
+        if (::onBackPressedCallback.isInitialized) {
+            onBackPressedCallback.isEnabled = isNotEqual
+        }
     }
 
     private fun showExitConfirmationDialog() {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
@@ -6,8 +6,8 @@ data class PersonalItemEditUiState(
     val isLoading: Boolean = false,
     val bottariId: Long,
     val title: String,
+    var orignalItems: List<BottariItemUiModel>,
     var items: List<BottariItemUiModel>,
 ) {
-    val initialItems: List<String> = items.map { it.name }
-    val initialItemIds: List<Long> = items.map { it.id }
+    val isNotEqual: Boolean = orignalItems != items
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
@@ -9,5 +9,5 @@ data class PersonalItemEditUiState(
     var initialItems: List<BottariItemUiModel>,
     var items: List<BottariItemUiModel>,
 ) {
-    val isNotEqual: Boolean = initialItems != items
+    val isDifferent: Boolean = initialItems != items
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
@@ -6,8 +6,8 @@ data class PersonalItemEditUiState(
     val isLoading: Boolean = false,
     val bottariId: Long,
     val title: String,
-    var orignalItems: List<BottariItemUiModel>,
+    var originalItems: List<BottariItemUiModel>,
     var items: List<BottariItemUiModel>,
 ) {
-    val isNotEqual: Boolean = orignalItems != items
+    val isNotEqual: Boolean = originalItems != items
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditUiState.kt
@@ -6,8 +6,8 @@ data class PersonalItemEditUiState(
     val isLoading: Boolean = false,
     val bottariId: Long,
     val title: String,
-    var originalItems: List<BottariItemUiModel>,
+    var initialItems: List<BottariItemUiModel>,
     var items: List<BottariItemUiModel>,
 ) {
-    val isNotEqual: Boolean = originalItems != items
+    val isNotEqual: Boolean = initialItems != items
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
@@ -67,10 +67,10 @@ class PersonalItemEditViewModel(
 
         val initialItemIds = initialItems.map { it.id }.toSet()
         val finalItemIds = finalItems.map { it.id }.toSet()
-        val deleteItemIds = initialItemIds.filter { it !in finalItemIds }
+        val deleteItemIds = initialItemIds.filterNot { it in finalItemIds }
         val createItemNames =
             finalItems
-                .filter { it.id !in initialItemIds }
+                .filterNot { it.id in initialItemIds }
                 .map { it.name }
 
         return ItemChanges(deleteItemIds, createItemNames)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
@@ -20,7 +20,7 @@ class PersonalItemEditViewModel(
         PersonalItemEditUiState(
             bottariId = stateHandle[KEY_BOTTARI_ID] ?: error(ERROR_REQUIRE_BOTTARI_ID),
             title = stateHandle[KEY_BOTTARI_TITLE] ?: "",
-            originalItems = stateHandle[KEY_BOTTARI_ITEMS] ?: emptyList(),
+            initialItems = stateHandle[KEY_BOTTARI_ITEMS] ?: emptyList(),
             items = stateHandle[KEY_BOTTARI_ITEMS] ?: emptyList(),
         ),
     ) {
@@ -33,7 +33,7 @@ class PersonalItemEditViewModel(
         if (itemName.isBlank() || isDuplicateItem(itemName)) return
 
         val itemToRestore =
-            currentState.originalItems.firstOrNull { originalItem ->
+            currentState.initialItems.firstOrNull { originalItem ->
                 originalItem.name == itemName && currentState.items.none { it.id == originalItem.id }
             }
 
@@ -62,7 +62,7 @@ class PersonalItemEditViewModel(
     }
 
     private fun calculateItemChanges(): ItemChanges {
-        val initialItems = currentState.originalItems
+        val initialItems = currentState.initialItems
         val finalItems = currentState.items
 
         val initialItemIds = initialItems.map { it.id }.toSet()
@@ -97,7 +97,7 @@ class PersonalItemEditViewModel(
             UiEventType.PERSONAL_BOTTARI_ITEM_EDIT,
             mapOf(
                 "bottari_id" to currentState.bottariId.toString(),
-                "old_items" to currentState.originalItems.toString(),
+                "old_items" to currentState.initialItems.toString(),
                 "new_items" to currentState.items.toString(),
             ),
         )
@@ -107,7 +107,7 @@ class PersonalItemEditViewModel(
         val restoredList = currentState.items + itemToRestore
 
         val originalOrderMap =
-            currentState.originalItems
+            currentState.initialItems
                 .withIndex()
                 .associate { (index, item) -> item.id to index }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
@@ -20,7 +20,7 @@ class PersonalItemEditViewModel(
         PersonalItemEditUiState(
             bottariId = stateHandle[KEY_BOTTARI_ID] ?: error(ERROR_REQUIRE_BOTTARI_ID),
             title = stateHandle[KEY_BOTTARI_TITLE] ?: "",
-            orignalItems = stateHandle[KEY_BOTTARI_ITEMS] ?: emptyList(),
+            originalItems = stateHandle[KEY_BOTTARI_ITEMS] ?: emptyList(),
             items = stateHandle[KEY_BOTTARI_ITEMS] ?: emptyList(),
         ),
     ) {
@@ -33,7 +33,7 @@ class PersonalItemEditViewModel(
         if (itemName.isBlank() || isDuplicateItem(itemName)) return
 
         val itemToRestore =
-            currentState.orignalItems.firstOrNull { originalItem ->
+            currentState.originalItems.firstOrNull { originalItem ->
                 originalItem.name == itemName && currentState.items.none { it.id == originalItem.id }
             }
 
@@ -62,12 +62,12 @@ class PersonalItemEditViewModel(
     }
 
     private fun calculateItemChanges(): ItemChanges {
-        val initialItems = currentState.orignalItems
+        val initialItems = currentState.originalItems
         val finalItems = currentState.items
 
         val initialItemIds = initialItems.map { it.id }.toSet()
-
-        val deleteItemIds = initialItemIds.filter { it !in finalItems.map { item -> item.id }.toSet() }
+        val finalItemIds = finalItems.map { it.id }.toSet()
+        val deleteItemIds = initialItemIds.filter { it !in finalItemIds }
         val createItemNames =
             finalItems
                 .filter { it.id !in initialItemIds }
@@ -97,7 +97,7 @@ class PersonalItemEditViewModel(
             UiEventType.PERSONAL_BOTTARI_ITEM_EDIT,
             mapOf(
                 "bottari_id" to currentState.bottariId.toString(),
-                "old_items" to currentState.orignalItems.toString(),
+                "old_items" to currentState.originalItems.toString(),
                 "new_items" to currentState.items.toString(),
             ),
         )
@@ -107,7 +107,7 @@ class PersonalItemEditViewModel(
         val restoredList = currentState.items + itemToRestore
 
         val originalOrderMap =
-            currentState.orignalItems
+            currentState.originalItems
                 .withIndex()
                 .associate { (index, item) -> item.id to index }
 
@@ -136,7 +136,7 @@ class PersonalItemEditViewModel(
         private const val ERROR_REQUIRE_BOTTARI_ID = "[ERROR] 보따리 ID가 없습니다"
 
         private const val DEFAULT_ITEM_ID = 0L
-        private const val ITEM_ID_INCREMENT = 1
+        private const val ITEM_ID_INCREMENT = 1L
 
         fun Factory(
             bottariId: Long,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/personal/item/PersonalItemEditViewModel.kt
@@ -34,7 +34,7 @@ class PersonalItemEditViewModel(
 
         val itemToRestore =
             currentState.initialItems.firstOrNull { originalItem ->
-                originalItem.name == itemName && currentState.items.none { it.id == originalItem.id }
+                originalItem.name == itemName && currentState.items.none { item -> item.id == originalItem.id }
             }
 
         if (itemToRestore != null) {
@@ -70,8 +70,8 @@ class PersonalItemEditViewModel(
         val deleteItemIds = initialItemIds.filterNot { it in finalItemIds }
         val createItemNames =
             finalItems
-                .filterNot { it.id in initialItemIds }
-                .map { it.name }
+                .filterNot { item -> item.id in initialItemIds }
+                .map { item -> item.name }
 
         return ItemChanges(deleteItemIds, createItemNames)
     }
@@ -113,12 +113,12 @@ class PersonalItemEditViewModel(
 
         val sortedList =
             restoredList.sortedWith(
-                compareBy { originalOrderMap[it.id] ?: Int.MAX_VALUE },
+                compareBy { item -> originalOrderMap[item.id] ?: Int.MAX_VALUE },
             )
         updateState { copy(items = sortedList) }
     }
 
-    private fun isDuplicateItem(name: String): Boolean = currentState.items.any { it.name == name }
+    private fun isDuplicateItem(name: String): Boolean = currentState.items.any { item -> item.name == name }
 
     private fun generateNewItemUiModel(name: String): BottariItemUiModel =
         BottariItemUiModel(
@@ -127,7 +127,7 @@ class PersonalItemEditViewModel(
             type = BottariItemTypeUiModel.PERSONAL,
         )
 
-    private fun nextGeneratedItemId(): Long = (currentState.items.maxOfOrNull { it.id } ?: DEFAULT_ITEM_ID) + ITEM_ID_INCREMENT
+    private fun nextGeneratedItemId(): Long = (currentState.items.maxOfOrNull { item -> item.id } ?: DEFAULT_ITEM_ID) + ITEM_ID_INCREMENT
 
     companion object {
         private const val KEY_BOTTARI_ID = "KEY_BOTTARI_ID"

--- a/android/Bottari/presentation/src/main/res/layout/activity_team_checklist.xml
+++ b/android/Bottari/presentation/src/main/res/layout/activity_team_checklist.xml
@@ -8,7 +8,7 @@
     android:theme="@style/Theme.Bottari"
     tools:context=".view.checklist.team.TeamChecklistActivity">
 
-    <androidx.appcompat.widget.Toolbar
+    <Toolbar
         android:id="@+id/toolbar_bottari"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -41,7 +41,7 @@
             android:padding="@dimen/space_small"
             android:src="@drawable/btn_swipe" />
 
-    </androidx.appcompat.widget.Toolbar>
+    </Toolbar>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fcv_team_checklist"

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_status.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_status.xml
@@ -9,7 +9,7 @@
 
     <TextView
         android:id="@+id/tv_team_bottari_item_status_title"
-        style="@style/Pretendard_Bold_24"
+        style="@style/Pretendard_Bold_22"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/space_x_large"
@@ -18,7 +18,7 @@
         app:layout_constraintEnd_toStartOf="@+id/btn_team_bottari_item_send_remind"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/btn_team_bottari_item_send_remind"
-        tools:text="이것은물건글자가열개 챙김 현황" />
+        tools:text="이것은물건글자가열다섯개입니다" />
 
     <TextView
         android:id="@+id/btn_team_bottari_item_send_remind"
@@ -29,8 +29,8 @@
         android:layout_marginEnd="@dimen/space_x_large"
         android:background="@drawable/bg_primary_radius_16dp"
         android:gravity="center"
-        android:paddingHorizontal="@dimen/space_large"
-        android:paddingVertical="@dimen/space_small"
+        android:paddingHorizontal="@dimen/space_small"
+        android:paddingVertical="@dimen/space_x_small"
         android:text="@string/team_status_send_remind_btn_text"
         android:textColor="@color/white"
         app:layout_constraintEnd_toEndOf="parent"

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_status.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_status.xml
@@ -9,15 +9,16 @@
 
     <TextView
         android:id="@+id/tv_team_bottari_item_status_title"
-        style="@style/Pretendard_Bold_28"
-        android:layout_width="wrap_content"
+        style="@style/Pretendard_Bold_24"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/space_x_large"
         android:textColor="@color/black"
         app:layout_constraintBottom_toBottomOf="@+id/btn_team_bottari_item_send_remind"
+        app:layout_constraintEnd_toStartOf="@+id/btn_team_bottari_item_send_remind"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/btn_team_bottari_item_send_remind"
-        tools:text="목걸이 챙김 현황" />
+        tools:text="이것은물건글자가열개 챙김 현황" />
 
     <TextView
         android:id="@+id/btn_team_bottari_item_send_remind"

--- a/android/Bottari/presentation/src/main/res/layout/item_checklist_mini.xml
+++ b/android/Bottari/presentation/src/main/res/layout/item_checklist_mini.xml
@@ -7,8 +7,9 @@
     android:layout_height="wrap_content"
     android:background="@drawable/bg_primary_radius_100dp"
     android:layout_marginEnd="@dimen/space_x_small"
-    android:layout_marginTop="@dimen/space_x_small"
     android:paddingHorizontal="@dimen/space_small"
+    android:layout_marginTop="4dp"
+    android:layout_marginBottom="4dp"
     android:paddingVertical="4dp">
 
     <TextView

--- a/android/Bottari/presentation/src/main/res/values/font_style.xml
+++ b/android/Bottari/presentation/src/main/res/values/font_style.xml
@@ -5,10 +5,10 @@
         <item name="android:textSize">32sp</item>
     </style>
 
-    <style name="Pretendard_Bold_24">
+    <style name="Pretendard_Bold_22">
         <item name="fontFamily">@font/pretendard</item>
         <item name="android:textFontWeight">700</item>
-        <item name="android:textSize">24sp</item>
+        <item name="android:textSize">22sp</item>
     </style>
 
     <style name="Pretendard_Bold_20">

--- a/android/Bottari/presentation/src/main/res/values/font_style.xml
+++ b/android/Bottari/presentation/src/main/res/values/font_style.xml
@@ -5,10 +5,10 @@
         <item name="android:textSize">32sp</item>
     </style>
 
-    <style name="Pretendard_Bold_28">
+    <style name="Pretendard_Bold_24">
         <item name="fontFamily">@font/pretendard</item>
         <item name="android:textFontWeight">700</item>
-        <item name="android:textSize">28sp</item>
+        <item name="android:textSize">24sp</item>
     </style>
 
     <style name="Pretendard_Bold_20">

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -292,7 +292,6 @@
 
     <!-- Team Bottari -->
     <string name="team_product_status_format">%d / %d</string>
-    <string name="team_product_status_title_format">%s 챙김 현황</string>
     <string name="team_status_fetch_failure_text">팀 보따리 현황을 불러오지 못했어요</string>
     <string name="team_status_send_remind_success_text">알람을 설정했어요</string>
     <string name="team_status_send_remind_failure_text">알람을 설정하지 못했어요</string>


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 개인 체크리스트 버그 수정 및 팀 체크리스트 레이아웃 수정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #443 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 체크리스트 삭제 및 추가 -> 최종적으로 변동 된 부분만 api 호출
- 처음 체크리스트를 저장하고 해당 체크리스트와 편집된 체크리스트를 비교해서 다를 때만 다이얼로그 노출
- 체크리스트 체크 시 디바운스 후 호출할 api 결과가 기존 결과랑 똑같을 경우 api 호출하지 않기로 수정
- 팀체크리스트 디자인에 맞게 일부 레이아웃 수정


<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
<img width="400" height="1000" alt="Screenshot_20250819_211246" src="https://github.com/user-attachments/assets/9e5f76cf-8c51-494d-aa7a-0e7ff2097075" />

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unsaved-changes detection in Personal Item Edit: the back button is disabled when edits differ from the original, preventing accidental exits.
  * Restoring items by name: re-add a previously deleted original item simply by entering its original name.
* **Bug Fixes**
  * More reliable checklist updates with selective processing, reducing unnecessary operations.
  * Improved edit flow accuracy: precise change tracking and preserved item order during saves, minimizing unintended modifications and duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->