### PR TITLE
[AN] 팀 보따리 목록 아이템 사이 간격 문제 수정

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/team/TeamBottariFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/team/TeamBottariFragment.kt
@@ -65,7 +65,9 @@ class TeamBottariFragment :
         viewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             binding.emptyView.clBottariEmptyView.isVisible = uiState.isEmpty
             toggleLoadingIndicator(uiState.isLoading)
-            adapter.submitList(uiState.bottaries)
+            adapter.submitList(uiState.bottaries) {
+                binding.rvTeamBottari.invalidateItemDecorations()
+            }
         }
 
         viewModel.uiEvent.observe(viewLifecycleOwner) { uiEvent ->


### PR DESCRIPTION
- `submitList` 콜백에서 `invalidateItemDecorations`를 호출하여 ItemDecoration이 정상적으로 적용되도록 수정합니다.

<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 목록 아이템 사이 간격 문제 수정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #456 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 팀 보따리 목록 아이템 사이 간격 문제 수정

<br>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 팀 보따리 화면에서 목록 갱신 직후 아이템 데코레이션(구분선/여백)이 즉시 재적용되도록 개선했습니다. 스크롤하거나 데이터가 업데이트될 때 구분선 겹침, 여백 불일치 등 간헐적 시각적 깨짐 현상이 해소되어 목록 표시가 안정적이고 일관되게 보입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->