### PR TITLE
[BE] 물품 보채기 알람 시, 본인 제거

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -46,7 +46,7 @@ public class TeamBottariEventListener {
     public void handleCreateTeamSharedItemEvent(final CreateTeamSharedItemEvent event) {
         final SseMessage message = new SseMessage(
                 SseResourceType.SHARED_ITEM_INFO,
-                SseEventType.CHANGE,
+                SseEventType.CREATE,
                 CreateTeamSharedItemData.from(event)
         );
         sseService.sendByTeamBottariId(event.getTeamBottariId(), message);
@@ -57,7 +57,7 @@ public class TeamBottariEventListener {
     public void handleDeleteTeamSharedItemEvent(final DeleteTeamSharedItemEvent event) {
         final SseMessage message = new SseMessage(
                 SseResourceType.SHARED_ITEM_INFO,
-                SseEventType.CHANGE,
+                SseEventType.DELETE,
                 DeleteTeamSharedItemData.from(event)
         );
         sseService.sendByTeamBottariId(event.getTeamBottariId(), message);

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
@@ -169,7 +169,7 @@ public class TeamAssignedItemService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "등록되지 않은 ssaid입니다."));
         validateMemberInTeam(info.getTeamBottari(), member);
         final List<TeamAssignedItem> items = teamAssignedItemRepository.findAllByInfoIdWithMember(infoId);
-        final List<Long> uncheckedMemberIds = collectUncheckedMemberIds(items);
+        final List<Long> uncheckedMemberIds = collectUncheckedMemberIds(member, items);
         sendRemindMessageToMembers(info, uncheckedMemberIds);
     }
 
@@ -396,9 +396,13 @@ public class TeamAssignedItemService {
         return Math.toIntExact(count);
     }
 
-    private List<Long> collectUncheckedMemberIds(final List<TeamAssignedItem> items) {
+    private List<Long> collectUncheckedMemberIds(
+            final Member member,
+            final List<TeamAssignedItem> items
+    ) {
         return items.stream()
                 .filter(item -> !item.isChecked())
+                .filter(item -> !item.isOwner(member.getSsaid()))
                 .map(this::memberIdByItem)
                 .toList();
     }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamAssignedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamAssignedItemServiceTest.java
@@ -733,22 +733,29 @@ class TeamAssignedItemServiceTest {
         void sendRemindAlarm() {
             // given
             final Member member = MemberFixture.MEMBER.get();
+            final Member antherMember = MemberFixture.ANOTHER_MEMBER.get();
             entityManager.persist(member);
+            entityManager.persist(antherMember);
 
             final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
             entityManager.persist(teamBottari);
 
             final TeamMember teamMember = new TeamMember(teamBottari, member);
+            final TeamMember anotherTeamMember = new TeamMember(teamBottari, antherMember);
             entityManager.persist(teamMember);
+            entityManager.persist(anotherTeamMember);
 
             final TeamAssignedItemInfo teamAssignedItemInfo = new TeamAssignedItemInfo("담당 물품", teamBottari);
             entityManager.persist(teamAssignedItemInfo);
 
             final TeamAssignedItem teamAssignedItem = new TeamAssignedItem(teamAssignedItemInfo, teamMember);
+            teamAssignedItem.check();
+            final TeamAssignedItem anotherMemberItem = new TeamAssignedItem(teamAssignedItemInfo, anotherTeamMember);
             entityManager.persist(teamAssignedItem);
+            entityManager.persist(anotherMemberItem);
 
             final List<Long> uncheckedMemberIds = List.of(
-                    member.getId()
+                    antherMember.getId()
             );
 
             doNothing().when(fcmMessageSender).sendMessageToMembers(eq(uncheckedMemberIds), any());

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamAssignedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamAssignedItemServiceTest.java
@@ -294,7 +294,7 @@ class TeamAssignedItemServiceTest {
             );
 
             // when
-            teamAssignedItemService.update(teamBottari.getId(), teamAssignedItem.getId(), request);
+            teamAssignedItemService.update(teamBottari.getId(), teamAssignedItemInfo.getId(), request);
             entityManager.flush();
             entityManager.clear();
 
@@ -517,7 +517,7 @@ class TeamAssignedItemServiceTest {
             entityManager.persist(teamAssignedItem);
 
             // when
-            teamAssignedItemService.delete(teamAssignedItem.getId(), member.getSsaid());
+            teamAssignedItemService.delete(teamAssignedItemInfo.getId(), member.getSsaid());
 
             // then
             final TeamAssignedItem actualItem = entityManager.find(TeamAssignedItem.class, teamAssignedItem.getId());
@@ -751,6 +751,7 @@ class TeamAssignedItemServiceTest {
             final TeamAssignedItem teamAssignedItem = new TeamAssignedItem(teamAssignedItemInfo, teamMember);
             teamAssignedItem.check();
             final TeamAssignedItem anotherMemberItem = new TeamAssignedItem(teamAssignedItemInfo, anotherTeamMember);
+            // anotherMemberItem은 체크하지 않음 (기본값이 false)
             entityManager.persist(teamAssignedItem);
             entityManager.persist(anotherMemberItem);
 

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
@@ -225,7 +225,7 @@ class TeamSharedItemServiceTest {
             entityManager.persist(teamSharedItem);
 
             // when & then
-            assertThatThrownBy(() -> teamSharedItemService.delete(teamSharedItem.getId(), anotherMember.getSsaid()))
+            assertThatThrownBy(() -> teamSharedItemService.delete(teamSharedItemInfo.getId(), anotherMember.getSsaid()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("해당 팀 보따리의 팀 멤버가 아닙니다.");
         }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
@@ -72,7 +72,8 @@ class TeamSharedItemServiceTest {
             entityManager.persist(teamSharedItem);
 
             // when
-            final List<ReadSharedItemResponse> actual = teamSharedItemService.getAllByTeamBottariId(teamBottari.getId());
+            final List<ReadSharedItemResponse> actual = teamSharedItemService.getAllByTeamBottariId(
+                    teamBottari.getId());
 
             // then
             final List<ReadSharedItemResponse> expected = List.of(
@@ -433,28 +434,35 @@ class TeamSharedItemServiceTest {
         void sendRemindAlarm() {
             // given
             final Member member = MemberFixture.MEMBER.get();
+            final Member antherMember = MemberFixture.ANOTHER_MEMBER.get();
             entityManager.persist(member);
+            entityManager.persist(antherMember);
 
             final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
             entityManager.persist(teamBottari);
 
             final TeamMember teamMember = new TeamMember(teamBottari, member);
+            final TeamMember anotherTeamMember = new TeamMember(teamBottari, antherMember);
             entityManager.persist(teamMember);
+            entityManager.persist(anotherTeamMember);
 
-            final TeamSharedItemInfo teamSharedItemInfo = new TeamSharedItemInfo("공통 물품", teamBottari);
-            entityManager.persist(teamSharedItemInfo);
+            final TeamSharedItemInfo info = new TeamSharedItemInfo("담당 물품", teamBottari);
+            entityManager.persist(info);
 
-            final TeamSharedItem teamSharedItem = new TeamSharedItem(teamSharedItemInfo, teamMember);
-            entityManager.persist(teamSharedItem);
+            final TeamSharedItem item = new TeamSharedItem(info, teamMember);
+            item.check();
+            final TeamSharedItem anotherMemberItem = new TeamSharedItem(info, anotherTeamMember);
+            entityManager.persist(item);
+            entityManager.persist(anotherMemberItem);
 
             final List<Long> uncheckedMemberIds = List.of(
-                    member.getId()
+                    antherMember.getId()
             );
 
             doNothing().when(fcmMessageSender).sendMessageToMembers(eq(uncheckedMemberIds), any());
 
             // when & then
-            assertThatCode(() -> teamSharedItemService.sendRemindAlarm(teamSharedItemInfo.getId(), member.getSsaid()))
+            assertThatCode(() -> teamSharedItemService.sendRemindAlarm(info.getId(), member.getSsaid()))
                     .doesNotThrowAnyException();
             verify(fcmMessageSender).sendMessageToMembers(eq(uncheckedMemberIds), any());
         }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 물품 보채기 알람 시, 본인 제거

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #457

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 물품 보채기 알람 시, 본인 제거
- 테스트 코드 상 info ID가 필요하지만 item ID를 사용하던 부분 수정
- 이벤트 타입 수정

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
| Before | After |
|--------|-------|
| (이전 화면) | (변경된 화면) |

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 팀 공유 물품의 실시간 알림에서 생성/삭제 이벤트가 올바른 유형으로 표시되어 피드 정확성이 향상되었습니다.
  * 담당/공유 물품 리마인더가 체크하지 않은 팀원에게만 발송되며, 소유자 본인에게는 더 이상 전송되지 않습니다.
  * 항목 업데이트/삭제 시 올바른 식별자를 사용하도록 정정해 작업 안정성과 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->