### PR TITLE
[AN] 선택적 팀원 보채기 미노출

### DIFF
--- a/android/Bottari/data/src/main/java/com/bottari/data/network/interceptor/AuthInterceptor.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/network/interceptor/AuthInterceptor.kt
@@ -20,7 +20,7 @@ class AuthInterceptor(
         return chain.proceed(newRequest)
     }
 
-    private fun getMemberIdentifier(): String? = memberIdentifierLocalDataSource.getMemberIdentifier().getOrNull()
+    private fun getMemberIdentifier(): String? = memberIdentifierLocalDataSource.getInstallationId().getOrNull()
 
     companion object {
         private const val IDENTIFIER_HEADER = "ssaid"

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -47,5 +47,5 @@ class MemberRepositoryImpl(
             memberIdentifierLocalDataSource.getMemberIdentifier()
         }
 
-    override fun getMemberId(): Result<Long> = memberIdentifierLocalDataSource.getMemberId()
+    override suspend fun getMemberId(): Result<Long> = memberIdentifierLocalDataSource.getMemberId()
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -19,7 +19,7 @@ class MemberRepositoryImpl(
 ) : MemberRepository {
     override suspend fun registerMember(fcmToken: String): Result<Long?> =
         withContext(coroutineDispatcher) {
-            memberIdentifierLocalDataSource.getMemberIdentifier()
+            memberIdentifierLocalDataSource.getInstallationId()
         }.mapCatching { memberId ->
             RegisterMemberRequest(memberId, fcmToken)
         }.mapCatching { registerMemberRequest ->
@@ -44,7 +44,7 @@ class MemberRepositoryImpl(
 
     override suspend fun getMemberIdentifier(): Result<String> =
         withContext(coroutineDispatcher) {
-            memberIdentifierLocalDataSource.getMemberIdentifier()
+            memberIdentifierLocalDataSource.getInstallationId()
         }
 
     override suspend fun getMemberId(): Result<Long> = memberIdentifierLocalDataSource.getMemberId()

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -35,19 +35,24 @@ class MemberRepositoryImpl(
         memberRemoteDataSource.saveMemberNickname(nickname.toRequest())
 
     override suspend fun checkRegisteredMember(): Result<RegisteredMember> =
-        memberRemoteDataSource
-            .checkRegisteredMember()
-            .mapCatching { it.toDomain() }
-            .onSuccess { registeredMember ->
-                if (registeredMember.isRegistered) {
-                    registeredMember.id?.let { memberIdentifierLocalDataSource.saveMemberId(it) }
+        withContext(coroutineDispatcher) {
+            memberRemoteDataSource
+                .checkRegisteredMember()
+                .mapCatching { it.toDomain() }
+                .onSuccess { registeredMember ->
+                    if (registeredMember.isRegistered) {
+                        registeredMember.id?.let { memberIdentifierLocalDataSource.saveMemberId(it) }
+                    }
                 }
-            }
+        }
 
     override suspend fun getInstallationId(): Result<String> =
         withContext(coroutineDispatcher) {
             memberIdentifierLocalDataSource.getInstallationId()
         }
 
-    override suspend fun getMemberId(): Result<Long> = memberIdentifierLocalDataSource.getMemberId()
+    override suspend fun getMemberId(): Result<Long> =
+        withContext(coroutineDispatcher) {
+            memberIdentifierLocalDataSource.getMemberId()
+        }
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -19,14 +19,16 @@ class MemberRepositoryImpl(
 ) : MemberRepository {
     override suspend fun registerMember(fcmToken: String): Result<Long?> =
         withContext(coroutineDispatcher) {
-            memberIdentifierLocalDataSource.getInstallationId()
-        }.mapCatching { memberId ->
-            RegisterMemberRequest(memberId, fcmToken)
-        }.mapCatching { registerMemberRequest ->
-            memberRemoteDataSource
-                .registerMember(registerMemberRequest)
-                .getOrThrow()
-                ?.also { memberIdentifierLocalDataSource.saveMemberId(it) }
+            memberIdentifierLocalDataSource
+                .getInstallationId()
+                .mapCatching { installationId ->
+                    RegisterMemberRequest(installationId, fcmToken)
+                }.mapCatching { request ->
+                    memberRemoteDataSource
+                        .registerMember(request)
+                        .getOrThrow()
+                        ?.also { memberIdentifierLocalDataSource.saveMemberId(it) }
+                }
         }
 
     override suspend fun saveMemberNickname(nickname: Nickname): Result<Unit> =

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -44,7 +44,7 @@ class MemberRepositoryImpl(
                 }
             }
 
-    override suspend fun getMemberIdentifier(): Result<String> =
+    override suspend fun getInstallationId(): Result<String> =
         withContext(coroutineDispatcher) {
             memberIdentifierLocalDataSource.getInstallationId()
         }

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -32,17 +32,20 @@ class MemberRepositoryImpl(
         }
 
     override suspend fun saveMemberNickname(nickname: Nickname): Result<Unit> =
-        memberRemoteDataSource.saveMemberNickname(nickname.toRequest())
+        withContext(coroutineDispatcher) {
+            memberRemoteDataSource.saveMemberNickname(nickname.toRequest())
+        }
 
     override suspend fun checkRegisteredMember(): Result<RegisteredMember> =
         withContext(coroutineDispatcher) {
             memberRemoteDataSource
                 .checkRegisteredMember()
                 .mapCatching { it.toDomain() }
-                .onSuccess { registeredMember ->
+                .mapCatching { registeredMember ->
                     if (registeredMember.isRegistered) {
                         registeredMember.id?.let { memberIdentifierLocalDataSource.saveMemberId(it) }
                     }
+                    registeredMember
                 }
         }
 

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSource.kt
@@ -1,7 +1,7 @@
 package com.bottari.data.source.local
 
 interface MemberIdentifierLocalDataSource {
-    fun getMemberIdentifier(): Result<String>
+    fun getInstallationId(): Result<String>
 
     fun saveMemberId(id: Long)
 

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSource.kt
@@ -2,4 +2,8 @@ package com.bottari.data.source.local
 
 interface MemberIdentifierLocalDataSource {
     fun getMemberIdentifier(): Result<String>
+
+    fun saveMemberId(id: Long)
+
+    fun getMemberId(): Result<Long>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSourceImpl.kt
@@ -1,10 +1,18 @@
 package com.bottari.data.source.local
 
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.installations.FirebaseInstallations
 import java.util.concurrent.TimeUnit
 
-class MemberIdentifierLocalDataSourceImpl : MemberIdentifierLocalDataSource {
+class MemberIdentifierLocalDataSourceImpl(
+    context: Context,
+) : MemberIdentifierLocalDataSource {
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences(MEMBER_IDENTIFIER_PREFERENCES, Context.MODE_PRIVATE)
+
     private var cachedMemberIdentifier: String? = null
 
     override fun getMemberIdentifier(): Result<String> =
@@ -12,5 +20,23 @@ class MemberIdentifierLocalDataSourceImpl : MemberIdentifierLocalDataSource {
             cachedMemberIdentifier ?: initialize().also { cachedMemberIdentifier = it }
         }
 
+    override fun saveMemberId(id: Long) {
+        sharedPreferences.edit { putLong(MEMBER_ID, id) }
+    }
+
+    override fun getMemberId(): Result<Long> {
+        val id = sharedPreferences.getLong(MEMBER_ID, -1)
+        return if (id == -1L) {
+            Result.failure(IllegalStateException("No member id found"))
+        } else {
+            Result.success(id)
+        }
+    }
+
     private fun initialize(): String = Tasks.await(FirebaseInstallations.getInstance().id, 10, TimeUnit.SECONDS)
+
+    companion object {
+        private const val MEMBER_IDENTIFIER_PREFERENCES = "MEMBER_IDENTIFIER_PREFERENCES"
+        private const val MEMBER_ID = "MEMBER_ID"
+    }
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSourceImpl.kt
@@ -13,11 +13,11 @@ class MemberIdentifierLocalDataSourceImpl(
     private val sharedPreferences: SharedPreferences =
         context.getSharedPreferences(MEMBER_IDENTIFIER_PREFERENCES, Context.MODE_PRIVATE)
 
-    private var cachedMemberIdentifier: String? = null
+    private var cachedInstallationId: String? = null
 
-    override fun getMemberIdentifier(): Result<String> =
+    override fun getInstallationId(): Result<String> =
         runCatching {
-            cachedMemberIdentifier ?: initialize().also { cachedMemberIdentifier = it }
+            cachedInstallationId ?: initialize().also { cachedInstallationId = it }
         }
 
     override fun saveMemberId(id: Long) {

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -45,7 +45,7 @@ class MemberRepositoryImplTest {
             val request = RegisterMemberRequest("ssaid", "token")
             coEvery { remoteDataSource.registerMember(request) } returns Result.success(1)
             coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Unit
-            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.success("ssaid")
+            coEvery { userInfoLocalDataSource.getInstallationId() } returns Result.success("ssaid")
 
             // when
             val result = repository.registerMember("token")
@@ -65,7 +65,7 @@ class MemberRepositoryImplTest {
             val request = RegisterMemberRequest("ssaid", "token")
             val exception = HttpException(Response.error<Unit>(400, errorResponseBody))
             coEvery { remoteDataSource.registerMember(request) } returns Result.failure(exception)
-            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.success("ssaid")
+            coEvery { userInfoLocalDataSource.getInstallationId() } returns Result.success("ssaid")
 
             // when
             val result = repository.registerMember("token")
@@ -183,7 +183,7 @@ class MemberRepositoryImplTest {
         runTest {
             // given
             val memberId = "test_member_id"
-            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns
+            coEvery { userInfoLocalDataSource.getInstallationId() } returns
                 Result.success(
                     memberId,
                 )
@@ -198,7 +198,7 @@ class MemberRepositoryImplTest {
             }
 
             // verify
-            coVerify(exactly = 1) { userInfoLocalDataSource.getMemberIdentifier() }
+            coVerify(exactly = 1) { userInfoLocalDataSource.getInstallationId() }
         }
 
     @DisplayName("사용자 식별자 조회를 실패하면 Failure를 반환한다")
@@ -207,7 +207,7 @@ class MemberRepositoryImplTest {
         runTest {
             // given
             val exception = Exception()
-            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.failure(exception)
+            coEvery { userInfoLocalDataSource.getInstallationId() } returns Result.failure(exception)
 
             // when
             val result = repository.getMemberIdentifier()
@@ -216,6 +216,6 @@ class MemberRepositoryImplTest {
             result.shouldBeFailure { error -> error shouldBe exception }
 
             // verify
-            coVerify(exactly = 1) { userInfoLocalDataSource.getMemberIdentifier() }
+            coVerify(exactly = 1) { userInfoLocalDataSource.getInstallationId() }
         }
 }

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -41,15 +41,19 @@ class MemberRepositoryImplTest {
     @Test
     fun registerMemberSuccessReturnsSuccess() =
         runTest {
+            // given
             val request = RegisterMemberRequest("ssaid", "token")
             coEvery { remoteDataSource.registerMember(request) } returns Result.success(1)
             coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Unit
             coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.success("ssaid")
 
+            // when
             val result = repository.registerMember("token")
 
+            // then
             result.shouldBeSuccess()
 
+            // verify
             coVerify(exactly = 1) { remoteDataSource.registerMember(request) }
         }
 
@@ -57,15 +61,19 @@ class MemberRepositoryImplTest {
     @Test
     fun registerMemberFailsReturnsFailure() =
         runTest {
+            // given
             val request = RegisterMemberRequest("ssaid", "token")
             val exception = HttpException(Response.error<Unit>(400, errorResponseBody))
             coEvery { remoteDataSource.registerMember(request) } returns Result.failure(exception)
             coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.success("ssaid")
 
+            // when
             val result = repository.registerMember("token")
 
+            // then
             result.shouldBeFailure { it shouldBe exception }
 
+            // verify
             coVerify(exactly = 1) { remoteDataSource.registerMember(request) }
         }
 
@@ -73,6 +81,7 @@ class MemberRepositoryImplTest {
     @Test
     fun saveMemberNicknameSuccess() =
         runTest {
+            // given
             val newNickname = Nickname("nickname")
             val request = SaveMemberNicknameRequest("nickname")
             coEvery {
@@ -81,10 +90,13 @@ class MemberRepositoryImplTest {
                 )
             } returns Result.success(Unit)
 
+            // when
             val result = repository.saveMemberNickname(newNickname)
 
+            // then
             result.shouldBeSuccess()
 
+            // verify
             coVerify(exactly = 1) { remoteDataSource.saveMemberNickname(request) }
         }
 
@@ -92,6 +104,7 @@ class MemberRepositoryImplTest {
     @Test
     fun saveMemberNicknameFailsReturnsFailure() =
         runTest {
+            // given
             val newNickname = Nickname("nickname")
             val request = SaveMemberNicknameRequest("nickname")
             val httpException = HttpException(Response.error<Unit>(400, errorResponseBody))
@@ -101,10 +114,13 @@ class MemberRepositoryImplTest {
                 )
             } returns Result.failure(httpException)
 
+            // when
             val result = repository.saveMemberNickname(newNickname)
 
+            // then
             result.shouldBeFailure { it shouldBe httpException }
 
+            // verify
             coVerify(exactly = 1) { remoteDataSource.saveMemberNickname(request) }
         }
 
@@ -112,6 +128,7 @@ class MemberRepositoryImplTest {
     @Test
     fun checkRegisteredMemberSuccess() =
         runTest {
+            // given
             val response = CheckRegisteredMemberResponse(true, 1, "test")
             coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Unit
             coEvery { remoteDataSource.checkRegisteredMember() } returns
@@ -119,8 +136,10 @@ class MemberRepositoryImplTest {
                     response,
                 )
 
+            // when
             val result = repository.checkRegisteredMember()
 
+            // then
             assertSoftly(result) {
                 shouldBeSuccess()
                 getOrThrow().isRegistered shouldBe true
@@ -128,6 +147,7 @@ class MemberRepositoryImplTest {
                 getOrThrow().name shouldBe "test"
             }
 
+            // verify
             coVerify(exactly = 1) { remoteDataSource.checkRegisteredMember() }
         }
 
@@ -135,14 +155,17 @@ class MemberRepositoryImplTest {
     @Test
     fun checkRegisteredMemberFailsReturnsFailure() =
         runTest {
+            // given
             val response = CheckRegisteredMemberResponse(false, 1, "test")
             coEvery { remoteDataSource.checkRegisteredMember() } returns
                 Result.success(
                     response,
                 )
 
+            // when
             val result = repository.checkRegisteredMember()
 
+            // then
             assertSoftly(result) {
                 shouldBeSuccess()
                 getOrThrow().isRegistered shouldBe false
@@ -150,6 +173,7 @@ class MemberRepositoryImplTest {
                 getOrThrow().name shouldBe "test"
             }
 
+            // verify
             coVerify(exactly = 1) { remoteDataSource.checkRegisteredMember() }
         }
 
@@ -157,19 +181,23 @@ class MemberRepositoryImplTest {
     @Test
     fun getMemberIdentifierReturnsSuccess() =
         runTest {
+            // given
             val memberId = "test_member_id"
             coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns
                 Result.success(
                     memberId,
                 )
 
+            // when
             val result = repository.getMemberIdentifier()
 
+            // then
             assertSoftly(result) {
                 shouldBeSuccess()
                 getOrThrow() shouldBe memberId
             }
 
+            // verify
             coVerify(exactly = 1) { userInfoLocalDataSource.getMemberIdentifier() }
         }
 
@@ -177,16 +205,17 @@ class MemberRepositoryImplTest {
     @Test
     fun getMemberIdentifierReturnsFailure() =
         runTest {
+            // given
             val exception = Exception()
-            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns
-                Result.failure(
-                    exception,
-                )
+            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.failure(exception)
 
+            // when
             val result = repository.getMemberIdentifier()
 
+            // then
             result.shouldBeFailure { error -> error shouldBe exception }
 
+            // verify
             coVerify(exactly = 1) { userInfoLocalDataSource.getMemberIdentifier() }
         }
 }

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -179,7 +179,7 @@ class MemberRepositoryImplTest {
 
     @DisplayName("사용자 식별자 조회를 성공하면 Success를 반환한다")
     @Test
-    fun getMemberIdentifierReturnsSuccess() =
+    fun getInstallationIdReturnsSuccess() =
         runTest {
             // given
             val memberId = "test_member_id"
@@ -189,7 +189,7 @@ class MemberRepositoryImplTest {
                 )
 
             // when
-            val result = repository.getMemberIdentifier()
+            val result = repository.getInstallationId()
 
             // then
             assertSoftly(result) {
@@ -203,14 +203,14 @@ class MemberRepositoryImplTest {
 
     @DisplayName("사용자 식별자 조회를 실패하면 Failure를 반환한다")
     @Test
-    fun getMemberIdentifierReturnsFailure() =
+    fun getInstallationIdReturnsFailure() =
         runTest {
             // given
             val exception = Exception()
             coEvery { userInfoLocalDataSource.getInstallationId() } returns Result.failure(exception)
 
             // when
-            val result = repository.getMemberIdentifier()
+            val result = repository.getInstallationId()
 
             // then
             result.shouldBeFailure { error -> error shouldBe exception }

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
@@ -44,7 +45,7 @@ class MemberRepositoryImplTest {
             // given
             val request = RegisterMemberRequest("ssaid", "token")
             coEvery { remoteDataSource.registerMember(request) } returns Result.success(1)
-            coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Unit
+            every { userInfoLocalDataSource.saveMemberId(1) } returns Unit
             coEvery { userInfoLocalDataSource.getInstallationId() } returns Result.success("ssaid")
 
             // when
@@ -130,7 +131,7 @@ class MemberRepositoryImplTest {
         runTest {
             // given
             val response = CheckRegisteredMemberResponse(true, 1, "test")
-            coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Unit
+            every { userInfoLocalDataSource.saveMemberId(1) } returns Unit
             coEvery { remoteDataSource.checkRegisteredMember() } returns
                 Result.success(
                     response,

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -41,18 +41,15 @@ class MemberRepositoryImplTest {
     @Test
     fun registerMemberSuccessReturnsSuccess() =
         runTest {
-            // given
             val request = RegisterMemberRequest("ssaid", "token")
             coEvery { remoteDataSource.registerMember(request) } returns Result.success(1)
+            coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Unit
             coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.success("ssaid")
 
-            // when
             val result = repository.registerMember("token")
 
-            // then
             result.shouldBeSuccess()
 
-            // verify
             coVerify(exactly = 1) { remoteDataSource.registerMember(request) }
         }
 
@@ -60,19 +57,15 @@ class MemberRepositoryImplTest {
     @Test
     fun registerMemberFailsReturnsFailure() =
         runTest {
-            // given
             val request = RegisterMemberRequest("ssaid", "token")
             val exception = HttpException(Response.error<Unit>(400, errorResponseBody))
             coEvery { remoteDataSource.registerMember(request) } returns Result.failure(exception)
             coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.success("ssaid")
 
-            // when
             val result = repository.registerMember("token")
 
-            // then
             result.shouldBeFailure { it shouldBe exception }
 
-            // verify
             coVerify(exactly = 1) { remoteDataSource.registerMember(request) }
         }
 
@@ -80,7 +73,6 @@ class MemberRepositoryImplTest {
     @Test
     fun saveMemberNicknameSuccess() =
         runTest {
-            // given
             val newNickname = Nickname("nickname")
             val request = SaveMemberNicknameRequest("nickname")
             coEvery {
@@ -89,13 +81,10 @@ class MemberRepositoryImplTest {
                 )
             } returns Result.success(Unit)
 
-            // when
             val result = repository.saveMemberNickname(newNickname)
 
-            // then
             result.shouldBeSuccess()
 
-            // verify
             coVerify(exactly = 1) { remoteDataSource.saveMemberNickname(request) }
         }
 
@@ -103,7 +92,6 @@ class MemberRepositoryImplTest {
     @Test
     fun saveMemberNicknameFailsReturnsFailure() =
         runTest {
-            // given
             val newNickname = Nickname("nickname")
             val request = SaveMemberNicknameRequest("nickname")
             val httpException = HttpException(Response.error<Unit>(400, errorResponseBody))
@@ -113,13 +101,10 @@ class MemberRepositoryImplTest {
                 )
             } returns Result.failure(httpException)
 
-            // when
             val result = repository.saveMemberNickname(newNickname)
 
-            // then
             result.shouldBeFailure { it shouldBe httpException }
 
-            // verify
             coVerify(exactly = 1) { remoteDataSource.saveMemberNickname(request) }
         }
 
@@ -127,17 +112,15 @@ class MemberRepositoryImplTest {
     @Test
     fun checkRegisteredMemberSuccess() =
         runTest {
-            // given
             val response = CheckRegisteredMemberResponse(true, 1, "test")
+            coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Unit
             coEvery { remoteDataSource.checkRegisteredMember() } returns
                 Result.success(
                     response,
                 )
 
-            // when
             val result = repository.checkRegisteredMember()
 
-            // then
             assertSoftly(result) {
                 shouldBeSuccess()
                 getOrThrow().isRegistered shouldBe true
@@ -145,7 +128,6 @@ class MemberRepositoryImplTest {
                 getOrThrow().name shouldBe "test"
             }
 
-            // verify
             coVerify(exactly = 1) { remoteDataSource.checkRegisteredMember() }
         }
 
@@ -153,17 +135,14 @@ class MemberRepositoryImplTest {
     @Test
     fun checkRegisteredMemberFailsReturnsFailure() =
         runTest {
-            // given
             val response = CheckRegisteredMemberResponse(false, 1, "test")
             coEvery { remoteDataSource.checkRegisteredMember() } returns
                 Result.success(
                     response,
                 )
 
-            // when
             val result = repository.checkRegisteredMember()
 
-            // then
             assertSoftly(result) {
                 shouldBeSuccess()
                 getOrThrow().isRegistered shouldBe false
@@ -171,7 +150,6 @@ class MemberRepositoryImplTest {
                 getOrThrow().name shouldBe "test"
             }
 
-            // verify
             coVerify(exactly = 1) { remoteDataSource.checkRegisteredMember() }
         }
 
@@ -179,23 +157,19 @@ class MemberRepositoryImplTest {
     @Test
     fun getMemberIdentifierReturnsSuccess() =
         runTest {
-            // given
             val memberId = "test_member_id"
             coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns
                 Result.success(
                     memberId,
                 )
 
-            // when
             val result = repository.getMemberIdentifier()
 
-            // then
             assertSoftly(result) {
                 shouldBeSuccess()
                 getOrThrow() shouldBe memberId
             }
 
-            // verify
             coVerify(exactly = 1) { userInfoLocalDataSource.getMemberIdentifier() }
         }
 
@@ -203,17 +177,16 @@ class MemberRepositoryImplTest {
     @Test
     fun getMemberIdentifierReturnsFailure() =
         runTest {
-            // given
             val exception = Exception()
-            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns Result.failure(exception)
+            coEvery { userInfoLocalDataSource.getMemberIdentifier() } returns
+                Result.failure(
+                    exception,
+                )
 
-            // when
             val result = repository.getMemberIdentifier()
 
-            // then
             result.shouldBeFailure { error -> error shouldBe exception }
 
-            // verify
             coVerify(exactly = 1) { userInfoLocalDataSource.getMemberIdentifier() }
         }
 }

--- a/android/Bottari/di/src/main/java/com/bottari/di/DataSourceProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/DataSourceProvider.kt
@@ -63,7 +63,7 @@ object DataSourceProvider {
         )
     }
     val memberIdentifierLocalDataSource: MemberIdentifierLocalDataSource by lazy {
-        MemberIdentifierLocalDataSourceImpl()
+        MemberIdentifierLocalDataSourceImpl(ApplicationContextProvider.applicationContext)
     }
     val teamBottariRemoteDataSource: TeamBottariRemoteDataSource by lazy {
         TeamBottariRemoteDataSourceImpl(

--- a/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
@@ -18,6 +18,7 @@ import com.bottari.domain.usecase.item.ResetBottariItemCheckStateUseCase
 import com.bottari.domain.usecase.item.SaveBottariItemsUseCase
 import com.bottari.domain.usecase.item.UnCheckBottariItemUseCase
 import com.bottari.domain.usecase.member.CheckRegisteredMemberUseCase
+import com.bottari.domain.usecase.member.GetMemberIdUseCase
 import com.bottari.domain.usecase.member.GetMemberIdentifierUseCase
 import com.bottari.domain.usecase.member.RegisterMemberUseCase
 import com.bottari.domain.usecase.member.SaveMemberNicknameUseCase
@@ -244,6 +245,9 @@ object UseCaseProvider {
     }
     val getMemberIdentifierUseCase: GetMemberIdentifierUseCase by lazy {
         GetMemberIdentifierUseCase(RepositoryProvider.memberRepository)
+    }
+    val getMemberIdUseCase: GetMemberIdUseCase by lazy {
+        GetMemberIdUseCase(RepositoryProvider.memberRepository)
     }
     val joinTeamBottariUseCase: JoinTeamBottariUseCase by lazy {
         JoinTeamBottariUseCase(RepositoryProvider.teamBottariRepository)

--- a/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/UseCaseProvider.kt
@@ -18,8 +18,8 @@ import com.bottari.domain.usecase.item.ResetBottariItemCheckStateUseCase
 import com.bottari.domain.usecase.item.SaveBottariItemsUseCase
 import com.bottari.domain.usecase.item.UnCheckBottariItemUseCase
 import com.bottari.domain.usecase.member.CheckRegisteredMemberUseCase
+import com.bottari.domain.usecase.member.GetInstallationIdUseCase
 import com.bottari.domain.usecase.member.GetMemberIdUseCase
-import com.bottari.domain.usecase.member.GetMemberIdentifierUseCase
 import com.bottari.domain.usecase.member.RegisterMemberUseCase
 import com.bottari.domain.usecase.member.SaveMemberNicknameUseCase
 import com.bottari.domain.usecase.notification.DeleteNotificationUseCase
@@ -243,8 +243,8 @@ object UseCaseProvider {
     val sendRemindByMemberMessageUseCase: SendRemindByMemberMessageUseCase by lazy {
         SendRemindByMemberMessageUseCase(RepositoryProvider.teamBottariRepository)
     }
-    val getMemberIdentifierUseCase: GetMemberIdentifierUseCase by lazy {
-        GetMemberIdentifierUseCase(RepositoryProvider.memberRepository)
+    val getInstallationIdUseCase: GetInstallationIdUseCase by lazy {
+        GetInstallationIdUseCase(RepositoryProvider.memberRepository)
     }
     val getMemberIdUseCase: GetMemberIdUseCase by lazy {
         GetMemberIdUseCase(RepositoryProvider.memberRepository)

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
@@ -11,4 +11,6 @@ interface MemberRepository {
     suspend fun checkRegisteredMember(): Result<RegisteredMember>
 
     suspend fun getMemberIdentifier(): Result<String>
+
+    fun getMemberId(): Result<Long>
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
@@ -10,7 +10,7 @@ interface MemberRepository {
 
     suspend fun checkRegisteredMember(): Result<RegisteredMember>
 
-    suspend fun getMemberIdentifier(): Result<String>
+    suspend fun getInstallationId(): Result<String>
 
     suspend fun getMemberId(): Result<Long>
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/repository/MemberRepository.kt
@@ -12,5 +12,5 @@ interface MemberRepository {
 
     suspend fun getMemberIdentifier(): Result<String>
 
-    fun getMemberId(): Result<Long>
+    suspend fun getMemberId(): Result<Long>
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetInstallationIdUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetInstallationIdUseCase.kt
@@ -5,5 +5,5 @@ import com.bottari.domain.repository.MemberRepository
 class GetInstallationIdUseCase(
     private val memberRepository: MemberRepository,
 ) {
-    suspend operator fun invoke(): Result<String> = memberRepository.getMemberIdentifier()
+    suspend operator fun invoke(): Result<String> = memberRepository.getInstallationId()
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetInstallationIdUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetInstallationIdUseCase.kt
@@ -2,7 +2,7 @@ package com.bottari.domain.usecase.member
 
 import com.bottari.domain.repository.MemberRepository
 
-class GetMemberIdentifierUseCase(
+class GetInstallationIdUseCase(
     private val memberRepository: MemberRepository,
 ) {
     suspend operator fun invoke(): Result<String> = memberRepository.getMemberIdentifier()

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetMemberIdUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetMemberIdUseCase.kt
@@ -5,5 +5,5 @@ import com.bottari.domain.repository.MemberRepository
 class GetMemberIdUseCase(
     private val memberRepository: MemberRepository,
 ) {
-    operator fun invoke(): Result<Long> = memberRepository.getMemberId()
+    suspend operator fun invoke(): Result<Long> = memberRepository.getMemberId()
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetMemberIdUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/member/GetMemberIdUseCase.kt
@@ -1,0 +1,9 @@
+package com.bottari.domain.usecase.member
+
+import com.bottari.domain.repository.MemberRepository
+
+class GetMemberIdUseCase(
+    private val memberRepository: MemberRepository,
+) {
+    operator fun invoke(): Result<Long> = memberRepository.getMemberId()
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/mapper/TeamMembersMapper.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/mapper/TeamMembersMapper.kt
@@ -17,13 +17,14 @@ object TeamMembersMapper {
                 }
         }
 
-    fun TeamMemberStatus.toUiModel(): TeamMemberStatusUiModel =
+    fun TeamMemberStatus.toUiModel(myId: Long): TeamMemberStatusUiModel =
         TeamMemberStatusUiModel(
             member = TeamMemberUiModel(id, nickname.value, isHost),
             totalItemsCount = totalItemsCount,
             checkedItemsCount = checkedItemsCount,
             sharedItems = sharedItems.map { sharedItem -> sharedItem.toUiModel() },
             assignedItems = assignedItems.map { assignedItem -> assignedItem.toUiModel() },
+            isMe = id == myId,
         )
 
     fun TeamMember.toUiModel(): TeamMemberUiModel = TeamMemberUiModel(memberId, nickname, false)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/TeamMemberStatusUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/TeamMemberStatusUiModel.kt
@@ -9,4 +9,5 @@ data class TeamMemberStatusUiModel(
 ) {
     val isItemsEmpty: Boolean
         get() = sharedItems.isEmpty() && assignedItems.isEmpty()
+    val isAllChecked: Boolean = checkedItemsCount == totalItemsCount
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/TeamMemberStatusUiModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/TeamMemberStatusUiModel.kt
@@ -6,6 +6,7 @@ data class TeamMemberStatusUiModel(
     val checkedItemsCount: Int,
     val sharedItems: List<ChecklistItemUiModel>,
     val assignedItems: List<ChecklistItemUiModel>,
+    val isMe: Boolean,
 ) {
     val isItemsEmpty: Boolean
         get() = sharedItems.isEmpty() && assignedItems.isEmpty()

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/TeamProductStatusItem.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/TeamProductStatusItem.kt
@@ -9,7 +9,10 @@ data class TeamBottariProductStatusUiModel(
     val checkItemsCount: Int,
     val totalItemsCount: Int,
     val type: BottariItemTypeUiModel,
-) : TeamProductStatusItem
+) : TeamProductStatusItem {
+    val isAllChecked: Boolean =
+        this.memberCheckStatus.all { memberCheckStatus -> memberCheckStatus.checked }
+}
 
 data class TeamChecklistTypeUiModel(
     val type: BottariItemTypeUiModel,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/TeamProductStatusItem.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/model/TeamProductStatusItem.kt
@@ -11,7 +11,7 @@ data class TeamBottariProductStatusUiModel(
     val type: BottariItemTypeUiModel,
 ) : TeamProductStatusItem {
     val isAllChecked: Boolean =
-        this.memberCheckStatus.all { memberCheckStatus -> memberCheckStatus.checked }
+        memberCheckStatus.isNotEmpty() && memberCheckStatus.all { it.checked }
 }
 
 data class TeamChecklistTypeUiModel(

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusFragment.kt
@@ -32,11 +32,6 @@ class TeamMembersStatusFragment :
         setupUI()
     }
 
-    override fun onStart() {
-        super.onStart()
-        viewModel.fetchTeamMembersStatus()
-    }
-
     override fun onClickSendRemind(member: TeamMemberUiModel) {
         viewModel.sendRemindMessage(member)
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusFragment.kt
@@ -61,6 +61,9 @@ class TeamMembersStatusFragment :
 
                 TeamMembersStatusUiEvent.SendRemindByMemberMessageFailure ->
                     requireView().showSnackbar(R.string.team_members_status_send_remind_message_failure_text)
+
+                TeamMembersStatusUiEvent.FetchMemberIdFailure ->
+                    requireView().showSnackbar(R.string.team_members_status_fetch_member_id_failure_text)
             }
         }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusUiEvent.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusUiEvent.kt
@@ -8,4 +8,6 @@ interface TeamMembersStatusUiEvent {
     ) : TeamMembersStatusUiEvent
 
     data object SendRemindByMemberMessageFailure : TeamMembersStatusUiEvent
+
+    data object FetchMemberIdFailure : TeamMembersStatusUiEvent
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusUiState.kt
@@ -5,4 +5,5 @@ import com.bottari.presentation.model.TeamMemberStatusUiModel
 data class TeamMembersStatusUiState(
     val isLoading: Boolean = false,
     val membersStatus: List<TeamMemberStatusUiModel> = emptyList(),
+    val myId: Long = -1L,
 )

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusUiState.kt
@@ -5,5 +5,5 @@ import com.bottari.presentation.model.TeamMemberStatusUiModel
 data class TeamMembersStatusUiState(
     val isLoading: Boolean = false,
     val membersStatus: List<TeamMemberStatusUiModel> = emptyList(),
-    val myId: Long = -1L,
+    val myId: Long? = null,
 )

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusUiState.kt
@@ -5,5 +5,5 @@ import com.bottari.presentation.model.TeamMemberStatusUiModel
 data class TeamMembersStatusUiState(
     val isLoading: Boolean = false,
     val membersStatus: List<TeamMemberStatusUiModel> = emptyList(),
-    val myId: Long? = null,
+    val myId: Long = -1L,
 )

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusViewModel.kt
@@ -29,7 +29,7 @@ class TeamMembersStatusViewModel(
     }
 
     private fun fetchTeamMembersStatus() {
-        val myId = currentState.myId ?: return
+        val myId = currentState.myId
         updateState { copy(isLoading = true) }
         launch {
             fetchTeamMembersStatusUseCase(teamBottariId)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusViewModel.kt
@@ -34,14 +34,10 @@ class TeamMembersStatusViewModel(
         launch {
             fetchTeamMembersStatusUseCase(teamBottariId)
                 .onSuccess { membersStatus ->
+                    val memberStatusUiModel = membersStatus.map { status -> status.toUiModel(myId) }
                     updateState {
                         copy(
-                            membersStatus =
-                                membersStatus.map { memberStatus ->
-                                    memberStatus.toUiModel(
-                                        myId,
-                                    )
-                                },
+                            membersStatus = memberStatusUiModel,
                         )
                     }
                 }.onFailure { emitEvent(TeamMembersStatusUiEvent.FetchMembersStatusFailure) }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/TeamMembersStatusViewModel.kt
@@ -29,10 +29,7 @@ class TeamMembersStatusViewModel(
     }
 
     fun fetchTeamMembersStatus() {
-        val myId =
-            currentState.myId.takeIf { it > 0 }
-                ?: getMemberIdUseCase().getOrNull()
-                ?: -1L
+        val myId = currentState.myId ?: return
         updateState { copy(isLoading = true) }
         launch {
             fetchTeamMembersStatusUseCase(teamBottariId)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/adapter/TeamMemberStatusViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/adapter/TeamMemberStatusViewHolder.kt
@@ -27,7 +27,8 @@ class TeamMemberStatusViewHolder private constructor(
             currentStatus?.let { status ->
                 binding.btnHurryUpAlert.isVisible =
                     binding.groupItems.isVisible &&
-                    status.isAllChecked.not()
+                    status.isAllChecked.not() &&
+                    currentStatus?.isMe?.not() ?: false
             }
         }
         binding.btnHurryUpAlert.setOnClickListener {
@@ -45,6 +46,7 @@ class TeamMemberStatusViewHolder private constructor(
         handleItemsCountStatus(status)
         sharedItemAdapter.submitList(status.sharedItems)
         assignedItemAdapter.submitList(status.assignedItems)
+        binding.btnHurryUpAlert.isVisible = status.isMe.not()
     }
 
     private fun handleItemsCountStatus(status: TeamMemberStatusUiModel) {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/adapter/TeamMemberStatusViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/adapter/TeamMemberStatusViewHolder.kt
@@ -19,21 +19,26 @@ class TeamMemberStatusViewHolder private constructor(
 ) : RecyclerView.ViewHolder(binding.root) {
     private val sharedItemAdapter: SharedItemAdapter by lazy { SharedItemAdapter() }
     private val assignedItemAdapter: AssignedItemAdapter by lazy { AssignedItemAdapter() }
-    private var member: TeamMemberUiModel? = null
+    private var currentStatus: TeamMemberStatusUiModel? = null
 
     init {
         itemView.setOnClickListener {
             binding.groupItems.apply { isVisible = !isVisible }
+            currentStatus?.let { status ->
+                binding.btnHurryUpAlert.isVisible =
+                    binding.groupItems.isVisible &&
+                    status.isAllChecked.not()
+            }
         }
         binding.btnHurryUpAlert.setOnClickListener {
-            member?.let(onSendRemindClickListener::onClickSendRemind)
+            currentStatus?.member?.let(onSendRemindClickListener::onClickSendRemind)
         }
         setupSharedItems()
         setupAssignedItems()
     }
 
     fun bind(status: TeamMemberStatusUiModel) {
-        member = status.member
+        currentStatus = status
         itemView.isClickable = status.isItemsEmpty.not()
         binding.tvMemberNickname.text = status.member.nickname
         binding.ivTeamHost.isVisible = status.member.isHost

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/adapter/TeamMemberStatusViewHolder.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/member/adapter/TeamMemberStatusViewHolder.kt
@@ -25,10 +25,7 @@ class TeamMemberStatusViewHolder private constructor(
         itemView.setOnClickListener {
             binding.groupItems.apply { isVisible = !isVisible }
             currentStatus?.let { status ->
-                binding.btnHurryUpAlert.isVisible =
-                    binding.groupItems.isVisible &&
-                    status.isAllChecked.not() &&
-                    currentStatus?.isMe?.not() ?: false
+                handleHurryUp(status.isAllChecked, status.isMe)
             }
         }
         binding.btnHurryUpAlert.setOnClickListener {
@@ -46,7 +43,7 @@ class TeamMemberStatusViewHolder private constructor(
         handleItemsCountStatus(status)
         sharedItemAdapter.submitList(status.sharedItems)
         assignedItemAdapter.submitList(status.assignedItems)
-        binding.btnHurryUpAlert.isVisible = status.isMe.not()
+        handleHurryUp(status.isAllChecked, status.isMe)
     }
 
     private fun handleItemsCountStatus(status: TeamMemberStatusUiModel) {
@@ -61,6 +58,16 @@ class TeamMemberStatusViewHolder private constructor(
                 status.checkedItemsCount,
                 status.totalItemsCount,
             )
+    }
+
+    private fun handleHurryUp(
+        isAllChecked: Boolean,
+        isMe: Boolean,
+    ) {
+        binding.btnHurryUpAlert.isVisible =
+            binding.groupItems.isVisible &&
+            isAllChecked.not() &&
+            isMe.not()
     }
 
     private fun setupSharedItems() {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusFragment.kt
@@ -3,6 +3,7 @@ package com.bottari.presentation.view.checklist.team.main.status
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bottari.presentation.R
@@ -45,6 +46,8 @@ class TeamBottariStatusFragment :
 
     private fun setupObserver() {
         viewModel.uiState.observe(viewLifecycleOwner) { state ->
+            binding.btnTeamBottariItemSendRemind.isVisible =
+                state.selectedProduct?.isAllChecked?.not() ?: false
             teamBottariProductStatusDetailAdapter.submitList(state.selectedProduct?.memberCheckStatus)
             binding.tvTeamBottariItemStatusTitle.text = state.selectedProduct?.name ?: ""
             teamBottariProductStatusAdapter.submitList(state.teamChecklistItems)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusFragment.kt
@@ -53,7 +53,7 @@ class TeamBottariStatusFragment :
             when (event) {
                 TeamBottariStatusUiEvent.FetchTeamBottariStatusFailure ->
                     requireView().showSnackbar(
-                        R.string.team_status_fetch_failure_text,
+                        R.string.team_product_status_fetch_failure_text,
                     )
                 TeamBottariStatusUiEvent.SendRemindSuccess -> requireView().showSnackbar(R.string.team_status_send_remind_success_text)
                 TeamBottariStatusUiEvent.SendRemindFailure -> requireView().showSnackbar(R.string.team_status_send_remind_failure_text)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusFragment.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusFragment.kt
@@ -46,7 +46,7 @@ class TeamBottariStatusFragment :
 
     private fun setupObserver() {
         viewModel.uiState.observe(viewLifecycleOwner) { state ->
-            binding.btnTeamBottariItemSendRemind.isVisible =
+            binding.btnTeamBottariItemSendHurryUp.isVisible =
                 state.selectedProduct?.isAllChecked?.not() ?: false
             teamBottariProductStatusDetailAdapter.submitList(state.selectedProduct?.memberCheckStatus)
             binding.tvTeamBottariItemStatusTitle.text = state.selectedProduct?.name ?: ""
@@ -77,7 +77,7 @@ class TeamBottariStatusFragment :
     }
 
     private fun setupListener() {
-        binding.btnTeamBottariItemSendRemind.setOnClickListener {
+        binding.btnTeamBottariItemSendHurryUp.setOnClickListener {
             viewModel.sendRemindByItem()
         }
     }

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_status.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_status.xml
@@ -22,7 +22,7 @@
         tools:text="이것은물건글자가열다섯개입니다" />
 
     <TextView
-        android:id="@+id/btn_team_bottari_item_send_remind"
+        android:id="@+id/btn_team_bottari_item_send_hurry_up"
         style="@style/Pretendard_Medium_20"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android/Bottari/presentation/src/main/res/layout/fragment_team_status.xml
+++ b/android/Bottari/presentation/src/main/res/layout/fragment_team_status.xml
@@ -13,11 +13,12 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/space_x_large"
+        android:layout_marginTop="@dimen/space_x_large"
         android:textColor="@color/black"
-        app:layout_constraintBottom_toBottomOf="@+id/btn_team_bottari_item_send_remind"
-        app:layout_constraintEnd_toStartOf="@+id/btn_team_bottari_item_send_remind"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/btn_team_bottari_item_send_remind"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="이것은물건글자가열다섯개입니다" />
 
     <TextView
@@ -40,7 +41,7 @@
         android:id="@+id/rv_team_bottari_item_status_detail"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="@dimen/space_x_large"
         android:layout_marginEnd="@dimen/space_x_large"
         android:background="@drawable/bg_white_radius_12dp"
         android:elevation="2dp"
@@ -49,7 +50,7 @@
         android:paddingVertical="@dimen/space_small"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/tv_team_bottari_item_status_title"
-        app:layout_constraintTop_toBottomOf="@+id/btn_team_bottari_item_send_remind"
+        app:layout_constraintTop_toBottomOf="@+id/tv_team_bottari_item_status_title"
         tools:listitem="@layout/item_checklist_mini" />
 
     <androidx.recyclerview.widget.RecyclerView

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -207,7 +207,7 @@
 
     <!-- Team Bottari -->
     <string name="team_checklist_tap_checklist_text">체크리스트</string>
-    <string name="team_checklist_tap_team_current_text">팀 보따리 현황</string>
+    <string name="team_checklist_tap_team_current_text">물건 현황</string>
     <string name="team_checklist_tap_member_checklist_text">멤버 현황</string>
 
     <!-- Bottari Item Type -->
@@ -298,7 +298,7 @@
 
     <!-- Team Bottari -->
     <string name="team_product_status_format">%d / %d</string>
-    <string name="team_status_fetch_failure_text">팀 보따리 현황을 불러오지 못했어요</string>
+    <string name="team_product_status_fetch_failure_text">물건 현황을 불러오지 못했어요</string>
     <string name="team_status_send_remind_success_text">알람을 설정했어요</string>
     <string name="team_status_send_remind_failure_text">알람을 설정하지 못했어요</string>
     <string name="team_status_send_remind_btn_text">보채기</string>

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="team_members_status_fetch_failure_text">팀원 현황을 조회하는데 실패했어요</string>
     <string name="team_members_status_send_remind_message_success_text">%s에게 알림을 전송했어요</string>
     <string name="team_members_status_send_remind_message_failure_text">보채기에 실패했어요</string>
+    <string name="team_members_status_fetch_member_id_failure_text">내 아이디 불러오기에 실패했어요</string>
 
     <!-- Alarm Edit -->
     <string name="alarm_edit_title_text">알람 설정</string>


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀원이 다 챙긴 경우 / 나 자신인 경우 보채기 미노출

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #461 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
-

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
| Before | After |
|--------|-------|
| (이전 화면) | (변경된 화면) |

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 기기 설치 ID(getInstallationId)와 로컬 멤버 ID(getMemberId/saveMemberId) 기반의 멤버 식별 API를 추가해 뷰모델에서 개인 식별 정보를 활용할 수 있게 했습니다.
  * 팀 멤버 UI 모델에 ‘나’ 여부(isMe)와 항목 전체 체크 여부(isAllChecked)를 추가했습니다.

* **UI/스타일**
  * 선택된 상품이 모두 체크되지 않았을 때만 ‘빠른 알림(허리업)’ 버튼을 노출하도록 개선했습니다.
  * 탭 타이틀·간격·배치·오류 문구를 업데이트하고, 멤버 ID 조회 실패 시 스낵바 알림을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->