### PR TITLE
[BE] 팀 보따리 나가기 기능 추가

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
@@ -61,6 +61,10 @@ public interface TeamBottariApiDocs {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "팀 보따리 생성 성공"),
     })
+    @ApiErrorCodes({
+            ErrorCode.TEAM_BOTTARI_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI
+    })
     ResponseEntity<Void> exit(
             final Long id,
             @Parameter(hidden = true) final String ssaid

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
@@ -59,9 +59,10 @@ public interface TeamBottariApiDocs {
 
     @Operation(summary = "팀 보따리 나가기")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "팀 보따리 생성 성공"),
+            @ApiResponse(responseCode = "204", description = "팀 보따리 생성 성공"),
     })
     @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
             ErrorCode.TEAM_BOTTARI_NOT_FOUND,
             ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI
     })

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariApiDocs.java
@@ -1,5 +1,6 @@
 package com.bottari.teambottari.controller;
 
+import com.bottari.config.MemberIdentifier;
 import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
 import com.bottari.teambottari.dto.CreateTeamBottariRequest;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Team Bottari", description = "팀 보따리 API")
 public interface TeamBottariApiDocs {
@@ -52,6 +54,15 @@ public interface TeamBottariApiDocs {
     })
     ResponseEntity<Void> create(
             final CreateTeamBottariRequest request,
+            @Parameter(hidden = true) final String ssaid
+    );
+
+    @Operation(summary = "팀 보따리 나가기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "팀 보따리 생성 성공"),
+    })
+    ResponseEntity<Void> exit(
+            final Long id,
             @Parameter(hidden = true) final String ssaid
     );
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariController.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/controller/TeamBottariController.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,5 +54,16 @@ public class TeamBottariController implements TeamBottariApiDocs {
         final Long id = teamBottariService.create(ssaid, request);
 
         return ResponseEntity.created(URI.create("/team-bottaries/" + id)).build();
+    }
+
+    @DeleteMapping("/{id}")
+    @Override
+    public ResponseEntity<Void> exit(
+            @PathVariable final Long id,
+            @MemberIdentifier final String ssaid
+    ) {
+        teamBottariService.exit(id,ssaid);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItemInfo.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItemInfo.java
@@ -1,6 +1,7 @@
 package com.bottari.teambottari.domain;
 
 import com.bottari.vo.ItemName;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
@@ -13,10 +14,12 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@SQLRestriction("deleted_at IS NULL")
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -34,6 +37,9 @@ public class TeamAssignedItemInfo {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     public TeamAssignedItemInfo(
             final String name,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamBottari.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamBottari.java
@@ -15,11 +15,15 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE team_bottari SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TeamBottari {
@@ -40,6 +44,9 @@ public class TeamBottari {
     @CreatedDate
     private LocalDateTime createdAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public TeamBottari(
             final String title,
             final Member owner,
@@ -48,6 +55,14 @@ public class TeamBottari {
         this.title = new BottariTitle(title);
         this.owner = owner;
         this.inviteCode = inviteCode;
+    }
+
+    public boolean isOwner(final Member member) {
+        return owner.equals(member);
+    }
+
+    public void changeOwner(final Member member) {
+        owner = member;
     }
 
     public String getTitle() {

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamMember.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamMember.java
@@ -1,18 +1,28 @@
 package com.bottari.teambottari.domain;
 
 import com.bottari.member.domain.Member;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE team_member SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TeamMember {
@@ -28,6 +38,12 @@ public class TeamMember {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     public TeamMember(
             final TeamBottari teamBottari,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItem.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItem.java
@@ -2,6 +2,7 @@ package com.bottari.teambottari.domain;
 
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,12 +10,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 public class TeamSharedItem {
 
@@ -31,6 +35,9 @@ public class TeamSharedItem {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_member_id")
     private TeamMember teamMember;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     public TeamSharedItem(
             final TeamSharedItemInfo info,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
@@ -26,7 +26,7 @@ public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamAssign
             final String name
     );
 
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("""
         UPDATE TeamAssignedItemInfo tai
         SET tai.deletedAt = CURRENT_TIMESTAMP 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
@@ -26,12 +26,11 @@ public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamAssign
             final String name
     );
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
-        UPDATE TeamAssignedItemInfo tai
-        SET tai.deletedAt = CURRENT_TIMESTAMP 
-        WHERE tai.id in :ids
-        """
-    )
+            UPDATE TeamAssignedItemInfo tai
+            SET tai.deletedAt = CURRENT_TIMESTAMP 
+            WHERE tai.id in :ids
+            """)
     void deleteByInfoIds(final List<Long> ids);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
@@ -3,6 +3,7 @@ package com.bottari.teambottari.repository;
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamAssignedItemInfo, Long> {
@@ -24,4 +25,13 @@ public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamAssign
             final Long teamBottariId,
             final String name
     );
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+        UPDATE TeamAssignedItemInfo tai
+        SET tai.deletedAt = CURRENT_TIMESTAMP 
+        WHERE tai.id in :ids
+        """
+    )
+    void deleteByInfoIds(final List<Long> ids);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
@@ -28,10 +28,15 @@ public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamAssign
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
-            UPDATE TeamAssignedItemInfo tai
-            SET tai.deletedAt = CURRENT_TIMESTAMP 
-            WHERE tai.id in :ids
-            AND tai.deletedAt IS NULL
-            """)
-    void deleteByInfoIds(final List<Long> ids);
+        UPDATE TeamAssignedItemInfo taii
+        SET taii.deletedAt = CURRENT_TIMESTAMP
+        WHERE taii IN (
+                SELECT taii_sub
+                FROM TeamAssignedItemInfo taii_sub
+                LEFT JOIN TeamAssignedItem tai ON tai.info = taii_sub
+                WHERE tai.id IS NULL
+                  AND taii_sub.teamBottari.id = :teamBottariId
+        )
+        """)
+    void deleteOrphanAssignedItemInfosByTeamBottariId(final Long teamBottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
@@ -31,6 +31,7 @@ public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamAssign
             UPDATE TeamAssignedItemInfo tai
             SET tai.deletedAt = CURRENT_TIMESTAMP 
             WHERE tai.id in :ids
+            AND tai.deletedAt IS NULL
             """)
     void deleteByInfoIds(final List<Long> ids);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -48,6 +48,7 @@ public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedIt
         UPDATE TeamAssignedItem tai
         SET tai.deletedAt = CURRENT_TIMESTAMP
         WHERE tai.teamMember.id = :teamMemberId
+        AND tai.deletedAt IS NULL
         """
     )
     void deleteByTeamMemberId(final Long teamMemberId);

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -43,7 +43,7 @@ public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedIt
 
     void deleteAllByInfo(final TeamAssignedItemInfo teamAssignedItemInfo);
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
         UPDATE TeamAssignedItem tai
         SET tai.deletedAt = CURRENT_TIMESTAMP

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -6,6 +6,7 @@ import com.bottari.teambottari.domain.TeamMember;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedItem, Long> {
@@ -38,7 +39,18 @@ public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedIt
             """)
     List<TeamAssignedItem> findAllByTeamMemberId(final Long teamMemberId);
 
+    boolean existsByInfoId(final Long infoId);
+
     void deleteAllByInfo(final TeamAssignedItemInfo teamAssignedItemInfo);
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+        UPDATE TeamAssignedItem tai
+        SET tai.deletedAt = CURRENT_TIMESTAMP
+        WHERE tai.teamMember.id = :teamMemberId
+        """
+    )
+    void deleteByTeamMemberId(final Long teamMemberId);
 
     @Query("""
             SELECT tai

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -43,7 +43,7 @@ public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedIt
 
     void deleteAllByInfo(final TeamAssignedItemInfo teamAssignedItemInfo);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("""
         UPDATE TeamAssignedItem tai
         SET tai.deletedAt = CURRENT_TIMESTAMP

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
@@ -3,8 +3,18 @@ package com.bottari.teambottari.repository;
 import com.bottari.teambottari.domain.TeamBottari;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TeamBottariRepository extends JpaRepository<TeamBottari, Long> {
 
     Optional<TeamBottari> findByInviteCode(final String inviteCode);
+
+    @Modifying
+    @Query("""
+        UPDATE TeamBottari tb
+        SET tb.deletedAt = CURRENT_TIMESTAMP
+        WHERE tb.id = :id
+    """)
+    void deleteById(final Long id);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
@@ -15,6 +15,7 @@ public interface TeamBottariRepository extends JpaRepository<TeamBottari, Long> 
             UPDATE TeamBottari tb
             SET tb.deletedAt = CURRENT_TIMESTAMP
             WHERE tb.id = :id
+            AND tb.deletedAt IS NULL
             """)
     void deleteById(final Long id);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamBottariRepository.java
@@ -10,11 +10,11 @@ public interface TeamBottariRepository extends JpaRepository<TeamBottari, Long> 
 
     Optional<TeamBottari> findByInviteCode(final String inviteCode);
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
-        UPDATE TeamBottari tb
-        SET tb.deletedAt = CURRENT_TIMESTAMP
-        WHERE tb.id = :id
-    """)
+            UPDATE TeamBottari tb
+            SET tb.deletedAt = CURRENT_TIMESTAMP
+            WHERE tb.id = :id
+            """)
     void deleteById(final Long id);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -61,6 +61,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             UPDATE TeamMember tm
             SET tm.deletedAt = CURRENT_TIMESTAMP
             WHERE tm.id = :id
+            AND tm.deletedAt IS NULL
             """)
     void deleteById(final Long id);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -6,6 +6,7 @@ import com.bottari.teambottari.repository.dto.TeamBottariMemberCountProjection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
@@ -54,4 +55,12 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             final Long teamBottariId,
             final List<Long> memberIds
     );
+
+    @Modifying
+    @Query("""
+        UPDATE TeamMember tm
+        SET tm.deletedAt = CURRENT_TIMESTAMP
+        WHERE tm.id = :id
+    """)
+    void deleteById(final Long id);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamMemberRepository.java
@@ -56,11 +56,11 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
             final List<Long> memberIds
     );
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
-        UPDATE TeamMember tm
-        SET tm.deletedAt = CURRENT_TIMESTAMP
-        WHERE tm.id = :id
-    """)
+            UPDATE TeamMember tm
+            SET tm.deletedAt = CURRENT_TIMESTAMP
+            WHERE tm.id = :id
+            """)
     void deleteById(final Long id);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
@@ -35,7 +35,7 @@ public interface TeamPersonalItemRepository extends JpaRepository<TeamPersonalIt
             final Long memberId
     );
 
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("""
             UPDATE TeamPersonalItem tpi
             SET tpi.deletedAt = CURRENT_TIMESTAMP

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
@@ -40,6 +40,7 @@ public interface TeamPersonalItemRepository extends JpaRepository<TeamPersonalIt
             UPDATE TeamPersonalItem tpi
             SET tpi.deletedAt = CURRENT_TIMESTAMP
             WHERE tpi.teamMember.id = :teamMemberId
+            AND tpi.deletedAt IS NULL
             """)
     void deleteByTeamMemberId(final Long teamMemberId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
@@ -35,7 +35,7 @@ public interface TeamPersonalItemRepository extends JpaRepository<TeamPersonalIt
             final Long memberId
     );
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             UPDATE TeamPersonalItem tpi
             SET tpi.deletedAt = CURRENT_TIMESTAMP

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamPersonalItemRepository.java
@@ -4,6 +4,7 @@ import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamPersonalItem;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamPersonalItemRepository extends JpaRepository<TeamPersonalItem, Long> {
@@ -33,4 +34,12 @@ public interface TeamPersonalItemRepository extends JpaRepository<TeamPersonalIt
             final Long teamBottariId,
             final Long memberId
     );
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            UPDATE TeamPersonalItem tpi
+            SET tpi.deletedAt = CURRENT_TIMESTAMP
+            WHERE tpi.teamMember.id = :teamMemberId
+            """)
+    void deleteByTeamMemberId(final Long teamMemberId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
@@ -26,11 +26,11 @@ public interface TeamSharedItemInfoRepository extends JpaRepository<TeamSharedIt
             final String name
     );
 
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("""
         UPDATE TeamSharedItemInfo tsi
         SET tsi.deletedAt = CURRENT_TIMESTAMP 
         WHERE tsi.teamBottari.id = :teamBottariId
         """)
-    void deleteByTeamBottariId();
+    void deleteByTeamBottariId(final Long teamBottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
@@ -3,6 +3,7 @@ package com.bottari.teambottari.repository;
 import com.bottari.teambottari.domain.TeamSharedItemInfo;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamSharedItemInfoRepository extends JpaRepository<TeamSharedItemInfo, Long> {
@@ -24,4 +25,12 @@ public interface TeamSharedItemInfoRepository extends JpaRepository<TeamSharedIt
             final Long teamBottariId,
             final String name
     );
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+        UPDATE TeamSharedItemInfo tsi
+        SET tsi.deletedAt = CURRENT_TIMESTAMP 
+        WHERE tsi.teamBottari.id = :teamBottariId
+        """)
+    void deleteByTeamBottariId();
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
@@ -31,6 +31,7 @@ public interface TeamSharedItemInfoRepository extends JpaRepository<TeamSharedIt
             UPDATE TeamSharedItemInfo tsi
             SET tsi.deletedAt = CURRENT_TIMESTAMP 
             WHERE tsi.teamBottari.id = :teamBottariId
+            AND tsi.deletedAt IS NULL
             """)
     void deleteByTeamBottariId(final Long teamBottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
@@ -29,7 +29,7 @@ public interface TeamSharedItemInfoRepository extends JpaRepository<TeamSharedIt
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             UPDATE TeamSharedItemInfo tsi
-            SET tsi.deletedAt = CURRENT_TIMESTAMP 
+            SET tsi.deletedAt = CURRENT_TIMESTAMP
             WHERE tsi.teamBottari.id = :teamBottariId
             AND tsi.deletedAt IS NULL
             """)

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemInfoRepository.java
@@ -26,11 +26,11 @@ public interface TeamSharedItemInfoRepository extends JpaRepository<TeamSharedIt
             final String name
     );
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
-        UPDATE TeamSharedItemInfo tsi
-        SET tsi.deletedAt = CURRENT_TIMESTAMP 
-        WHERE tsi.teamBottari.id = :teamBottariId
-        """)
+            UPDATE TeamSharedItemInfo tsi
+            SET tsi.deletedAt = CURRENT_TIMESTAMP 
+            WHERE tsi.teamBottari.id = :teamBottariId
+            """)
     void deleteByTeamBottariId(final Long teamBottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -46,6 +46,7 @@ public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, 
             UPDATE TeamSharedItem tsi
             SET tsi.deletedAt = CURRENT_TIMESTAMP
             WHERE tsi.teamMember.id = :teamMemberId
+            AND tsi.deletedAt IS NULL
             """)
     void deleteByTeamMemberId(final Long teamMemberId);
 

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -41,7 +41,7 @@ public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, 
 
     void deleteAllByInfo(final TeamSharedItemInfo teamSharedItemInfo);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("""
             UPDATE TeamSharedItem tsi
             SET tsi.deletedAt = CURRENT_TIMESTAMP

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -41,7 +41,7 @@ public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, 
 
     void deleteAllByInfo(final TeamSharedItemInfo teamSharedItemInfo);
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             UPDATE TeamSharedItem tsi
             SET tsi.deletedAt = CURRENT_TIMESTAMP

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -6,6 +6,7 @@ import com.bottari.teambottari.domain.TeamSharedItemInfo;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, Long> {
@@ -39,6 +40,14 @@ public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, 
     List<TeamSharedItem> findAllByTeamMemberId(final Long teamMemberId);
 
     void deleteAllByInfo(final TeamSharedItemInfo teamSharedItemInfo);
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            UPDATE TeamSharedItem tsi
+            SET tsi.deletedAt = CURRENT_TIMESTAMP
+            WHERE tsi.teamMember.id = :teamMemberId
+            """)
+    void deleteByTeamMemberId(final Long teamMemberId);
 
     @Query("""
             SELECT tsi

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
@@ -149,7 +149,9 @@ public class TeamBottariService {
                 toDelete.add(info.getId());
             }
         }
-        teamAssignedItemInfoRepository.deleteByInfoIds(toDelete);
+        if (!toDelete.isEmpty()) {
+            teamAssignedItemInfoRepository.deleteByInfoIds(toDelete);
+        }
     }
 
     private Member getMemberBySsaid(final String ssaid) {

--- a/backend/bottari/src/main/resources/data.sql
+++ b/backend/bottari/src/main/resources/data.sql
@@ -215,16 +215,16 @@ VALUES
     ('방벨로의 출장 준비', 2, 'team-2-invite-code', '2024-07-12 10:05:00');
 
 -- 팀 멤버 데이터
-INSERT INTO team_member (team_bottari_id, member_id)
+INSERT INTO team_member (team_bottari_id, member_id, created_at)
 VALUES
     -- '다이스의 첫 여행 준비' (team_bottari_id: 1) -> team_member_id: 1, 2, 3
-    (1, 1), -- owner
-    (1, 2),
-    (1, 3),
+    (1, 1,'2024-01-10 10:00:00'), -- owner
+    (1, 2,'2024-01-10 12:00:00'),
+    (1, 3,'2024-01-10 11:00:00'),
     -- '방벨로의 출장 준비' (team_bottari_id: 2) -> team_member_id: 4, 5, 6
-    (2, 2), -- owner
-    (2, 1),
-    (2, 5);
+    (2, 2,'2024-01-10 10:00:00'), -- owner
+    (2, 1,'2024-01-10 10:00:00'),
+    (2, 5,'2024-01-10 10:00:00');
 
 -- 팀 공유 아이템 정보 (team_shared_item_info)
 INSERT INTO team_shared_item_info (team_bottari_id, name, created_at)

--- a/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamBottariTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamBottariTest.java
@@ -9,14 +9,11 @@ import com.bottari.member.domain.Member;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@TestInstance(Lifecycle.PER_CLASS)
 class TeamBottariTest {
 
     @DisplayName("팀 보따리 제목이 공백인 경우, 예외를 던진다.")

--- a/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamBottariTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/domain/TeamBottariTest.java
@@ -1,14 +1,22 @@
 package com.bottari.teambottari.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.bottari.error.BusinessException;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.member.domain.Member;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@TestInstance(Lifecycle.PER_CLASS)
 class TeamBottariTest {
 
     @DisplayName("팀 보따리 제목이 공백인 경우, 예외를 던진다.")
@@ -35,5 +43,46 @@ class TeamBottariTest {
         assertThatThrownBy(() -> new TeamBottari(title, member, "inviteCode"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("보따리 제목이 너무 깁니다. - 최대 15자까지 입력 가능합니다.");
+    }
+
+    @DisplayName("팀 보따리의 주인인지 판단한다.")
+    @ParameterizedTest
+    @MethodSource
+    void isOwner(
+            final Member owner,
+            final Member member,
+            final boolean expected
+    ) {
+        // given
+        final TeamBottari teamBottari = new TeamBottari("title", owner, "inviteCode");
+
+        // when
+        final boolean actual = teamBottari.isOwner(member);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> isOwner() {
+        return Stream.of(
+                Arguments.of(new Member("ssaid", "name"), new Member("ssaid", "name"), true),
+                Arguments.of(new Member("ssaid", "name"), new Member("ssaid2", "name2"), false)
+        );
+    }
+
+    @DisplayName("팀 보따리의 주인을 교체한다.")
+    @Test
+    void changeOwner() {
+        // given
+        final Member beforeOwner = new Member("ssaid", "exOwner");
+        final Member afterOwner = new Member("ssaid2", "afterOwner");
+
+        final TeamBottari teamBottari = new TeamBottari("title", beforeOwner, "inviteCode");
+
+        // when
+        teamBottari.changeOwner(afterOwner);
+
+        //then
+        assertThat(teamBottari.getOwner().getName()).isEqualTo(afterOwner.getName());
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamBottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamBottariServiceTest.java
@@ -164,11 +164,11 @@ class TeamBottariServiceTest {
                     teamBottari.getTitle(),
                     List.of(
                             // 공통 물품이더라도 하나만 포함
-                            new TeamItem(sharedItem.getId(), sharedItem.getInfo().getName())
+                            new TeamItem(sharedItemInfo.getId(), sharedItem.getInfo().getName())
                     ),
                     List.of(
                             // 다른 사람에게 할당된 assigned item 포함
-                            new TeamItem(assignedItem.getId(), assignedItem.getInfo().getName())
+                            new TeamItem(assignedItemInfo.getId(), assignedItem.getInfo().getName())
                     ),
                     List.of(
                             // 본인에게 할당된 personal item 포함, 다른 사람의 personal item 제외

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamBottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamBottariServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.bottari.config.JpaAuditingConfig;
 import com.bottari.error.BusinessException;
 import com.bottari.fixture.MemberFixture;
+import com.bottari.fixture.TeamBottariFixture;
 import com.bottari.member.domain.Member;
 import com.bottari.teambottari.domain.TeamAssignedItem;
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;
@@ -319,6 +320,510 @@ class TeamBottariServiceTest {
             assertThatThrownBy(() -> teamBottariService.create(nonExistentSsaid, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("사용자를 찾을 수 없습니다. - 등록되지 않은 ssaid입니다.");
+        }
+    }
+
+    @Nested
+    class exitTest {
+
+        @DisplayName("팀 보따리 탈퇴 시, 본인의 개인 물품들을 삭제한다.")
+        @Test
+        void exit_DeletePersonalItems() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(otherMember);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember);
+            entityManager.persist(teamMember2);
+
+            final TeamPersonalItem personalItem = new TeamPersonalItem("personalItem1", teamMember1);
+            entityManager.persist(personalItem);
+            final TeamPersonalItem otherPersonalItem = new TeamPersonalItem("personalItem2", teamMember2);
+            entityManager.persist(otherPersonalItem);
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamPersonalItem actualMemberPersonalItem = (TeamPersonalItem) entityManager.createNativeQuery(
+                    """
+                     SELECT * 
+                     FROM team_personal_item
+                     WHERE id = :id
+                     """, TeamPersonalItem.class)
+                    .setParameter("id", personalItem.getId())
+                    .getSingleResult();
+            final TeamPersonalItem actualOtherMemberPersonalItem = (TeamPersonalItem) entityManager.createNativeQuery(
+                    """
+                      SELECT * 
+                      FROM team_personal_item
+                      WHERE id = :id
+                      """, TeamPersonalItem.class)
+                    .setParameter("id", otherPersonalItem.getId())
+                    .getSingleResult();
+
+            assertThat(actualMemberPersonalItem.getDeletedAt()).isNotNull();
+            assertThat(actualOtherMemberPersonalItem.getDeletedAt()).isNull();
+        }
+
+        @DisplayName("팀 보따리 탈퇴 시, 본인의 공통 물품들을 삭제한다.")
+        @Test
+        void exit_DeleteSharedItems() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(otherMember);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember);
+            entityManager.persist(teamMember2);
+
+            final TeamSharedItemInfo teamSharedItemInfo = new TeamSharedItemInfo("sharedItem", teamBottari);
+            entityManager.persist(teamSharedItemInfo);
+
+            final TeamSharedItem sharedItem = new TeamSharedItem(teamSharedItemInfo, teamMember1);
+            entityManager.persist(sharedItem);
+            final TeamSharedItem otherSharedItem = new TeamSharedItem(teamSharedItemInfo, teamMember2);
+            entityManager.persist(otherSharedItem);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamSharedItem actualMemberSharedItem = (TeamSharedItem) entityManager.createNativeQuery(
+                     """
+                     SELECT * 
+                     FROM team_shared_item
+                     WHERE id = :id
+                     """, TeamSharedItem.class)
+                    .setParameter("id", sharedItem.getId())
+                    .getSingleResult();
+            final TeamSharedItem actualOtherMemberSharedItem = (TeamSharedItem) entityManager.createNativeQuery(
+                            """
+                                        SELECT * 
+                                        FROM team_shared_item
+                                        WHERE id = :id
+                                    """, TeamSharedItem.class)
+                    .setParameter("id", otherSharedItem.getId())
+                    .getSingleResult();
+
+            assertThat(actualMemberSharedItem.getDeletedAt()).isNotNull();
+            assertThat(actualOtherMemberSharedItem.getDeletedAt()).isNull();
+        }
+
+        @DisplayName("팀 보따리 탈퇴 시, 본인의 담당 물품들을 삭제한다.")
+        @Test
+        void exit_DeleteAssignedItems() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(otherMember);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember);
+            entityManager.persist(teamMember2);
+
+            final TeamAssignedItemInfo teamAssignedItemInfo = new TeamAssignedItemInfo("assignedInfo", teamBottari);
+            entityManager.persist(teamAssignedItemInfo);
+
+            final TeamAssignedItem assignedItem = new TeamAssignedItem(teamAssignedItemInfo, teamMember1);
+            entityManager.persist(assignedItem);
+            final TeamAssignedItem otherAssignedItem = new TeamAssignedItem(teamAssignedItemInfo, teamMember2);
+            entityManager.persist(otherAssignedItem);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamAssignedItem actualMemberAssignedItem = (TeamAssignedItem) entityManager.createNativeQuery(
+                   """
+                    SELECT * 
+                    FROM team_assigned_item
+                    WHERE id = :id
+                    """, TeamAssignedItem.class)
+                    .setParameter("id", assignedItem.getId())
+                    .getSingleResult();
+            final TeamAssignedItem actualOtherMemberAssignedItem = (TeamAssignedItem) entityManager.createNativeQuery(
+                            """
+                                        SELECT * 
+                                        FROM team_assigned_item
+                                        WHERE id = :id
+                                    """, TeamAssignedItem.class)
+                    .setParameter("id", otherAssignedItem.getId())
+                    .getSingleResult();
+
+            assertThat(actualMemberAssignedItem.getDeletedAt()).isNotNull();
+            assertThat(actualOtherMemberAssignedItem.getDeletedAt()).isNull();
+        }
+
+        @DisplayName("본인의 담당 물품들을 삭제 후, 해당 물품에 대해 담당하는 사람이 없을 경우 정보를 삭제한다.")
+        @Test
+        void exit_DeleteAssignedItemsInfo() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(otherMember);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember);
+            entityManager.persist(teamMember2);
+
+            final TeamAssignedItemInfo teamAssignedItemInfo1 = new TeamAssignedItemInfo("assignedInfo1", teamBottari);
+            entityManager.persist(teamAssignedItemInfo1);
+            final TeamAssignedItemInfo teamAssignedItemInfo2 = new TeamAssignedItemInfo("assignedInfo2", teamBottari);
+            entityManager.persist(teamAssignedItemInfo2);
+
+            final TeamAssignedItem assignedItem = new TeamAssignedItem(teamAssignedItemInfo1, teamMember1);
+            entityManager.persist(assignedItem);
+            final TeamAssignedItem otherAssignedItem = new TeamAssignedItem(teamAssignedItemInfo1, teamMember2);
+            entityManager.persist(otherAssignedItem);
+            final TeamAssignedItem assignedItem2 = new TeamAssignedItem(teamAssignedItemInfo2, teamMember1);
+            entityManager.persist(assignedItem2);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamAssignedItemInfo actualAssignedItemInfo1 = (TeamAssignedItemInfo) entityManager.createNativeQuery(
+                    """
+                    SELECT * 
+                    FROM team_assigned_item_info
+                    WHERE id = :id
+                    """, TeamAssignedItemInfo.class)
+                    .setParameter("id", teamAssignedItemInfo1.getId())
+                    .getSingleResult();
+            final TeamAssignedItemInfo actualAssignedItemInfo2 = (TeamAssignedItemInfo) entityManager.createNativeQuery(
+                    """
+                    SELECT * 
+                    FROM team_assigned_item_info
+                    WHERE id = :id
+                    """, TeamAssignedItemInfo.class)
+                    .setParameter("id", teamAssignedItemInfo2.getId())
+                    .getSingleResult();
+
+            assertThat(actualAssignedItemInfo1.getDeletedAt()).isNull();
+            assertThat(actualAssignedItemInfo2.getDeletedAt()).isNotNull();
+        }
+
+        @DisplayName("팀 보따리 탈퇴 시, 자신이 팀 보따리 주인인 경우 남은 인원 중 보따리에 들어온 순으로 주인을 넘긴다.")
+        @Test
+        void exit_ChangeOwner() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember1 = new Member("ssaid2", "member2");
+            entityManager.persist(otherMember1);
+            final Member otherMember2 = new Member("ssaid3", "member3");
+            entityManager.persist(otherMember2);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember1);
+            entityManager.persist(teamMember2);
+            final TeamMember teamMember3 = new TeamMember(teamBottari, otherMember2);
+            entityManager.persist(teamMember3);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            assertThat(teamBottari.getOwner().getId()).isEqualTo(otherMember1.getId());
+        }
+
+        @DisplayName("자신이 팀 보따리 주인이 아니고 남은 인원이 있는 경우, 팀 보따리 주인은 그대로 유지된다.")
+        @Test
+        void exit_NotChangeOwner() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember1 = new Member("ssaid2", "member2");
+            entityManager.persist(otherMember1);
+            final Member otherMember2 = new Member("ssaid3", "member3");
+            entityManager.persist(otherMember2);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember1);
+            entityManager.persist(teamMember2);
+            final TeamMember teamMember3 = new TeamMember(teamBottari, otherMember2);
+            entityManager.persist(teamMember3);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), otherMember1.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            assertThat(teamBottari.getOwner().getId()).isEqualTo(member.getId());
+        }
+
+        @DisplayName("팀 보따리 탈퇴 시, 팀 정보에서 삭제된다.")
+        @Test
+        void exit_DeleteTeamMember() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(otherMember);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember);
+            entityManager.persist(teamMember2);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), otherMember.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamMember actualTeamMember1 = (TeamMember) entityManager.createNativeQuery(
+                    """
+                     SELECT * 
+                     FROM team_member
+                     WHERE id = :id
+                     """, TeamMember.class)
+                    .setParameter("id", teamMember1.getId())
+                    .getSingleResult();
+            final TeamMember actualTeamMember2 = (TeamMember) entityManager.createNativeQuery(
+                            """
+                                        SELECT * 
+                                        FROM team_member
+                                        WHERE id = :id
+                                    """, TeamMember.class)
+                    .setParameter("id", teamMember2.getId())
+                    .getSingleResult();
+            assertThat(actualTeamMember1.getDeletedAt()).isNull();
+            assertThat(actualTeamMember2.getDeletedAt()).isNotNull();
+        }
+
+        @DisplayName("팀 보따리 탈퇴 시, 남은 인원이 없는 경우 공동 물품 정보를 모두 삭제한다.")
+        @Test
+        void exit_DeleteSharedItemInfo() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            final TeamSharedItemInfo teamSharedItemInfo1 = new TeamSharedItemInfo("sharedItemInfo", teamBottari);
+            entityManager.persist(teamSharedItemInfo1);
+            final TeamSharedItemInfo teamSharedItemInfo2 = new TeamSharedItemInfo("sharedItemInfo", teamBottari);
+            entityManager.persist(teamSharedItemInfo2);
+
+            final TeamSharedItem teamSharedItem1 = new TeamSharedItem(teamSharedItemInfo1, teamMember);
+            entityManager.persist(teamSharedItem1);
+            final TeamSharedItem teamSharedItem2 = new TeamSharedItem(teamSharedItemInfo2, teamMember);
+            entityManager.persist(teamSharedItem2);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamSharedItemInfo actualTeamSharedItemInfo1 = (TeamSharedItemInfo) entityManager.createNativeQuery(
+                    """
+                     SELECT * 
+                     FROM team_shared_item_info
+                     WHERE id = :id
+                     """, TeamSharedItemInfo.class)
+                    .setParameter("id", teamSharedItemInfo1.getId())
+                    .getSingleResult();
+            final TeamSharedItemInfo actualTeamSharedItemInfo2 = (TeamSharedItemInfo) entityManager.createNativeQuery(
+                   """
+                    SELECT * 
+                    FROM team_shared_item_info
+                    WHERE id = :id
+                    """, TeamSharedItemInfo.class)
+                    .setParameter("id", teamSharedItemInfo2.getId())
+                    .getSingleResult();
+            assertThat(actualTeamSharedItemInfo1.getDeletedAt()).isNotNull();
+            assertThat(actualTeamSharedItemInfo2.getDeletedAt()).isNotNull();
+        }
+
+        @DisplayName("팀 보따리 탈퇴 시, 남은 인원이 있는 경우 공동 물품 정보는 유지된다.")
+        @Test
+        void exit_NotDeleteSharedItemInfo() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(otherMember);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember);
+            entityManager.persist(teamMember2);
+
+            final TeamSharedItemInfo teamSharedItemInfo = new TeamSharedItemInfo("sharedItemInfo", teamBottari);
+            entityManager.persist(teamSharedItemInfo);
+
+            final TeamSharedItem teamSharedItem1 = new TeamSharedItem(teamSharedItemInfo, teamMember1);
+            entityManager.persist(teamSharedItem1);
+            final TeamSharedItem teamSharedItem2 = new TeamSharedItem(teamSharedItemInfo, teamMember2);
+            entityManager.persist(teamSharedItem2);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamSharedItemInfo actualTeamSharedItemInfo = (TeamSharedItemInfo) entityManager.createNativeQuery(
+                    """
+                     SELECT * 
+                     FROM team_shared_item_info
+                     WHERE id = :id
+                     """, TeamSharedItemInfo.class)
+                    .setParameter("id", teamSharedItemInfo.getId())
+                    .getSingleResult();
+            assertThat(actualTeamSharedItemInfo.getDeletedAt()).isNull();
+        }
+
+        @DisplayName("팀 보따리 탈퇴 시, 남은 인원이 없는 경우 팀 보따리를 삭제한다.")
+        @Test
+        void exit_DeleteTeamBottari() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamBottari actualTeamBottari = (TeamBottari) entityManager.createNativeQuery(
+                     """
+                     SELECT * 
+                     FROM team_bottari
+                     WHERE id = :id
+                     """, TeamBottari.class)
+                    .setParameter("id", teamBottari.getId())
+                    .getSingleResult();
+            assertThat(actualTeamBottari.getDeletedAt()).isNotNull();
+        }
+
+        @DisplayName("팀 보따리 탈퇴 시, 남은 인원이 있는 경우 팀 보따리를 삭제하지 않는다.")
+        @Test
+        void exit_NotDeleteTeamBottari() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final Member otherMember = MemberFixture.ANOTHER_MEMBER.get();
+            entityManager.persist(otherMember);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            final TeamMember teamMember1 = new TeamMember(teamBottari, member);
+            entityManager.persist(teamMember1);
+            final TeamMember teamMember2 = new TeamMember(teamBottari, otherMember);
+            entityManager.persist(teamMember2);
+
+            // when
+            teamBottariService.exit(teamBottari.getId(), member.getSsaid());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final TeamBottari actualTeamBottari = (TeamBottari) entityManager.createNativeQuery(
+                    """
+                      SELECT * 
+                      FROM team_bottari
+                      WHERE id = :id
+                      """, TeamBottari.class)
+                    .setParameter("id", teamBottari.getId())
+                    .getSingleResult();
+            assertThat(actualTeamBottari.getDeletedAt()).isNull();
+        }
+
+        @DisplayName("팀 보따리 삭제 시, 팀 보따리가 존재하지 않은 경우 예외가 발생한다.")
+        @Test
+        void exit_Exception_NotExistTeamBottari() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final Long invalidTeamBottariId = 1L;
+
+            // when & then
+            assertThatThrownBy(() -> teamBottariService.exit(invalidTeamBottariId, member.getSsaid()))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("팀 보따리를 찾을 수 없습니다.");
+        }
+
+        @DisplayName("팀 보따리 삭제 시, 해당 팀에 속하지 않은 경우 예외가 발생한다.")
+        @Test
+        void exit_Exception_NotInTeam() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+
+            final TeamBottari teamBottari = TeamBottariFixture.TEAM_BOTTARI.get(member);
+            entityManager.persist(teamBottari);
+
+            // when & then
+            assertThatThrownBy(() -> teamBottariService.exit(teamBottari.getId(), member.getSsaid()))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 팀 보따리의 팀 멤버가 아닙니다.");
         }
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 나가기 기능 추가

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #458 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
# 도메인 Soft Delete

팀 보따리 나갈 때는 Soft Delete로 하였음. 만약 사용자가 실수로 나가고 복구 혹은 확인 하기 위함

### TeamAssignedInfo

- `LocalDateTime deletedAt;` 필드 추가
- `@SQLRestriction("deleted_at IS NULL")` 추가
- 팀 보따리가 아닌 개인적으로 편집을 하는 경우 Hard Delete를 함. 팀 보따리 나갈 때는 Soft Delete

### TeamSharedItem

- `LocalDateTime deletedAt;` 필드 추가
- `@SQLRestriction("deleted_at IS NULL")` 추가

그 외 아이템과 아이템 정보들은 이미 deleteAt 및 Soft Delete가 이미 적용됨

### TeamBottari

- `LocalDateTime deletedAt;` 필드 추가
- `@SQLRestriction("deleted_at IS NULL")` 추가
- `@SQLDelete(sql = "UPDATE team_bottari SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")` 추가
- 팀 보따리는 무조건 Soft Delete → 개인 보따리와 같은 이유

### TeamMember

- `LocalDateTime deletedAt;` 필드 추가
- `@SQLRestriction("deleted_at IS NULL")` 추가
- `@SQLDelete(sql = "UPDATE team_bottari SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")` 추가
- TeamMember도 무조건 Soft Delete → 현재는 없는 로직이지만, 다시 재입장이 불가 혹은 다시 들어왔을 때 기존 물품 복구 등 이전 기록이 활용 될 수 있을거 같음!

# 전체적인 흐름
1. 개인 물품들 삭제
2. 공유 물품들 삭제
3. 담당 물품들 삭제
4. 자신만 담당하는 물품은 물품 정보까지 삭제
5. 자신이 보따리 주인이고, 팀원이 남아있다면 주인 권한 넘기기
6. 팀 정보 삭제
7. 본인이 마지막 팀원인 경우
    - 공유 물품 삭제
    - 팀 보따리 삭제
## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
이전 테스트 잘못 작성된 부분도 고쳤습니다 😊
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 팀 보따리 탈퇴 기능 추가: 사용자가 팀에서 나갈 수 있습니다.
  * 소유자 탈퇴 시 생성 순서 기준으로 소유권 자동 이전.
  * 마지막 구성원 탈퇴 시 팀 및 관련 공유 정보 자동 정리.
  * 탈퇴 시 해당 사용자의 개인/공유/할당 항목이 정리되어 다른 구성원 데이터는 유지됩니다.
* **잡일(데이터/마이그레이션)**
  * 데이터 시드에 생성일(created_at) 정보 추가 및 삭제 처리(soft-delete) 반영.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->