### PR TITLE
[AN] FCM Token 갱신 시점 변경

### DIFF
--- a/android/Bottari/data/src/main/java/com/bottari/data/local/MemberInfoDataStore.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/local/MemberInfoDataStore.kt
@@ -1,0 +1,31 @@
+package com.bottari.data.local
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+
+class MemberInfoDataStore(
+    private val context: Context,
+) {
+    private val Context.dataStore by preferencesDataStore(name = DATASTORE_NAME)
+    private val keyMemberId = longPreferencesKey(KEY_MEMBER_ID)
+
+    suspend fun saveMemberId(memberId: Long) {
+        context.dataStore.edit { prefs ->
+            prefs[keyMemberId] = memberId
+        }
+    }
+
+    suspend fun getMemberId(): Long {
+        val prefs = context.dataStore.data.first()
+        return requireNotNull(prefs[keyMemberId]) { ERROR_MEMBER_ID_NULL }
+    }
+
+    companion object {
+        private const val DATASTORE_NAME = "user_info"
+        private const val KEY_MEMBER_ID = "KEY_MEMBER_ID"
+        private const val ERROR_MEMBER_ID_NULL = "[ERROR] 회원 ID가 null 입니다"
+    }
+}

--- a/android/Bottari/data/src/main/java/com/bottari/data/local/MemberInfoDataStore.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/local/MemberInfoDataStore.kt
@@ -12,16 +12,19 @@ class MemberInfoDataStore(
     private val Context.dataStore by preferencesDataStore(name = DATASTORE_NAME)
     private val keyMemberId = longPreferencesKey(KEY_MEMBER_ID)
 
-    suspend fun saveMemberId(memberId: Long) {
-        context.dataStore.edit { prefs ->
-            prefs[keyMemberId] = memberId
+    suspend fun saveMemberId(memberId: Long): Result<Unit> =
+        runCatching {
+            context.dataStore.edit { prefs ->
+                prefs[keyMemberId] = memberId
+            }
         }
-    }
 
-    suspend fun getMemberId(): Long {
-        val prefs = context.dataStore.data.first()
-        return requireNotNull(prefs[keyMemberId]) { ERROR_MEMBER_ID_NULL }
-    }
+    suspend fun getMemberId(): Result<Long> =
+        runCatching {
+            val prefs = context.dataStore.data.first()
+            val memberId = prefs[keyMemberId]
+            requireNotNull(memberId) { ERROR_MEMBER_ID_NULL }
+        }
 
     companion object {
         private const val DATASTORE_NAME = "user_info"

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/FcmRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/FcmRepositoryImpl.kt
@@ -1,11 +1,17 @@
 package com.bottari.data.repository
 
 import com.bottari.data.model.fcm.SaveFcmTokenRequest
+import com.bottari.data.source.local.MemberIdentifierLocalDataSource
 import com.bottari.data.source.remote.FcmRemoteDataSource
+import com.bottari.domain.extension.flatMapCatching
 import com.bottari.domain.repository.FcmRepository
 
 class FcmRepositoryImpl(
     private val fcmRemoteDataSource: FcmRemoteDataSource,
+    private val memberIdentifierLocalDataSource: MemberIdentifierLocalDataSource,
 ) : FcmRepository {
-    override suspend fun saveFcmToken(fcmToken: String): Result<Unit> = fcmRemoteDataSource.saveFcmToken(SaveFcmTokenRequest(fcmToken))
+    override suspend fun saveFcmToken(fcmToken: String): Result<Unit> =
+        memberIdentifierLocalDataSource
+            .getMemberId()
+            .flatMapCatching { fcmRemoteDataSource.saveFcmToken(SaveFcmTokenRequest(fcmToken)) }
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -42,7 +42,11 @@ class MemberRepositoryImpl(
             .checkRegisteredMember()
             .mapCatching { checkInfo -> checkInfo.toDomain() }
             .flatMapCatching { registeredMember ->
-                if (registeredMember.isRegistered.not()) return@flatMapCatching Result.success(registeredMember)
+                if (registeredMember.isRegistered.not()) {
+                    return@flatMapCatching Result.success(
+                        registeredMember,
+                    )
+                }
                 saveMemberIdToLocal(registeredMember.id).map { registeredMember }
             }
 
@@ -66,8 +70,10 @@ class MemberRepositoryImpl(
     private fun saveMemberIdToLocal(memberId: Long?): Result<Long> =
         runCatching {
             requireNotNull(memberId) { ERROR_MEMBER_ID_NULL }
-            memberIdentifierLocalDataSource.saveMemberId(memberId)
-            memberId
+            memberIdentifierLocalDataSource
+                .saveMemberId(memberId)
+                .map { memberId }
+                .getOrThrow()
         }
 
     companion object {

--- a/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/repository/MemberRepositoryImpl.kt
@@ -67,7 +67,7 @@ class MemberRepositoryImpl(
             .checkRegisteredMember()
             .flatMapCatching { checkInfo -> saveMemberIdToLocal(checkInfo.id) }
 
-    private fun saveMemberIdToLocal(memberId: Long?): Result<Long> =
+    private suspend fun saveMemberIdToLocal(memberId: Long?): Result<Long> =
         runCatching {
             requireNotNull(memberId) { ERROR_MEMBER_ID_NULL }
             memberIdentifierLocalDataSource

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSource.kt
@@ -3,7 +3,7 @@ package com.bottari.data.source.local
 interface MemberIdentifierLocalDataSource {
     fun getInstallationId(): Result<String>
 
-    fun saveMemberId(id: Long)
+    fun saveMemberId(id: Long): Result<Unit>
 
     fun getMemberId(): Result<Long>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSource.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSource.kt
@@ -3,7 +3,7 @@ package com.bottari.data.source.local
 interface MemberIdentifierLocalDataSource {
     fun getInstallationId(): Result<String>
 
-    fun saveMemberId(id: Long): Result<Unit>
+    suspend fun saveMemberId(id: Long): Result<Unit>
 
-    fun getMemberId(): Result<Long>
+    suspend fun getMemberId(): Result<Long>
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSourceImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/source/local/MemberIdentifierLocalDataSourceImpl.kt
@@ -15,16 +15,9 @@ class MemberIdentifierLocalDataSourceImpl(
             cachedInstallationId ?: initialize().also { cachedInstallationId = it }
         }
 
-    override suspend fun saveMemberId(id: Long): Result<Unit> = runCatching { memberInfoDataStore.saveMemberId(id) }
+    override suspend fun saveMemberId(id: Long): Result<Unit> = memberInfoDataStore.saveMemberId(id)
 
-    override suspend fun getMemberId(): Result<Long> =
-        runCatching {
-            requireNotNull(memberInfoDataStore.getMemberId()) { ERROR_MEMBER_ID_NULL }
-        }
+    override suspend fun getMemberId(): Result<Long> = memberInfoDataStore.getMemberId()
 
     private fun initialize(): String = Tasks.await(FirebaseInstallations.getInstance().id, 10, TimeUnit.SECONDS)
-
-    companion object {
-        private const val ERROR_MEMBER_ID_NULL = "[ERROR] 회원 ID가 null 입니다"
-    }
 }

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/FcmRepositoryTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/FcmRepositoryTest.kt
@@ -9,7 +9,6 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
@@ -32,7 +31,7 @@ class FcmRepositoryTest {
         dataSource = mockk<FcmRemoteDataSource>()
         localDataSource = mockk<MemberIdentifierLocalDataSource>()
         repository = FcmRepositoryImpl(dataSource, localDataSource)
-        every { localDataSource.getMemberId() } returns Result.success(1)
+        coEvery { localDataSource.getMemberId() } returns Result.success(1)
     }
 
     @DisplayName("FCM 토큰 저장에 성공하는 경우 Success를 반환한다")

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/FcmRepositoryTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/FcmRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.bottari.data.repository
 
 import com.bottari.data.model.fcm.SaveFcmTokenRequest
+import com.bottari.data.source.local.MemberIdentifierLocalDataSource
 import com.bottari.data.source.remote.FcmRemoteDataSource
 import com.bottari.domain.repository.FcmRepository
 import io.kotest.matchers.result.shouldBeFailure
@@ -8,6 +9,7 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
@@ -20,6 +22,7 @@ import retrofit2.Response
 
 class FcmRepositoryTest {
     private lateinit var dataSource: FcmRemoteDataSource
+    private lateinit var localDataSource: MemberIdentifierLocalDataSource
     private lateinit var repository: FcmRepository
     private val errorResponseBody =
         """{"message":"FCM 토큰 정보가 존재하지 않습니다."}""".toResponseBody("application/json".toMediaType())
@@ -27,7 +30,9 @@ class FcmRepositoryTest {
     @BeforeEach
     fun setUp() {
         dataSource = mockk<FcmRemoteDataSource>()
-        repository = FcmRepositoryImpl(dataSource)
+        localDataSource = mockk<MemberIdentifierLocalDataSource>()
+        repository = FcmRepositoryImpl(dataSource, localDataSource)
+        every { localDataSource.getMemberId() } returns Result.success(1)
     }
 
     @DisplayName("FCM 토큰 저장에 성공하는 경우 Success를 반환한다")

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -13,7 +13,6 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
@@ -46,7 +45,7 @@ class MemberRepositoryImplTest {
             val request = RegisterMemberRequest("ssaid", "token")
             coEvery { remoteDataSource.registerMember(request) } returns Result.success(1)
             coEvery { userInfoLocalDataSource.getInstallationId() } returns Result.success("ssaid")
-            every { userInfoLocalDataSource.saveMemberId(1) } returns Result.success(Unit)
+            coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Result.success(Unit)
 
             // when
             val result = repository.registerMember("token")
@@ -125,7 +124,7 @@ class MemberRepositoryImplTest {
             // given
             val response = CheckRegisteredMemberResponse(true, 1, "test")
             coEvery { remoteDataSource.checkRegisteredMember() } returns Result.success(response)
-            every { userInfoLocalDataSource.saveMemberId(1) } returns Result.success(Unit)
+            coEvery { userInfoLocalDataSource.saveMemberId(1) } returns Result.success(Unit)
 
             // when
             val result = repository.checkRegisteredMember()

--- a/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
+++ b/android/Bottari/data/src/test/java/com/bottari/data/repository/MemberRepositoryImplTest.kt
@@ -45,8 +45,8 @@ class MemberRepositoryImplTest {
             // given
             val request = RegisterMemberRequest("ssaid", "token")
             coEvery { remoteDataSource.registerMember(request) } returns Result.success(1)
-            every { userInfoLocalDataSource.saveMemberId(1) } returns Unit
             coEvery { userInfoLocalDataSource.getInstallationId() } returns Result.success("ssaid")
+            every { userInfoLocalDataSource.saveMemberId(1) } returns Result.success(Unit)
 
             // when
             val result = repository.registerMember("token")
@@ -85,11 +85,7 @@ class MemberRepositoryImplTest {
             // given
             val newNickname = Nickname("nickname")
             val request = SaveMemberNicknameRequest("nickname")
-            coEvery {
-                remoteDataSource.saveMemberNickname(
-                    request,
-                )
-            } returns Result.success(Unit)
+            coEvery { remoteDataSource.saveMemberNickname(request) } returns Result.success(Unit)
 
             // when
             val result = repository.saveMemberNickname(newNickname)
@@ -109,11 +105,8 @@ class MemberRepositoryImplTest {
             val newNickname = Nickname("nickname")
             val request = SaveMemberNicknameRequest("nickname")
             val httpException = HttpException(Response.error<Unit>(400, errorResponseBody))
-            coEvery {
-                remoteDataSource.saveMemberNickname(
-                    request,
-                )
-            } returns Result.failure(httpException)
+            coEvery { remoteDataSource.saveMemberNickname(request) } returns
+                Result.failure(httpException)
 
             // when
             val result = repository.saveMemberNickname(newNickname)
@@ -131,11 +124,8 @@ class MemberRepositoryImplTest {
         runTest {
             // given
             val response = CheckRegisteredMemberResponse(true, 1, "test")
-            every { userInfoLocalDataSource.saveMemberId(1) } returns Unit
-            coEvery { remoteDataSource.checkRegisteredMember() } returns
-                Result.success(
-                    response,
-                )
+            coEvery { remoteDataSource.checkRegisteredMember() } returns Result.success(response)
+            every { userInfoLocalDataSource.saveMemberId(1) } returns Result.success(Unit)
 
             // when
             val result = repository.checkRegisteredMember()
@@ -158,10 +148,7 @@ class MemberRepositoryImplTest {
         runTest {
             // given
             val response = CheckRegisteredMemberResponse(false, 1, "test")
-            coEvery { remoteDataSource.checkRegisteredMember() } returns
-                Result.success(
-                    response,
-                )
+            coEvery { remoteDataSource.checkRegisteredMember() } returns Result.success(response)
 
             // when
             val result = repository.checkRegisteredMember()
@@ -184,10 +171,7 @@ class MemberRepositoryImplTest {
         runTest {
             // given
             val memberId = "test_member_id"
-            coEvery { userInfoLocalDataSource.getInstallationId() } returns
-                Result.success(
-                    memberId,
-                )
+            coEvery { userInfoLocalDataSource.getInstallationId() } returns Result.success(memberId)
 
             // when
             val result = repository.getInstallationId()

--- a/android/Bottari/di/src/main/java/com/bottari/di/DataSourceProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/DataSourceProvider.kt
@@ -68,7 +68,7 @@ object DataSourceProvider {
         )
     }
     val memberIdentifierLocalDataSource: MemberIdentifierLocalDataSource by lazy {
-        MemberIdentifierLocalDataSourceImpl(ApplicationContextProvider.applicationContext)
+        MemberIdentifierLocalDataSourceImpl()
     }
     val teamBottariRemoteDataSource: TeamBottariRemoteDataSource by lazy {
         TeamBottariRemoteDataSourceImpl(

--- a/android/Bottari/di/src/main/java/com/bottari/di/DataSourceProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/DataSourceProvider.kt
@@ -68,7 +68,7 @@ object DataSourceProvider {
         )
     }
     val memberIdentifierLocalDataSource: MemberIdentifierLocalDataSource by lazy {
-        MemberIdentifierLocalDataSourceImpl()
+        MemberIdentifierLocalDataSourceImpl(DataStoreProvider.provideMemberInfoDataStore)
     }
     val teamBottariRemoteDataSource: TeamBottariRemoteDataSource by lazy {
         TeamBottariRemoteDataSourceImpl(

--- a/android/Bottari/di/src/main/java/com/bottari/di/DataStoreProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/DataStoreProvider.kt
@@ -1,9 +1,13 @@
 package com.bottari.di
 
 import com.bottari.data.local.AppConfigDataStore
+import com.bottari.data.local.MemberInfoDataStore
 
 object DataStoreProvider {
     val provideAppConfigDataStore: AppConfigDataStore by lazy {
         AppConfigDataStore(ApplicationContextProvider.applicationContext)
+    }
+    val provideMemberInfoDataStore: MemberInfoDataStore by lazy {
+        MemberInfoDataStore(ApplicationContextProvider.applicationContext)
     }
 }

--- a/android/Bottari/di/src/main/java/com/bottari/di/RepositoryProvider.kt
+++ b/android/Bottari/di/src/main/java/com/bottari/di/RepositoryProvider.kt
@@ -65,7 +65,10 @@ object RepositoryProvider {
         )
     }
     val fcmRepository: FcmRepository by lazy {
-        FcmRepositoryImpl(DataSourceProvider.fcmRemoteDataSource)
+        FcmRepositoryImpl(
+            DataSourceProvider.fcmRemoteDataSource,
+            DataSourceProvider.memberIdentifierLocalDataSource,
+        )
     }
     val remoteConfigRepository: RemoteConfigRepository by lazy {
         RemoteConfigRepositoryImpl(DataSourceProvider.firebaseRemoteConfigDataSource)

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/extension/ResultExtension.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/extension/ResultExtension.kt
@@ -1,7 +1,47 @@
 package com.bottari.domain.extension
 
+/**
+ * 성공 값만 변환합니다.
+ *
+ * 변환 과정에서 예외가 발생하면 그대로 던집니다.
+ */
+inline fun <T, R> Result<T>.map(transform: (T) -> R): Result<R> =
+    fold(
+        onSuccess = { Result.success(transform(it)) },
+        onFailure = { Result.failure(it) },
+    )
+
+/**
+ * 성공 값만 변환합니다.
+ *
+ * 변환 과정에서 예외가 발생하면 [Result.failure] 로 감쌉니다.
+ */
+inline fun <T, R> Result<T>.mapCatching(transform: (T) -> R): Result<R> =
+    fold(
+        onSuccess = { runCatching { transform(it) } },
+        onFailure = { Result.failure(it) },
+    )
+
+/**
+ * 성공 값을 [Result] 로 변환합니다.
+ *
+ * 변환 과정에서 예외가 발생하면 그대로 던집니다.
+ */
 inline fun <T, R> Result<T>.flatMap(transform: (T) -> Result<R>): Result<R> =
     fold(
         onSuccess = { transform(it) },
+        onFailure = { Result.failure(it) },
+    )
+
+/**
+ * 성공 값을 [Result] 로 변환합니다.
+ *
+ * 변환 과정에서 예외가 발생하면 [Result.failure] 로 감쌉니다.
+ */
+inline fun <T, R> Result<T>.flatMapCatching(transform: (T) -> Result<R>): Result<R> =
+    fold(
+        onSuccess = {
+            runCatching { transform(it) }.getOrElse { throwable -> Result.failure(throwable) }
+        },
         onFailure = { Result.failure(it) },
     )

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/fcm/SaveFcmTokenUseCase.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/usecase/fcm/SaveFcmTokenUseCase.kt
@@ -5,5 +5,5 @@ import com.bottari.domain.repository.FcmRepository
 class SaveFcmTokenUseCase(
     private val fcmRepository: FcmRepository,
 ) {
-    suspend operator fun invoke(fcmToken: String): Result<Unit> = runCatching { fcmRepository.saveFcmToken(fcmToken) }
+    suspend operator fun invoke(fcmToken: String): Result<Unit> = fcmRepository.saveFcmToken(fcmToken)
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/ReminderMessagingService.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/ReminderMessagingService.kt
@@ -46,7 +46,7 @@ class ReminderMessagingService(
     private fun saveToken(token: String) {
         CoroutineScope(Dispatchers.IO).launch {
             saveFcmTokenUseCase(token)
-                .onFailure { error -> BottariLogger.error(error.message, error) }
+                .onFailure { error -> BottariLogger.error(LOG_FORMAT.format(error.message), error) }
         }
     }
 
@@ -71,7 +71,7 @@ class ReminderMessagingService(
         runCatching {
             stringId?.toLong()
         }.onFailure { error ->
-            BottariLogger.error(error.message, error)
+            BottariLogger.error(LOG_FORMAT.format(error.message), error)
         }.getOrNull()
 
     private fun String?.orNullIfBlank(): String? = this?.takeIf { it.isNotBlank() }
@@ -99,11 +99,15 @@ class ReminderMessagingService(
         item: String,
     ) {
         val message =
-            getString(R.string.common_team_bottari_notification_send_remind_by_item_message_text, item)
+            getString(
+                R.string.common_team_bottari_notification_send_remind_by_item_message_text,
+                item,
+            )
         notificationHelper.sendTeamNotification(id, title, message)
     }
 
     companion object {
+        private const val LOG_FORMAT = "[Reminder Messaging Service] %s"
         private const val NOTIFICATION_PREFIX_OLD = "gcm.notification"
         private const val KEY_TEAM_BOTTARI_ID = "teamBottariId"
         private const val KEY_TEAM_BOTTARI_TITLE = "teamBottariTitle"


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- FCM Token 갱신 시점 변경

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #469 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
### FCM Token 갱신 시점 변경
기존 로그인 플로우에 토큰 저장 API 플로우 추가

### RemindMessageService
newToken 콜백 호출 시 회원 가입 여부 확인 하도록 변경

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - FCM 토큰 자동 저장 경로가 추가되어 로그인/재등록 시 토큰이 서버에 안전하게 저장됩니다.
  - 회원 ID를 영구 저장·조회하는 새로운 데이터 저장소가 추가되었습니다.

- **개선**
  - 회원 ID의 로컬 우선 동기화로 등록/로그인 흐름의 일관성과 복원력이 향상되었습니다.
  - 오류 로그 포맷을 일원화해 문제 진단이 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->