### PR TITLE
[BE] 유효하지 않은 FCM 처리 버그 수정

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageSender.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageSender.java
@@ -2,12 +2,11 @@ package com.bottari.fcm;
 
 import static com.bottari.error.ErrorCode.FCM_INVALID_TOKEN;
 import static com.bottari.error.ErrorCode.FCM_MESSAGE_SEND_FAIL;
-import static com.bottari.error.ErrorCode.FCM_TOKEN_NOT_FOUND;
 
 import com.bottari.error.BusinessException;
 import com.bottari.fcm.domain.FcmToken;
 import com.bottari.fcm.dto.SendMessageRequest;
-import com.bottari.fcm.repository.FcmTokenRepository;
+import com.bottari.fcm.service.FcmTokenService;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -21,21 +20,20 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FcmMessageSender {
 
+    private final FcmTokenService fcmTokenService;
     private final FirebaseMessaging firebaseMessaging;
-    private final FcmTokenRepository fcmTokenRepository;
 
     public void sendMessageToMember(
             final Long memberId,
             final SendMessageRequest request
     ) {
-        final FcmToken fcmToken = fcmTokenRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new BusinessException(FCM_TOKEN_NOT_FOUND));
+        final FcmToken fcmToken = fcmTokenService.getByMemberId(memberId);
         final Message message = createMessage(request, fcmToken);
         try {
             firebaseMessaging.send(message);
         } catch (final FirebaseMessagingException e) {
             if (isInvalidFcmToken(e)) {
-                fcmTokenRepository.deleteById(fcmToken.getId());
+                fcmTokenService.deleteById(fcmToken.getId());
                 throw new BusinessException(FCM_INVALID_TOKEN);
             }
             throw new BusinessException(FCM_MESSAGE_SEND_FAIL);
@@ -46,7 +44,7 @@ public class FcmMessageSender {
             final List<Long> memberIds,
             final SendMessageRequest request
     ) {
-        final List<FcmToken> fcmTokens = fcmTokenRepository.findByMemberIdIn(memberIds);
+        final List<FcmToken> fcmTokens = fcmTokenService.getByMembersIn(memberIds);
         final List<Long> invalidTokenIds = new ArrayList<>();
         for (final FcmToken fcmToken : fcmTokens) {
             final Message message = createMessage(request, fcmToken);
@@ -61,7 +59,7 @@ public class FcmMessageSender {
             }
         }
         if (!invalidTokenIds.isEmpty()) {
-            fcmTokenRepository.deleteByIds(invalidTokenIds);
+            fcmTokenService.deleteByIds(invalidTokenIds);
             throw new BusinessException(FCM_INVALID_TOKEN);
         }
     }

--- a/backend/bottari/src/main/java/com/bottari/fcm/repository/FcmTokenRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/repository/FcmTokenRepository.java
@@ -16,6 +16,7 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     List<FcmToken> findByMemberIdIn(final List<Long> memberIds);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
+//    @Modifying
     @Query("""
             UPDATE FcmToken f
             SET f.deletedAt = CURRENT_TIMESTAMP

--- a/backend/bottari/src/main/java/com/bottari/fcm/repository/FcmTokenRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/repository/FcmTokenRepository.java
@@ -16,7 +16,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     List<FcmToken> findByMemberIdIn(final List<Long> memberIds);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-//    @Modifying
     @Query("""
             UPDATE FcmToken f
             SET f.deletedAt = CURRENT_TIMESTAMP

--- a/backend/bottari/src/main/java/com/bottari/fcm/service/FcmTokenService.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/service/FcmTokenService.java
@@ -1,10 +1,13 @@
 package com.bottari.fcm.service;
 
+import static com.bottari.error.ErrorCode.FCM_TOKEN_NOT_FOUND;
+
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.fcm.domain.FcmToken;
 import com.bottari.fcm.dto.UpdateFcmRequest;
 import com.bottari.fcm.repository.FcmTokenRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +18,15 @@ public class FcmTokenService {
 
     private final FcmTokenRepository fcmTokenRepository;
 
+    public FcmToken getByMemberId(final Long memberId) {
+        return fcmTokenRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new BusinessException(FCM_TOKEN_NOT_FOUND));
+    }
+
+    public List<FcmToken> getByMembersIn(final List<Long> memberIds) {
+        return fcmTokenRepository.findByMemberIdIn(memberIds);
+    }
+
     @Transactional
     public void updateFcmToken(
             final String ssaid,
@@ -23,5 +35,14 @@ public class FcmTokenService {
         final FcmToken fcmToken = fcmTokenRepository.findByMemberSsaid(ssaid)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FCM_TOKEN_NOT_FOUND));
         fcmToken.updateFcmToken(request.fcmToken());
+    }
+
+    public void deleteById(final Long id) {
+        fcmTokenRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void deleteByIds(final List<Long> ids) {
+        fcmTokenRepository.deleteByIds(ids);
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/fcm/FcmMessageSenderTest.java
+++ b/backend/bottari/src/test/java/com/bottari/fcm/FcmMessageSenderTest.java
@@ -11,6 +11,7 @@ import com.bottari.error.BusinessException;
 import com.bottari.fcm.domain.FcmToken;
 import com.bottari.fcm.dto.MessageType;
 import com.bottari.fcm.dto.SendMessageRequest;
+import com.bottari.fcm.service.FcmTokenService;
 import com.bottari.fixture.FcmTokenFixture;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.member.domain.Member;
@@ -37,11 +38,17 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
-@Import(FcmMessageSender.class)
+@Import({
+        FcmMessageSender.class,
+        FcmTokenService.class
+})
 class FcmMessageSenderTest {
 
     @Autowired
     private FcmMessageSender fcmMessageSender;
+
+    @Autowired
+    private FcmTokenService fcmTokenService;
 
     @MockitoBean
     private FirebaseMessaging firebaseMessaging;

--- a/backend/bottari/src/test/java/com/bottari/fcm/service/FcmTokenServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/fcm/service/FcmTokenServiceTest.java
@@ -2,6 +2,7 @@ package com.bottari.fcm.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.bottari.error.BusinessException;
 import com.bottari.fcm.domain.FcmToken;
@@ -10,6 +11,7 @@ import com.bottari.fixture.FcmTokenFixture;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.member.domain.Member;
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,88 @@ class FcmTokenServiceTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Nested
+    class GetByMemberIdTest {
+
+        @DisplayName("멤버 ID로 FCM 토큰을 정상적으로 조회한다.")
+        @Test
+        void getByMemberId() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final FcmToken fcmToken = FcmTokenFixture.FCM_TOKEN.get(member);
+            entityManager.persist(fcmToken);
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            final FcmToken actual = fcmTokenService.getByMemberId(member.getId());
+
+            // then
+            assertThat(actual.getId()).isEqualTo(fcmToken.getId());
+        }
+
+        @DisplayName("멤버 ID로 조회 시, FCM 토큰이 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void getByMemberId_Exception_NotFound() {
+            // given
+            final Long nonExistentMemberId = 999L;
+
+            // when & then
+            assertThatThrownBy(() -> fcmTokenService.getByMemberId(nonExistentMemberId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("FCM 토큰 정보가 존재하지 않습니다.");
+        }
+
+    }
+
+    @Nested
+    class GetByMembersInTest {
+
+        @DisplayName("여러 멤버 ID로 FCM 토큰들을 정상적으로 조회한다.")
+        @Test
+        void getByMembersIn() {
+            // given
+            final Member member1 = MemberFixture.MEMBER.get();
+            final Member member2 = MemberFixture.MEMBER.get();
+            entityManager.persist(member1);
+            entityManager.persist(member2);
+
+            final FcmToken fcmToken1 = FcmTokenFixture.FCM_TOKEN.get(member1);
+            final FcmToken fcmToken2 = FcmTokenFixture.FCM_TOKEN.get(member2);
+            entityManager.persist(fcmToken1);
+            entityManager.persist(fcmToken2);
+            entityManager.flush();
+            entityManager.clear();
+
+            final List<Long> memberIds = List.of(member1.getId(), member2.getId());
+
+            // when
+            final List<FcmToken> actual = fcmTokenService.getByMembersIn(memberIds);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(2),
+                    () -> assertThat(actual).extracting(FcmToken::getId)
+                            .containsExactlyInAnyOrder(fcmToken1.getId(), fcmToken2.getId())
+            );
+        }
+
+        @DisplayName("존재하지 않는 멤버 ID들로 조회하면 빈 리스트를 반환한다.")
+        @Test
+        void getByMembersIn_EmptyResult() {
+            // given
+            final List<Long> nonExistentMemberIds = List.of(999L, 1000L);
+
+            // when
+            final List<FcmToken> actual = fcmTokenService.getByMembersIn(nonExistentMemberIds);
+
+            // then
+            assertThat(actual).isEmpty();
+        }
+
+    }
 
     @Nested
     class UpdateTest {
@@ -61,6 +145,73 @@ class FcmTokenServiceTest {
             assertThatThrownBy(() -> fcmTokenService.updateFcmToken(ssaid, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("FCM 토큰 정보가 존재하지 않습니다.");
+        }
+    }
+
+    @Nested
+    class DeleteByIdTest {
+
+        @DisplayName("ID로 FCM 토큰을 정상적으로 삭제한다.")
+        @Test
+        void deleteById() {
+            // given
+            final Member member = MemberFixture.MEMBER.get();
+            entityManager.persist(member);
+            final FcmToken fcmToken = FcmTokenFixture.FCM_TOKEN.get(member);
+            entityManager.persist(fcmToken);
+            entityManager.flush();
+
+            // when
+            fcmTokenService.deleteById(fcmToken.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final FcmToken actual = entityManager.find(FcmToken.class, fcmToken.getId());
+            assertThat(actual).isNull();
+        }
+    }
+
+    @Nested
+    class DeleteByIdsTest {
+
+        @DisplayName("여러 ID로 FCM 토큰들을 정상적으로 삭제한다.")
+        @Test
+        void deleteByIds() {
+            // given
+            final Member member1 = MemberFixture.MEMBER.get();
+            final Member member2 = MemberFixture.MEMBER.get();
+            entityManager.persist(member1);
+            entityManager.persist(member2);
+
+            final FcmToken fcmToken1 = FcmTokenFixture.FCM_TOKEN.get(member1);
+            final FcmToken fcmToken2 = FcmTokenFixture.FCM_TOKEN.get(member2);
+            entityManager.persist(fcmToken1);
+            entityManager.persist(fcmToken2);
+            entityManager.flush();
+
+            final List<Long> ids = List.of(fcmToken1.getId(), fcmToken2.getId());
+
+            // when
+            fcmTokenService.deleteByIds(ids);
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            assertAll(
+                    () -> assertThat(entityManager.find(FcmToken.class, fcmToken1.getId())).isNull(),
+                    () -> assertThat(entityManager.find(FcmToken.class, fcmToken2.getId())).isNull()
+            );
+        }
+
+        @DisplayName("빈 리스트로 삭제를 호출해도 예외가 발생하지 않는다.")
+        @Test
+        void deleteByIds_EmptyList() {
+            // given
+            final List<Long> emptyIds = List.of();
+
+            // when & then
+            fcmTokenService.deleteByIds(emptyIds);
         }
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 유효하지 않은 FCM 처리 버그 수정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #479 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 기존 FcmSender에서 Repository 참조
- 이를 Service로 분리 후, 트랜잭션 처리

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 푸시 알림(FCM) 토큰 관리를 서비스 레이어로 일원화하여 처리 안정성과 유지보수성을 강화했습니다.
  - 잘못된 토큰을 자동 정리하는 흐름을 개선하고, 단건·대량 발송 시 오류 처리의 일관성을 높였습니다.
- Tests
  - 토큰 조회·삭제 및 발송 시나리오에 대한 테스트를 대폭 보강해 회귀를 방지하고 신뢰성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->