### PR TITLE
[AN] 멤버 보채기 알림 수신 시 타입 불일치 문제 수정

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/ReminderMessagingService.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/ReminderMessagingService.kt
@@ -56,14 +56,21 @@ class ReminderMessagingService(
         val type = data[KEY_MESSAGE_TYPE].orNullIfBlank() ?: return
 
         when (type) {
-            TYPE_TEAM_ITEM_CHANGED -> handleItemChangedMessage(teamBottariId, teamBottariTitle)
-            TYPE_REMIND_BY_MEMBER -> handleRemindByMemberMessage(teamBottariId, teamBottariTitle)
+            TYPE_TEAM_ITEM_CHANGED ->
+                handleItemChangedMessage(teamBottariId, teamBottariTitle)
+
+            TYPE_REMIND_BY_TEAM_MEMBER ->
+                handleRemindByMemberMessage(teamBottariId, teamBottariTitle)
+
             TYPE_REMIND_BY_ITEM -> {
                 val item = data[KEY_TEAM_ITEM_NAME].orNullIfBlank() ?: return
                 handleRemindByItemMessage(teamBottariId, teamBottariTitle, item)
             }
 
-            else -> return
+            else -> {
+                BottariLogger.error(ERROR_INVALID_MESSAGE_TYPE.format(type))
+                return
+            }
         }
     }
 
@@ -109,12 +116,16 @@ class ReminderMessagingService(
     companion object {
         private const val LOG_FORMAT = "[Reminder Messaging Service] %s"
         private const val NOTIFICATION_PREFIX_OLD = "gcm.notification"
+
         private const val KEY_TEAM_BOTTARI_ID = "teamBottariId"
         private const val KEY_TEAM_BOTTARI_TITLE = "teamBottariTitle"
         private const val KEY_TEAM_ITEM_NAME = "teamItemName"
-        private const val TYPE_TEAM_ITEM_CHANGED = "TEAM_ITEM_CHANGED"
-        private const val TYPE_REMIND_BY_MEMBER = "REMIND_BY_MEMBER"
-        private const val TYPE_REMIND_BY_ITEM = "REMIND_BY_ITEM"
         private const val KEY_MESSAGE_TYPE = "type"
+
+        private const val TYPE_TEAM_ITEM_CHANGED = "TEAM_ITEM_CHANGED"
+        private const val TYPE_REMIND_BY_TEAM_MEMBER = "REMIND_BY_TEAM_MEMBER"
+        private const val TYPE_REMIND_BY_ITEM = "REMIND_BY_ITEM"
+
+        private const val ERROR_INVALID_MESSAGE_TYPE = "[ERROR] Invalid Message Type (%s)"
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/NotificationHelper.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/NotificationHelper.kt
@@ -37,7 +37,8 @@ class NotificationHelper(
         createTeamNotificationChannel()
         val pendingIntent = createTeamPendingIntent(teamBottariId, teamBottariTitle)
         val notification = createTeamNotification(pendingIntent, teamBottariTitle, message)
-        manager.notify(teamBottariId.toInt(), notification)
+        val notificationId = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()
+        manager.notify(notificationId, notification)
     }
 
     private fun createPersonalNotificationChannel() {
@@ -109,8 +110,12 @@ class NotificationHelper(
         NotificationCompat
             .Builder(context, TEAM_BOTTARI_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_bottari_logo)
-            .setContentTitle(context.getString(R.string.common_team_bottari_notification_title_text, bottariTitle))
-            .setContentText(message)
+            .setContentTitle(
+                context.getString(
+                    R.string.common_team_bottari_notification_title_text,
+                    bottariTitle,
+                ),
+            ).setContentText(message)
             .setContentIntent(intent)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 멤버 보채기 알림 수신 시 타입 불일치 문제 수정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #480 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 멤버 보채기 알림 수신 시 타입 불일치 문제 수정

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- 알림 정상 수신 테스트 완료
- 정의되지 않은 타입으로 오는 경우 Error 로그 추가함


<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 팀 구성원 리마인더 알림 분기 로직을 바로잡아 누락·오동작 사례를 해소했습니다.
  - 유효하지 않은 메시지 타입을 명확히 감지·차단해 알림 처리 안정성을 높였습니다.
  - 팀 알림이 기존 알림을 덮어쓰지 않고 각기 독립적으로 표시되도록 알림 ID 생성 방식을 변경했습니다.
- 기타(Chores)
  - FCM 토큰 저장 및 메시지 파싱 시 오류 로깅을 강화해 문제 원인 파악을 용이하게 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->