### PR TITLE
[AN] 홈 화면에서 두번 뒤로가기 누를 시 종료

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/SnackbarExt.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/SnackbarExt.kt
@@ -31,9 +31,13 @@ fun View.showSnackbar(
 fun View.showSnackbar(
     message: String,
     duration: SnackBarDuration = SnackBarDuration.SHORT_DELAY,
+    anchor: View? = null,
     onDismiss: (() -> Unit)? = null,
 ) {
     Snackbar.make(this, message, Snackbar.LENGTH_INDEFINITE).apply {
+        anchor?.let { anchorView ->
+            this.anchorView = anchorView
+        }
         onDismiss?.let { addDismissCallback(it) }
         show()
         this.view.postDelayed({ dismiss() }, duration.value)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/SnackbarExt.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/common/extension/SnackbarExt.kt
@@ -15,9 +15,13 @@ enum class SnackBarDuration(
 fun View.showSnackbar(
     @StringRes messageRes: Int,
     duration: SnackBarDuration = SnackBarDuration.SHORT_DELAY,
+    anchor: View? = null,
     onDismiss: (() -> Unit)? = null,
 ) {
     Snackbar.make(this, messageRes, Snackbar.LENGTH_INDEFINITE).apply {
+        anchor?.let { anchorView ->
+            this.anchorView = anchorView
+        }
         onDismiss?.let { addDismissCallback(it) }
         show()
         this.view.postDelayed({ dismiss() }, duration.value)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/HomeActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/HomeActivity.kt
@@ -11,17 +11,17 @@ import androidx.fragment.app.Fragment
 import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseActivity
 import com.bottari.presentation.common.extension.applyWindowInsetsWithBottomNavigation
+import com.bottari.presentation.common.extension.showSnackbar
 import com.bottari.presentation.databinding.ActivityHomeBinding
 import com.bottari.presentation.view.home.more.MoreFragment
 import com.bottari.presentation.view.home.personal.BottariFragment
 import com.bottari.presentation.view.home.team.TeamBottariFragment
 import com.bottari.presentation.view.home.template.TemplateFragment
-import com.google.android.material.snackbar.Snackbar
 
 class HomeActivity : BaseActivity<ActivityHomeBinding>(ActivityHomeBinding::inflate) {
     private val deeplinkFlag: Boolean by lazy { intent.getBooleanExtra(KEY_DEEPLINK, false) }
     private var isBackPressedOnce: Boolean = false
-    private val handler = Handler(Looper.getMainLooper())
+    private val handler: Handler by lazy { Handler(Looper.getMainLooper()) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -82,7 +82,7 @@ class HomeActivity : BaseActivity<ActivityHomeBinding>(ActivityHomeBinding::infl
             return
         }
         isBackPressedOnce = true
-        Snackbar.make(binding.root, getString(R.string.bottari_home_exit_confirm_text), Snackbar.LENGTH_SHORT).show()
+        binding.fcvHome.showSnackbar(R.string.bottari_home_exit_confirm_text)
         handler.postDelayed({
             isBackPressedOnce = false
         }, EXIT_DELAY_TIME)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/HomeActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/HomeActivity.kt
@@ -3,7 +3,10 @@ package com.bottari.presentation.view.home
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.MenuItem
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseActivity
@@ -13,13 +16,17 @@ import com.bottari.presentation.view.home.more.MoreFragment
 import com.bottari.presentation.view.home.personal.BottariFragment
 import com.bottari.presentation.view.home.team.TeamBottariFragment
 import com.bottari.presentation.view.home.template.TemplateFragment
+import com.google.android.material.snackbar.Snackbar
 
 class HomeActivity : BaseActivity<ActivityHomeBinding>(ActivityHomeBinding::inflate) {
     private val deeplinkFlag: Boolean by lazy { intent.getBooleanExtra(KEY_DEEPLINK, false) }
+    private var isBackPressedOnce: Boolean = false
+    private val handler = Handler(Looper.getMainLooper())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setupUI(savedInstanceState)
+        setupListener()
     }
 
     private fun setupUI(savedInstanceState: Bundle?) {
@@ -31,6 +38,12 @@ class HomeActivity : BaseActivity<ActivityHomeBinding>(ActivityHomeBinding::infl
         }
         binding.bnvHome.menu.findItem(binding.bnvHome.selectedItemId)?.let {
             changeToolbarTitle(it)
+        }
+    }
+
+    private fun setupListener() {
+        onBackPressedDispatcher.addCallback(this) {
+            showExitSnackbar()
         }
     }
 
@@ -63,8 +76,26 @@ class HomeActivity : BaseActivity<ActivityHomeBinding>(ActivityHomeBinding::infl
         binding.toolbarHome.title = item.title
     }
 
+    private fun showExitSnackbar() {
+        if (isBackPressedOnce) {
+            finish()
+            return
+        }
+        isBackPressedOnce = true
+        Snackbar.make(binding.root, getString(R.string.bottari_home_exit_confirm_text), Snackbar.LENGTH_SHORT).show()
+        handler.postDelayed({
+            isBackPressedOnce = false
+        }, EXIT_DELAY_TIME)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        handler.removeCallbacksAndMessages(null)
+    }
+
     companion object {
         private const val KEY_DEEPLINK = "KEY_DEEPLINK"
+        private const val EXIT_DELAY_TIME = 2000L
 
         fun newIntent(context: Context) = Intent(context, HomeActivity::class.java)
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/HomeActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/home/HomeActivity.kt
@@ -82,7 +82,7 @@ class HomeActivity : BaseActivity<ActivityHomeBinding>(ActivityHomeBinding::infl
             return
         }
         isBackPressedOnce = true
-        binding.fcvHome.showSnackbar(R.string.bottari_home_exit_confirm_text)
+        binding.fcvHome.showSnackbar(R.string.bottari_home_exit_confirm_text, anchor = binding.bnvHome)
         handler.postDelayed({
             isBackPressedOnce = false
         }, EXIT_DELAY_TIME)

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -135,7 +135,7 @@
     <string name="bottari_home_delete_failure_text">보따리를 삭제하지 못했어요</string>
     <string name="bottari_home_empty_view_title_text">보따리가 없습니다</string>
     <string name="bottari_home_empty_view_description_text">오른쪽 아래 버튼을 눌러 새 보따리를 만들거나,\n‘모두의 보따리’에서 원하는 보따리를 가져와보세요!</string>
-    <string name="bottari_home_exit_confirm_text">한 번 더 누르면 종료됩니다.</string>
+    <string name="bottari_home_exit_confirm_text">한 번 더 누르면 앱이 종료돼요</string>
 
     <!-- Bottari Item -->
     <string name="bottari_item_alarm_repeat_everyday_text">매일 알람</string>

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -135,6 +135,7 @@
     <string name="bottari_home_delete_failure_text">보따리를 삭제하지 못했어요</string>
     <string name="bottari_home_empty_view_title_text">보따리가 없습니다</string>
     <string name="bottari_home_empty_view_description_text">오른쪽 아래 버튼을 눌러 새 보따리를 만들거나,\n‘모두의 보따리’에서 원하는 보따리를 가져와보세요!</string>
+    <string name="bottari_home_exit_confirm_text">한 번 더 누르면 종료됩니다.</string>
 
     <!-- Bottari Item -->
     <string name="bottari_item_alarm_repeat_everyday_text">매일 알람</string>


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 홈 화면에서 두번 뒤로가기 누를 시 종료

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #484 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
-
<br>

## 📸 스크린샷 (선택)

<img width="360" height="800" alt="Screenshot_20250821_204130" src="https://github.com/user-attachments/assets/1503c633-0942-424e-8894-5674bd888adc" />

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 홈 화면에서 뒤로가기 한 번 누르면 하단에 종료 안내 스낵바가 표시되고, 2초 내 다시 누르면 앱이 종료됩니다.
  * 스낵바는 하단 내비게이션에 앵커되어 표시될 수 있도록 개선되었습니다.
  * 종료 안내 문구("한 번 더 누르면 앱이 종료돼요")가 추가되었습니다.

* **버그 수정**
  * 뒤로가기 처리 관련 타이밍/리소스 정리를 추가해 불필요한 동작 및 메모리 문제를 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->