### PR TITLE
[BE] 팀 보따리 나갈 시, 예외 수정

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemInfoRepository.java
@@ -28,15 +28,16 @@ public interface TeamAssignedItemInfoRepository extends JpaRepository<TeamAssign
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
-        UPDATE TeamAssignedItemInfo taii
-        SET taii.deletedAt = CURRENT_TIMESTAMP
-        WHERE taii IN (
-                SELECT taii_sub
-                FROM TeamAssignedItemInfo taii_sub
-                LEFT JOIN TeamAssignedItem tai ON tai.info = taii_sub
-                WHERE tai.id IS NULL
-                  AND taii_sub.teamBottari.id = :teamBottariId
-        )
-        """)
+            UPDATE TeamAssignedItemInfo taii
+            SET taii.deletedAt = CURRENT TIMESTAMP
+            WHERE taii.teamBottari.id = :teamBottariId
+            AND taii.deletedAt IS NULL
+            AND NOT EXISTS (
+                SELECT 1
+                FROM TeamAssignedItem tai
+                WHERE tai.info = taii
+                AND tai.deletedAt IS NULL
+            )
+            """)
     void deleteOrphanAssignedItemInfosByTeamBottariId(final Long teamBottariId);
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -39,17 +39,15 @@ public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedIt
             """)
     List<TeamAssignedItem> findAllByTeamMemberId(final Long teamMemberId);
 
-    boolean existsByInfoId(final Long infoId);
-
     void deleteAllByInfo(final TeamAssignedItemInfo teamAssignedItemInfo);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
-        UPDATE TeamAssignedItem tai
-        SET tai.deletedAt = CURRENT_TIMESTAMP
-        WHERE tai.teamMember.id = :teamMemberId
-        AND tai.deletedAt IS NULL
-        """
+            UPDATE TeamAssignedItem tai
+            SET tai.deletedAt = CURRENT_TIMESTAMP
+            WHERE tai.teamMember.id = :teamMemberId
+            AND tai.deletedAt IS NULL
+            """
     )
     void deleteByTeamMemberId(final Long teamMemberId);
 


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 나갈 시, 예외 수정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- MySQL에서는 UPDATE 쿼리에 서브 쿼리 사용 불가

**BEFORE**
```sql
        UPDATE TeamAssignedItemInfo taii
        SET taii.deletedAt = CURRENT_TIMESTAMP
        WHERE taii IN (
                SELECT taii_sub
                FROM TeamAssignedItemInfo taii_sub
                LEFT JOIN TeamAssignedItem tai ON tai.info = taii_sub
                WHERE tai.id IS NULL
                  AND taii_sub.teamBottari.id = :teamBottariId
        )
```

**AFTER**
```sql
            UPDATE TeamAssignedItemInfo taii
            SET taii.deletedAt = CURRENT TIMESTAMP
            WHERE taii.teamBottari.id = :teamBottariId
            AND taii.deletedAt IS NULL
            AND NOT EXISTS (
                SELECT 1
                FROM TeamAssignedItem tai
                WHERE tai.info = taii
                AND tai.deletedAt IS NULL
            )
```

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * 팀 항목 할당 정리 로직 개선으로 고아 데이터가 남는 경우를 방지하여 목록/통계에 유령 항목이 노출될 수 있는 문제를 완화했습니다.
  * 삭제 처리 시점과 조건을 정교화해 데이터 정합성을 강화했습니다.
* Refactor
  * 정리 쿼리 방식을 개선해 처리 안정성과 효율을 향상했습니다.
* Chores
  * 사용되지 않는 내부 메서드를 정리해 코드베이스를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->