### PR TITLE
[AN] 앱링크 접속 시 홈 화면이 먼저 출력되는 문제 해결

### DIFF
--- a/android/Bottari/presentation/src/main/AndroidManifest.xml
+++ b/android/Bottari/presentation/src/main/AndroidManifest.xml
@@ -38,9 +38,6 @@
             android:name=".view.edit.personal.PersonalBottariEditActivity"
             android:exported="false" />
         <activity
-            android:name=".view.setting.SettingActivity"
-            android:exported="false" />
-        <activity
             android:name=".view.template.TemplateActivity"
             android:exported="false" />
         <activity


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 앱링크 문제 해결

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #465 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 유효한 딥링크가 있을 때 홈으로 이동하던 문제를 수정하고, 초대 화면으로 우선 이동하도록 개선.
  - 로그인/회원가입/권한 플래그 처리 실패 시 앱이 일관되게 종료되도록 정리하여 비정상 상태에 머무는 문제 개선.

- 작업 정리
  - 사용되지 않는 설정 화면 액티비티 선언을 매니페스트에서 제거(사용자 기능 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->