### PR TITLE
[BE] 팀 보따리 탈퇴 시 알림 및 SSE 알림 기능 추가

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageConverter.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageConverter.java
@@ -6,6 +6,7 @@ import com.bottari.fcm.dto.MessageType;
 import com.bottari.fcm.dto.SendMessageRequest;
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;
 import com.bottari.teambottari.domain.TeamBottari;
+import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamSharedItemInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,6 +22,8 @@ public class FcmMessageConverter {
     private static final String TEAM_ITEM_NAME = "teamItemName";
     private static final String TEAM_SHARED_ITEM_NAMES = "teamSharedItemNames";
     private static final String TEAM_ASSIGNED_ITEM_NAMES = "teamAssignedItemNames";
+    private static final String EXIT_MEMBER_ID = "exitMemberId";
+    private static final String EXIT_MEMBER_NAME = "exitMemberName";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -90,5 +93,26 @@ public class FcmMessageConverter {
         } catch (final JsonProcessingException e) {
             throw new BusinessException(ErrorCode.FCM_MESSAGE_CONVERT_FAIL);
         }
+    }
+
+    public SendMessageRequest convert(
+            final TeamBottari teamBottari,
+            final TeamMember exitTeamMember,
+            final MessageType messageType
+    ) {
+        final Long teamBottariId = teamBottari.getId();
+        final String teamBottariTitle = teamBottari.getTitle();
+        final Long exitMemberId = exitTeamMember.getMember().getId();
+        final String exitMemberName = exitTeamMember.getMember().getName();
+
+        return new SendMessageRequest(
+                Map.of(
+                        TEAM_BOTTARI_ID, String.valueOf(teamBottariId),
+                        TEAM_BOTTARI_TITLE, teamBottariTitle,
+                        EXIT_MEMBER_ID, String.valueOf(exitMemberId),
+                        EXIT_MEMBER_NAME, exitMemberName
+                ),
+                messageType
+        );
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/fcm/dto/MessageType.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/dto/MessageType.java
@@ -5,5 +5,6 @@ public enum MessageType {
     TEAM_ITEM_CHANGED,
     REMIND_BY_ITEM,
     REMIND_BY_TEAM_MEMBER,
+    EXIT_TEAM_BOTTARI
     ;
 }

--- a/backend/bottari/src/main/java/com/bottari/sse/component/SseService.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/SseService.java
@@ -1,6 +1,5 @@
 package com.bottari.sse.component;
 
-import com.bottari.sse.dto.ConnectSuccessData;
 import com.bottari.sse.message.SseMessage;
 import java.io.IOException;
 import java.util.List;
@@ -42,9 +41,5 @@ public class SseService {
         sseEmitter.onTimeout(() -> sseRepository.remove(teamBottariId, sseEmitter));
         sseEmitter.onError(throwable -> sseRepository.remove(teamBottariId, sseEmitter));
         sseRepository.save(teamBottariId, sseEmitter);
-        try {
-            sseEmitter.send(new ConnectSuccessData("Connect Success"), MediaType.APPLICATION_JSON);
-        } catch (final Exception ignored) {
-        }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -7,6 +7,7 @@ import com.bottari.sse.dto.CreateTeamMemberData;
 import com.bottari.sse.dto.CreateTeamSharedItemData;
 import com.bottari.sse.dto.DeleteAssignedItemData;
 import com.bottari.sse.dto.DeleteTeamSharedItemData;
+import com.bottari.sse.dto.ExitTeamMemberData;
 import com.bottari.sse.message.SseEventType;
 import com.bottari.sse.message.SseMessage;
 import com.bottari.sse.message.SseResourceType;
@@ -17,6 +18,7 @@ import com.bottari.teambottari.event.CreateAssignedItemEvent;
 import com.bottari.teambottari.event.CreateTeamSharedItemEvent;
 import com.bottari.teambottari.event.DeleteAssignedItemEvent;
 import com.bottari.teambottari.event.DeleteTeamSharedItemEvent;
+import com.bottari.teambottari.event.ExitTeamMemberEvent;
 import com.bottari.teambottari.service.CreateTeamMemberEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -114,6 +116,17 @@ public class TeamBottariEventListener {
                 SseResourceType.ASSIGNED_ITEM_INFO,
                 SseEventType.DELETE,
                 DeleteAssignedItemData.from(event)
+        );
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), message);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleExitTeamMemberEvent(final ExitTeamMemberEvent event) {
+        final SseMessage message = new SseMessage(
+                SseResourceType.TEAM_MEMBER,
+                SseEventType.DELETE,
+                ExitTeamMemberData.from(event)
         );
         sseService.sendByTeamBottariId(event.getTeamBottariId(), message);
     }

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/ConnectSuccessData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/ConnectSuccessData.java
@@ -1,6 +1,0 @@
-package com.bottari.sse.dto;
-
-public record ConnectSuccessData(
-        String message
-) {
-}

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/ExitTeamMemberData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/ExitTeamMemberData.java
@@ -1,0 +1,15 @@
+package com.bottari.sse.dto;
+
+import com.bottari.teambottari.event.ExitTeamMemberEvent;
+import java.time.LocalDateTime;
+
+public record ExitTeamMemberData(
+        Long bottariId,
+        Long exitMemberId,
+        LocalDateTime publishedAt
+) {
+
+    public static ExitTeamMemberData from(final ExitTeamMemberEvent event) {
+        return new ExitTeamMemberData(event.getTeamBottariId(), event.getExitMemberId(), event.getPublishedAt());
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/event/ExitTeamMemberEvent.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/event/ExitTeamMemberEvent.java
@@ -1,0 +1,13 @@
+package com.bottari.teambottari.event;
+
+import com.bottari.support.CustomApplicationEvent;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ExitTeamMemberEvent extends CustomApplicationEvent {
+
+    private final Long teamBottariId;
+    private final Long exitMemberId;
+}

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamBottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamBottariServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.bottari.config.JpaAuditingConfig;
 import com.bottari.error.BusinessException;
+import com.bottari.fcm.FcmMessageConverter;
+import com.bottari.fcm.FcmMessageSender;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.fixture.TeamBottariFixture;
 import com.bottari.member.domain.Member;
@@ -27,9 +29,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
-@Import({TeamBottariService.class, JpaAuditingConfig.class})
+@Import({
+        TeamBottariService.class,
+        JpaAuditingConfig.class,
+        FcmMessageConverter.class
+})
 class TeamBottariServiceTest {
 
     @Autowired
@@ -37,6 +44,9 @@ class TeamBottariServiceTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @MockitoBean
+    private FcmMessageSender fcmMessageSender;
 
     @Nested
     class GetAllBySsaid {


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 탈퇴 시 알림 및 SSE 알림 기능 추가

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #487

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 팀 보따리 탈퇴 시 SSE 연결되어 있는 팀 맴버들에게 이벤트 전송
- 팀 보따리 탈퇴 시 남은 팀 맴버들에게 팀 탈퇴 FCM 메시지 전송


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 팀 구성원이 탈퇴하면 남은 구성원에게 푸시 알림이 전송됩니다.
  - 실시간 이벤트(SSE)로 팀원 탈퇴가 즉시 전파되어 화면 상태가 자동으로 갱신됩니다.
- 변경
  - 초기 연결 시 전송되던 연결 성공 알림(SSE)을 제거하여 불필요한 트래픽을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->