### PR TITLE
[AN] 팀 보따리 나가기 SSE 이벤트 및 FCM Type 추가

### DIFF
--- a/android/Bottari/data/build.gradle.kts
+++ b/android/Bottari/data/build.gradle.kts
@@ -16,7 +16,7 @@ android {
 
     val localProperties = gradleLocalProperties(rootDir, providers)
 
-    fun getPropertyOrThrow(key: String) = localProperties.getProperty(key) ?: error("$key is missing in local.properties")
+    fun getPropertyOrThrow(key: String): String = localProperties.getProperty(key)?.trim() ?: error("$key is missing in local.properties")
 
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/sse/EventDataResponse.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/sse/EventDataResponse.kt
@@ -27,6 +27,19 @@ sealed interface EventDataResponse {
     }
 
     @Serializable
+    data class TeamMemberDeleteResponse(
+        @SerialName("publishedAt")
+        @Serializable(with = LocalDateTimeSerializer::class)
+        override val publishedAt: LocalDateTime,
+        @SerialName("exitMemberId")
+        val exitMemberId: Long,
+        @SerialName("bottariId")
+        val bottariId: String,
+    ) : EventDataResponse {
+        override fun toDomain(): EventData = EventData.TeamMemberDelete(publishedAt, exitMemberId, bottariId)
+    }
+
+    @Serializable
     data class SharedItemInfoCreateResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/sse/OnEventRaw.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/sse/OnEventRaw.kt
@@ -29,6 +29,12 @@ fun OnEventRaw.toEvent(json: Json): EventStateResponse.OnEventResponse {
                     data,
                 )
 
+            ResourceResponse.TEAM_MEMBER to EventResponse.DELETE ->
+                json.decodeFromJsonElement(
+                    EventDataResponse.TeamMemberDeleteResponse.serializer(),
+                    data,
+                )
+
             ResourceResponse.SHARED_ITEM to EventResponse.CHANGE ->
                 json.decodeFromJsonElement(
                     EventDataResponse.SharedItemChangeResponse.serializer(),

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/model/event/EventData.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/model/event/EventData.kt
@@ -12,6 +12,12 @@ sealed interface EventData {
         val isOwner: Boolean,
     ) : EventData
 
+    data class TeamMemberDelete(
+        override val publishedAt: LocalDateTime,
+        val exitMemberId: Long,
+        val bottariId: String,
+    ) : EventData
+
     data class SharedItemInfoCreate(
         override val publishedAt: LocalDateTime,
         val infoId: Long,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/FcmMessage.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/FcmMessage.kt
@@ -1,0 +1,151 @@
+package com.bottari.presentation.service.fcm
+
+import com.bottari.logger.BottariLogger
+import com.bottari.presentation.R
+import com.bottari.presentation.util.NotificationHelper
+
+sealed class FcmMessage {
+    abstract fun sendNotification(notificationHelper: NotificationHelper)
+
+    data class TeamItemChanged(
+        val teamBottariId: Long,
+        val teamBottariTitle: String,
+    ) : FcmMessage() {
+        override fun sendNotification(notificationHelper: NotificationHelper) {
+            notificationHelper.sendTeamMessage(
+                teamBottariId,
+                teamBottariTitle,
+                R.string.common_team_bottari_notification_item_changed_message_text,
+            )
+        }
+
+        companion object {
+            const val TYPE = "TEAM_ITEM_CHANGED"
+
+            fun fromData(data: Map<String, String>) =
+                data.getLong(KEY_TEAM_ID)?.let { id ->
+                    TeamItemChanged(id, data.getString(KEY_TEAM_TITLE))
+                }
+        }
+    }
+
+    data class RemindByMember(
+        val teamBottariId: Long,
+        val teamBottariTitle: String,
+    ) : FcmMessage() {
+        override fun sendNotification(notificationHelper: NotificationHelper) {
+            notificationHelper.sendTeamMessage(
+                teamBottariId,
+                teamBottariTitle,
+                R.string.common_team_bottari_notification_send_remind_by_member_message_text,
+            )
+        }
+
+        companion object {
+            const val TYPE = "REMIND_BY_TEAM_MEMBER"
+
+            fun fromData(data: Map<String, String>) =
+                data.getLong(KEY_TEAM_ID)?.let { id ->
+                    RemindByMember(id, data.getString(KEY_TEAM_TITLE))
+                }
+        }
+    }
+
+    data class RemindByItem(
+        val teamBottariId: Long,
+        val teamBottariTitle: String,
+        val itemName: String,
+    ) : FcmMessage() {
+        override fun sendNotification(notificationHelper: NotificationHelper) {
+            notificationHelper.sendTeamMessage(
+                teamBottariId,
+                teamBottariTitle,
+                R.string.common_team_bottari_notification_send_remind_by_item_message_text,
+                itemName,
+                teamBottariTitle,
+            )
+        }
+
+        companion object {
+            const val TYPE = "REMIND_BY_ITEM"
+            private const val KEY_ITEM_NAME = "teamItemName"
+
+            fun fromData(data: Map<String, String>) =
+                data.getLong(KEY_TEAM_ID)?.let { id ->
+                    RemindByItem(
+                        id,
+                        data.getString(KEY_TEAM_TITLE),
+                        data.getString(KEY_ITEM_NAME),
+                    )
+                }
+        }
+    }
+
+    data class ExitTeam(
+        val teamBottariId: Long,
+        val teamBottariTitle: String,
+        val memberName: String,
+    ) : FcmMessage() {
+        override fun sendNotification(notificationHelper: NotificationHelper) {
+            notificationHelper.sendTeamMessage(
+                teamBottariId,
+                teamBottariTitle,
+                R.string.common_team_bottari_notification_exit_team_bottari_message_text,
+                memberName,
+                teamBottariTitle,
+            )
+        }
+
+        companion object {
+            const val TYPE = "EXIT_TEAM_BOTTARI"
+            private const val KEY_MEMBER_NAME = "exitMemberName"
+
+            fun fromData(data: Map<String, String>) =
+                data.getLong(KEY_TEAM_ID)?.let { id ->
+                    ExitTeam(
+                        id,
+                        data.getString(KEY_TEAM_TITLE),
+                        data.getString(KEY_MEMBER_NAME),
+                    )
+                }
+        }
+    }
+
+    data class Unknown(
+        val rawData: Map<String, String>,
+    ) : FcmMessage() {
+        override fun sendNotification(notificationHelper: NotificationHelper) {
+            val type = rawData[KEY_TYPE].orEmpty()
+            val dataSummary = rawData.entries.joinToString(", ") { "${it.key}=${it.value}" }
+            BottariLogger.error("[FCM] Unknown type: $type, data: $dataSummary")
+        }
+    }
+
+    companion object {
+        const val KEY_TYPE = "type"
+        const val KEY_TEAM_ID = "teamBottariId"
+        const val KEY_TEAM_TITLE = "teamBottariTitle"
+
+        fun fromData(data: Map<String, String>): FcmMessage =
+            when (data[KEY_TYPE]) {
+                TeamItemChanged.TYPE -> TeamItemChanged.fromData(data) ?: Unknown(data)
+                RemindByMember.TYPE -> RemindByMember.fromData(data) ?: Unknown(data)
+                RemindByItem.TYPE -> RemindByItem.fromData(data) ?: Unknown(data)
+                ExitTeam.TYPE -> ExitTeam.fromData(data) ?: Unknown(data)
+                else -> Unknown(data)
+            }
+    }
+}
+
+private fun Map<String, String>.getLong(key: String): Long? = this[key]?.toLongOrNull()
+
+private fun Map<String, String>.getString(key: String): String = this[key].orEmpty()
+
+private fun NotificationHelper.sendTeamMessage(
+    teamId: Long,
+    teamTitle: String,
+    messageRes: Int,
+    vararg args: Any,
+) {
+    sendTeamNotification(teamId, teamTitle, getString(messageRes, *args))
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/ReminderMessagingService.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/ReminderMessagingService.kt
@@ -28,6 +28,7 @@ class ReminderMessagingService(
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
+        BottariLogger.data("[FCM] onMessageReceived!\n${message.data}")
         if (message.data.isEmpty()) return
         handleMessageData(message.data)
     }
@@ -68,6 +69,11 @@ class ReminderMessagingService(
             TYPE_REMIND_BY_ITEM -> {
                 val item = data[KEY_TEAM_ITEM_NAME].orEmpty()
                 handleRemindByItemMessage(teamBottariId, teamBottariTitle, item)
+            }
+
+            TYPE_EXIT_TEAM_BOTTARI -> {
+                val memberName = data[KEY_EXIT_MEMBER_NAME].orEmpty()
+                handleExitTeamBottariMessage(teamBottariId, teamBottariTitle, memberName)
             }
         }
     }
@@ -110,6 +116,20 @@ class ReminderMessagingService(
         notificationHelper.sendTeamNotification(id, title, message)
     }
 
+    private fun handleExitTeamBottariMessage(
+        id: Long,
+        title: String,
+        memberName: String,
+    ) {
+        val message =
+            getString(
+                R.string.common_team_bottari_notification_exit_team_bottari_message_text,
+                memberName,
+                title,
+            )
+        notificationHelper.sendTeamNotification(id, title, message)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         serviceScope.coroutineContext.cancel()
@@ -122,10 +142,12 @@ class ReminderMessagingService(
         private const val KEY_TEAM_BOTTARI_ID = "teamBottariId"
         private const val KEY_TEAM_BOTTARI_TITLE = "teamBottariTitle"
         private const val KEY_TEAM_ITEM_NAME = "teamItemName"
+        private const val KEY_EXIT_MEMBER_NAME = "exitMemberName"
         private const val KEY_MESSAGE_TYPE = "type"
 
         private const val TYPE_TEAM_ITEM_CHANGED = "TEAM_ITEM_CHANGED"
         private const val TYPE_REMIND_BY_TEAM_MEMBER = "REMIND_BY_TEAM_MEMBER"
         private const val TYPE_REMIND_BY_ITEM = "REMIND_BY_ITEM"
+        private const val TYPE_EXIT_TEAM_BOTTARI = "EXIT_TEAM_BOTTARI"
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/ReminderMessagingService.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/service/fcm/ReminderMessagingService.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import com.bottari.di.UseCaseProvider
 import com.bottari.domain.usecase.fcm.SaveFcmTokenUseCase
 import com.bottari.logger.BottariLogger
-import com.bottari.presentation.R
 import com.bottari.presentation.util.NotificationHelper
 import com.google.firebase.messaging.Constants
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -23,14 +22,22 @@ class ReminderMessagingService(
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        saveFcmToken(token)
+        serviceScope.launch {
+            saveFcmTokenUseCase(token)
+                .onFailure { error ->
+                    BottariLogger.error(LOG_FORMAT.format(error.message), error)
+                }
+        }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
-        BottariLogger.data("[FCM] onMessageReceived!\n${message.data}")
+        BottariLogger.data(LOG_FORMAT.format(message.data))
         if (message.data.isEmpty()) return
-        handleMessageData(message.data)
+
+        FcmMessage
+            .fromData(message.data)
+            .sendNotification(notificationHelper)
     }
 
     override fun handleIntent(intent: Intent?) {
@@ -45,91 +52,6 @@ class ReminderMessagingService(
         super.handleIntent(sanitizedIntent)
     }
 
-    private fun saveFcmToken(token: String) {
-        serviceScope.launch {
-            saveFcmTokenUseCase(token)
-                .onFailure { error ->
-                    BottariLogger.error(LOG_FORMAT.format(error.message), error)
-                }
-        }
-    }
-
-    private fun handleMessageData(data: Map<String, String>) {
-        val teamBottariId = data[KEY_TEAM_BOTTARI_ID].toLongOrNullWithLog() ?: return
-        val teamBottariTitle = data[KEY_TEAM_BOTTARI_TITLE].orNullIfBlank() ?: return
-        val type = data[KEY_MESSAGE_TYPE].orNullIfBlank() ?: return
-
-        when (type) {
-            TYPE_TEAM_ITEM_CHANGED ->
-                handleItemChangedMessage(teamBottariId, teamBottariTitle)
-
-            TYPE_REMIND_BY_TEAM_MEMBER ->
-                handleRemindByMemberMessage(teamBottariId, teamBottariTitle)
-
-            TYPE_REMIND_BY_ITEM -> {
-                val item = data[KEY_TEAM_ITEM_NAME].orEmpty()
-                handleRemindByItemMessage(teamBottariId, teamBottariTitle, item)
-            }
-
-            TYPE_EXIT_TEAM_BOTTARI -> {
-                val memberName = data[KEY_EXIT_MEMBER_NAME].orEmpty()
-                handleExitTeamBottariMessage(teamBottariId, teamBottariTitle, memberName)
-            }
-        }
-    }
-
-    private fun String?.toLongOrNullWithLog(): Long? =
-        runCatching { this?.toLong() }
-            .onFailure { error ->
-                BottariLogger.error(LOG_FORMAT.format(error.message), error)
-            }.getOrNull()
-
-    private fun String?.orNullIfBlank(): String? = this?.takeIf { it.isNotBlank() }
-
-    private fun handleItemChangedMessage(
-        id: Long,
-        title: String,
-    ) {
-        val message = getString(R.string.common_team_bottari_notification_item_changed_message_text)
-        notificationHelper.sendTeamNotification(id, title, message)
-    }
-
-    private fun handleRemindByMemberMessage(
-        id: Long,
-        title: String,
-    ) {
-        val message =
-            getString(R.string.common_team_bottari_notification_send_remind_by_member_message_text)
-        notificationHelper.sendTeamNotification(id, title, message)
-    }
-
-    private fun handleRemindByItemMessage(
-        id: Long,
-        title: String,
-        item: String,
-    ) {
-        val message =
-            getString(
-                R.string.common_team_bottari_notification_send_remind_by_item_message_text,
-                item,
-            )
-        notificationHelper.sendTeamNotification(id, title, message)
-    }
-
-    private fun handleExitTeamBottariMessage(
-        id: Long,
-        title: String,
-        memberName: String,
-    ) {
-        val message =
-            getString(
-                R.string.common_team_bottari_notification_exit_team_bottari_message_text,
-                memberName,
-                title,
-            )
-        notificationHelper.sendTeamNotification(id, title, message)
-    }
-
     override fun onDestroy() {
         super.onDestroy()
         serviceScope.coroutineContext.cancel()
@@ -138,16 +60,5 @@ class ReminderMessagingService(
     companion object {
         private const val LOG_FORMAT = "[FCM] %s"
         private const val NOTIFICATION_PREFIX_OLD = "gcm.notification"
-
-        private const val KEY_TEAM_BOTTARI_ID = "teamBottariId"
-        private const val KEY_TEAM_BOTTARI_TITLE = "teamBottariTitle"
-        private const val KEY_TEAM_ITEM_NAME = "teamItemName"
-        private const val KEY_EXIT_MEMBER_NAME = "exitMemberName"
-        private const val KEY_MESSAGE_TYPE = "type"
-
-        private const val TYPE_TEAM_ITEM_CHANGED = "TEAM_ITEM_CHANGED"
-        private const val TYPE_REMIND_BY_TEAM_MEMBER = "REMIND_BY_TEAM_MEMBER"
-        private const val TYPE_REMIND_BY_ITEM = "REMIND_BY_ITEM"
-        private const val TYPE_EXIT_TEAM_BOTTARI = "EXIT_TEAM_BOTTARI"
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/NotificationHelper.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/util/NotificationHelper.kt
@@ -19,6 +19,11 @@ class NotificationHelper(
     private val manager: NotificationManager =
         context.getSystemService(NotificationManager::class.java)
 
+    fun getString(
+        resId: Int,
+        vararg formatArgs: Any,
+    ): String = context.getString(resId, *formatArgs)
+
     fun sendPersonalNotification(
         bottariId: Long,
         bottariTitle: String,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/management/TeamManagementViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/management/TeamManagementViewModel.kt
@@ -67,8 +67,9 @@ class TeamManagementViewModel(
             connectTeamEventUseCase(teamBottariId)
                 .filterIsInstance<EventState.OnEvent>()
                 .map { event -> event.data }
-                .filter { eventData -> eventData is EventData.TeamMemberCreate }
-                .debounce(DEBOUNCE_DELAY)
+                .filter { eventData ->
+                    eventData is EventData.TeamMemberCreate || eventData is EventData.TeamMemberDelete
+                }.debounce(DEBOUNCE_DELAY)
                 .onEach { fetchTeamMembers() }
                 .launchIn(this)
         }

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -242,7 +242,7 @@
     <string name="team_members_status_items_empty_text">챙길 물건이 없어요</string>
     <string name="team_members_status_fetch_failure_text">팀원 현황을 조회하는데 실패했어요</string>
     <string name="team_members_status_send_remind_message_success_text">%s에게 알림을 전송했어요</string>
-    <string name="team_members_status_요_message_failure_text">보채기에 실패했어요</string>
+    <string name="team_members_status_send_remind_message_failure_text">보채기에 실패했어요</string>
     <string name="team_members_status_fetch_member_id_failure_text">내 아이디 불러오기에 실패했어요</string>
 
     <!-- Alarm Edit -->

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="common_team_bottari_notification_item_changed_message_text">챙겨야 할 물건이 변경되었어요.</string>
     <string name="common_team_bottari_notification_send_remind_by_member_message_text">아직 챙기지 않은 물건이 있어요.</string>
     <string name="common_team_bottari_notification_send_remind_by_item_message_text">%s 챙겨 주세요.</string>
-
+    <string name="common_team_bottari_notification_exit_team_bottari_message_text">%s님이 %s에서 나갔어요.</string>
     <!--  Splash Screen  -->
     <string name="splash_screen_permission_denied_text">권한이 거부되어 일부 기능이 제한돼요.\n기능 사용 시 다시 요청드릴게요.</string>
 

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -242,7 +242,7 @@
     <string name="team_members_status_items_empty_text">챙길 물건이 없어요</string>
     <string name="team_members_status_fetch_failure_text">팀원 현황을 조회하는데 실패했어요</string>
     <string name="team_members_status_send_remind_message_success_text">%s에게 알림을 전송했어요</string>
-    <string name="team_members_status_send_remind_message_failure_text">보채기에 실패했어요</string>
+    <string name="team_members_status_요_message_failure_text">보채기에 실패했어요</string>
     <string name="team_members_status_fetch_member_id_failure_text">내 아이디 불러오기에 실패했어요</string>
 
     <!-- Alarm Edit -->
@@ -310,8 +310,8 @@
     <string name="team_product_status_fetch_failure_text">물건 현황을 불러오지 못했어요</string>
     <string name="team_status_empty_view_title">확인할 물건이 보이지 않아요</string>
     <string name="team_status_empty_view_text">팀원들과 함께 보따리를 만들어보세요!</string>
-    <string name="team_status_send_remind_success_text">알람을 설정했어요</string>
-    <string name="team_status_send_remind_failure_text">알람을 설정하지 못했어요</string>
+    <string name="team_status_send_remind_success_text">알림을 전송했어요</string>
+    <string name="team_status_send_remind_failure_text">보채기에 실패했어</string>
     <string name="team_status_send_remind_btn_text">보채기</string>
 
     <!-- Team Bottari Fab -->


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 나가기 SSE 이벤트 및 FCM Type 추가

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #495 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 팀 보따리 나가기 SSE 이벤트 및 FCM Type 추가

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 팀 관련 푸시 알림 유형 추가(팀 아이템 변경, 멤버/아이템 기준 보채기, 팀원 탈퇴) 및 SSE 팀원 탈퇴 이벤트 수신·도메인 반영 추가.

- 개선
  - 팀 관리 화면에서 팀원 탈퇴 이벤트 발생 시 실시간 구성원 목록 갱신 확대.
  - 알림 문구 일부 변경 및 문자열 리소스 정비.

- 기타
  - FCM 수신·처리 흐름 및 로깅 통합, 알림 발송 경로 통일.
  - 알림 헬퍼 문자열 포맷 지원 및 설정값 공백 제거 처리 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->