### PR TITLE
[AN] 리프레시 시 지금 선택한 아이템이 유지되지 않는 버그 수정

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/status/TeamBottariStatusViewModel.kt
@@ -121,10 +121,9 @@ class TeamBottariStatusViewModel(
         val sharedItems = teamBottariStatus.sharedItems.map { it.toSharedUiModel() }
         val assignedItems = teamBottariStatus.assignedItems.map { it.toAssignedUiModel() }
         val teamStatusListItems = generateTeamItemsList(sharedItems, assignedItems)
+        val allProductItems = teamStatusListItems.filterIsInstance<TeamBottariProductStatusUiModel>()
         val selectedProduct =
-            teamStatusListItems
-                .filterIsInstance<TeamBottariProductStatusUiModel>()
-                .firstOrNull()
+            allProductItems.find { it.id == currentState.selectedProduct?.id } ?: allProductItems.firstOrNull()
         updateState {
             copy(
                 sharedItems = sharedItems,


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- [AN] 리프레시 시 지금 선택한 아이템이 유지되지 않는 버그 수정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #498 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
-


<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->

[Screen_recording_20250822_101125.webm](https://github.com/user-attachments/assets/a8e827e2-509e-49c5-9882-0de6660a5300)


<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 팀 상태 목록이 갱신될 때 선택한 상품이 초기화되던 문제를 수정했습니다. 기존에 선택한 상품이 목록에 남아 있으면 그대로 유지되며, 없을 경우 첫 번째 상품이 자동으로 선택됩니다. 상품 항목이 전혀 없으면 선택이 해제됩니다.
  - 항목 생성·변경이 발생해도 선택 상태가 일관되게 유지되어 불필요한 재선택 동작이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->