### PR TITLE
[AN] 물건 편집 화면 SSE 수신 후 화면 상태 유지 안되는 문제 수정

### DIFF
--- a/android/Bottari/app/build.gradle.kts
+++ b/android/Bottari/app/build.gradle.kts
@@ -70,7 +70,7 @@ android {
 
 tasks.register("printVersionName") {
     doLast {
-        println(android.defaultConfig.versionName)
+        println(libs.versions.versionName.get())
     }
 }
 


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 물건 편집 화면 SSE 수신 후 화면 상태 유지 안되는 문제 수정

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #499 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 물건 편집 화면 SSE 수신 후 화면 상태 유지 안되는 문제 수정

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- 추후 팀 보따리 물건 편집 중 입력창 물건 중복 체크 로직을 해결해야 합니다.
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 팀 구성원 호스트 표시가 새로고침 후에도 정확히 유지되도록 동기화 개선
  - 할당 아이템의 선택 상태가 새로고침 시 현재 선택과 일치하도록 동기화
  - 아이템 저장 후 선택/호스트 상태가 일관되게 초기화되어 화면 표시 오류 감소
- 작업(Chores)
  - 빌드 스크립트의 버전 출력 태스크 동작을 정리하여 버전 정보 출력 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->