### PR TITLE
[BE] FCM 메시지 다중 전송 시 오류 발생한 경우 처리 개선

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageSender.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageSender.java
@@ -64,6 +64,7 @@ public class FcmMessageSender {
             fcmTokenService.deleteByIds(invalidTokenIds);
             log.info("만료된 FCM 토큰 {}개를 삭제했습니다.", invalidTokenIds.size());
         }
+        throwIfAllSendsFailed(memberIds, invalidTokenIds);
     }
 
     private boolean isInvalidFcmToken(final FirebaseMessagingException exception) {
@@ -82,5 +83,14 @@ public class FcmMessageSender {
                 .putData("type", request.messageType().name())
                 .putAllData(request.data())
                 .build();
+    }
+
+    private void throwIfAllSendsFailed(
+            final List<Long> memberIds,
+            final List<Long> invalidTokenIds
+    ) {
+        if (memberIds.size() == invalidTokenIds.size()) {
+            throw new BusinessException(FCM_MESSAGE_SEND_FAIL);
+        }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageSender.java
+++ b/backend/bottari/src/main/java/com/bottari/fcm/FcmMessageSender.java
@@ -14,8 +14,10 @@ import com.google.firebase.messaging.MessagingErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FcmMessageSender {
@@ -60,7 +62,7 @@ public class FcmMessageSender {
         }
         if (!invalidTokenIds.isEmpty()) {
             fcmTokenService.deleteByIds(invalidTokenIds);
-            throw new BusinessException(FCM_INVALID_TOKEN);
+            log.info("만료된 FCM 토큰 {}개를 삭제했습니다.", invalidTokenIds.size());
         }
     }
 
@@ -68,7 +70,7 @@ public class FcmMessageSender {
         final MessagingErrorCode messagingErrorCode = exception.getMessagingErrorCode();
 
         return messagingErrorCode == MessagingErrorCode.UNREGISTERED
-               || messagingErrorCode == MessagingErrorCode.INVALID_ARGUMENT;
+                || messagingErrorCode == MessagingErrorCode.INVALID_ARGUMENT;
     }
 
     private Message createMessage(

--- a/backend/bottari/src/main/resources/data.sql
+++ b/backend/bottari/src/main/resources/data.sql
@@ -8,6 +8,17 @@ VALUES ('test_ssaid_1', '다이스'),
        ('test_ssaid_6', '민호떡'),
        ('test_ssaid_7', '김훌라');
 
+-- FCM 토큰 데이터
+INSERT INTO fcm_token (member_id, token)
+VALUES
+    (1, 'fcm_token_1'),
+    (2, 'fcm_token_2'),
+    (3, 'fcm_token_3'),
+    (4, 'fcm_token_4'),
+    (5, 'fcm_token_5'),
+    (6, 'fcm_token_6'),
+    (7, 'fcm_token_7');
+
 -- 보따리 데이터
 INSERT INTO bottari (title, member_id, created_at)
 VALUES

--- a/backend/bottari/src/test/java/com/bottari/fcm/FcmMessageSenderTest.java
+++ b/backend/bottari/src/test/java/com/bottari/fcm/FcmMessageSenderTest.java
@@ -163,24 +163,10 @@ class FcmMessageSenderTest {
                     .doesNotThrowAnyException();
         }
 
-        @DisplayName("FCM 토큰 정보가 존재하지 않으면 예외가 발생한다.")
-        @Test
-        void sendMessageToMembers_Exception_NotExistsFcmToken() {
-            // given
-            final Member member = MemberFixture.MEMBER.get();
-            entityManager.persist(member);
-            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND_BY_ITEM);
-
-            // when & then
-            assertThatThrownBy(() -> fcmMessageSender.sendMessageToMember(member.getId(), request))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage("FCM 토큰 정보가 존재하지 않습니다.");
-        }
-
-        @DisplayName("특정 사용자에 대해 유효하지 않은 FCM 토큰을 사용하면, 해당 토큰을 비활성화하고 예외를 발생시킨다.")
+        @DisplayName("여러 사용자 중 일부만 유효하지 않은 FCM 토큰을 사용하면, 예외 없이 해당 토큰만 비활성화한다.")
         @ParameterizedTest
         @EnumSource(value = MessagingErrorCode.class, names = {"UNREGISTERED", "INVALID_ARGUMENT"})
-        void sendMessageToMembers_Exception_InvalidToken(final MessagingErrorCode errorCode) throws Exception {
+        void sendMessageToMembers_PartialFailure_NoException(final MessagingErrorCode errorCode) throws Exception {
             // given
             final Member member1 = MemberFixture.MEMBER.get();
             entityManager.persist(member1);
@@ -203,9 +189,9 @@ class FcmMessageSenderTest {
             final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND_BY_ITEM);
 
             // when & then
-            assertThatThrownBy(() -> fcmMessageSender.sendMessageToMembers(memberIds, request))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage("유효하지 않은 토큰으로 인해 FCM 메시지 전송을 실패하였습니다.");
+            assertThatCode(() -> fcmMessageSender.sendMessageToMembers(memberIds, request))
+                    .doesNotThrowAnyException();
+
             final FcmToken member1Token = (FcmToken) entityManager.createNativeQuery("""
                                 SELECT * FROM fcm_token WHERE member_id = :id
                             """, FcmToken.class)
@@ -218,6 +204,43 @@ class FcmMessageSenderTest {
                     .getSingleResult();
             assertThat(member1Token.getDeletedAt()).isNotNull();
             assertThat(member2Token.getDeletedAt()).isNull();
+        }
+
+        @DisplayName("모든 사용자가 유효하지 않은 FCM 토큰을 사용하면, 모든 토큰을 비활성화하고 예외를 발생시킨다.")
+        @ParameterizedTest
+        @EnumSource(value = MessagingErrorCode.class, names = {"UNREGISTERED", "INVALID_ARGUMENT"})
+        void sendMessageToMembers_TotalFailure_ThrowException(final MessagingErrorCode errorCode) throws Exception {
+            // given
+            final Member member1 = MemberFixture.MEMBER.get();
+            entityManager.persist(member1);
+            final FcmToken fcmToken1 = FcmTokenFixture.FCM_TOKEN.get(member1);
+            entityManager.persist(fcmToken1);
+            final Member member2 = MemberFixture.MEMBER.get();
+            entityManager.persist(member2);
+            final FcmToken fcmToken2 = FcmTokenFixture.FCM_TOKEN.get(member2);
+            entityManager.persist(fcmToken2);
+            final FirebaseMessagingException exception = createFirebaseMessagingException(errorCode);
+            doThrow(exception).when(firebaseMessaging).send(any(Message.class));
+            final List<Long> memberIds = List.of(member1.getId(), member2.getId());
+            final SendMessageRequest request = new SendMessageRequest(Map.of(), MessageType.REMIND_BY_ITEM);
+
+            // when & then
+            assertThatThrownBy(() -> fcmMessageSender.sendMessageToMembers(memberIds, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("FCM 서버 문제로 FCM 메시지 전송을 실패하였습니다.");
+
+            final FcmToken member1Token = (FcmToken) entityManager.createNativeQuery("""
+                                SELECT * FROM fcm_token WHERE member_id = :id
+                            """, FcmToken.class)
+                    .setParameter("id", member1.getId())
+                    .getSingleResult();
+            final FcmToken member2Token = (FcmToken) entityManager.createNativeQuery("""
+                                SELECT * FROM fcm_token WHERE member_id = :id
+                            """, FcmToken.class)
+                    .setParameter("id", member2.getId())
+                    .getSingleResult();
+            assertThat(member1Token.getDeletedAt()).isNotNull();
+            assertThat(member2Token.getDeletedAt()).isNotNull();
         }
 
         @DisplayName("FCM 서버의 이상으로 메시지 전송에 실패하면 예외가 발생한다.")


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- FCM 메시지 다중 전송 시 오류 발생한 경우 처리 개선

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #523 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 관련 이슈를 살펴봐주세요!

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- 단일 전송에서는 그대로 예외가 발생하도록 구현했습니다. 한명에게 보내는 것이기에 성공 또는 실패만 있기 때문에 비즈니스 로직에서 유연하게 처리하여 사용하는 것이 좋아보였기 때문입니다!
- 전체 전송에서는 애매한 상태(누구는 전송, 누구는 실패)가 있고, 그 이유도 유효하지 않은 토큰(다음에도 사용할 수 없는 토큰)이기 때문에 청소를 한다는 개념으로 예외를 던지지 않도록 했습니다.
    - 모든 요청이 실패한 경우에는 예외를 던지도록 했는데 이부분 고민되네요.

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 푸시 알림 전송 안정성 개선: 여러 사용자에게 전송 시 일부 토큰만 유효하지 않아도 전체 실패로 간주하지 않고 유효하지 않은 토큰만 비활성화 처리.
  - 모든 대상 전송 실패 시에만 오류를 반환하도록 오류 처리 로직 정비.
- 작업(Chores)
  - 개발/테스트용 FCM 토큰 시드 데이터 추가로 초기 데이터 구성 개선.
- 테스트
  - 부분 실패/전체 실패 시나리오 보강 테스트 추가 및 기대 동작 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->