### PR TITLE
[BE] 전문 검색 인덱스 적용

### DIFF
--- a/.github/workflows/ci-dev-server.yml
+++ b/.github/workflows/ci-dev-server.yml
@@ -40,14 +40,16 @@ jobs:
 
       - name: Wait for MySQL to be ready
         run: |
-          for i in {1..30}; do
+          for i in {1..36}; do
             if docker exec test-mysql mysqladmin ping -h localhost -u root -p${{ secrets.TEST_DATABASE_PASSWORD }} --silent; then
               echo "MySQL is up!"
-              break
+              exit 0
             fi
-            echo "Waiting for MySQL..."
-            sleep 2
+            echo "Waiting for MySQL... ($i/36)"
+            sleep 5
           done
+          echo "MySQL did not start within 3 minutes."
+          exit 1
 
       # Webhook 설정
       - name: Determine Webhook
@@ -62,7 +64,6 @@ jobs:
           DATABASE_PASSWORD: ${{ secrets.TEST_DATABASE_PASSWORD }}
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
         run: ./gradlew clean build --no-daemon
-        continue-on-error: true
 
       # 테스트 성공 시 리뷰 요청 알림
       - name: Notify Discord (Test Success - Review Request)

--- a/.github/workflows/ci-dev-server.yml
+++ b/.github/workflows/ci-dev-server.yml
@@ -9,15 +9,6 @@ on:
 jobs:
   ci-and-pr-notification:
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: ${{ secrets.TEST_DATABASE_IMAGE }}
-        env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.TEST_DATABASE_PASSWORD }}
-          MYSQL_DATABASE: ${{ secrets.TEST_DATABASE_NAME }}
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping -h localhost" --health-interval=10s --health-timeout=5s --health-retries=10 -v ${{ github.workspace }}/custom-mysql.cnf:/etc/mysql/conf.d/custom.cnf
 
     steps:
       - name: Checkout Repository
@@ -36,6 +27,27 @@ jobs:
         run: |
           echo "[mysqld]" > custom-mysql.cnf
           echo "ngram_token_size=${{ secrets.TEST_NGRAM_TOKEN_SIZE }}" >> custom-mysql.cnf
+
+      - name: Start MySQL with custom image
+        run: |
+          docker run -d \
+            --name test-mysql \
+            -e MYSQL_ROOT_PASSWORD=${{ secrets.TEST_DATABASE_PASSWORD }} \
+            -e MYSQL_DATABASE=${{ secrets.TEST_DATABASE_NAME }} \
+            -p 3306:3306 \
+            -v ${{ github.workspace }}/custom-mysql.cnf:/etc/mysql/conf.d/custom.cnf \
+            ${{ secrets.TEST_DATABASE_IMAGE }}
+
+      - name: Wait for MySQL to be ready
+        run: |
+          for i in {1..30}; do
+            if docker exec test-mysql mysqladmin ping -h localhost -u root -p${{ secrets.TEST_DATABASE_PASSWORD }} --silent; then
+              echo "MySQL is up!"
+              break
+            fi
+            echo "Waiting for MySQL..."
+            sleep 2
+          done
 
       # Webhook 설정
       - name: Determine Webhook
@@ -58,7 +70,6 @@ jobs:
           BASE_BRANCH=${{ github.event.pull_request.base.ref }}
           HEAD_BRANCH=${{ github.event.pull_request.head.ref }}
 
-          # 리뷰어 멘션 & 리스트 생성
           REVIEWERS=$(jq -r '.pull_request.requested_reviewers[].login' <<< '${{ toJson(github.event) }}')
           MENTIONS=""
           REVIEWER_NAMES=""
@@ -119,3 +130,8 @@ jobs:
           }'
           echo "$MESSAGE" > payload.json
           curl -H "Content-Type: application/json" -d @payload.json $WEBHOOK
+
+      # 항상 DB 컨테이너 정리
+      - name: Cleanup MySQL
+        if: always()
+        run: docker rm -f test-mysql || true

--- a/.github/workflows/ci-dev-server.yml
+++ b/.github/workflows/ci-dev-server.yml
@@ -9,6 +9,16 @@ on:
 jobs:
   ci-and-pr-notification:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: ${{ secrets.TEST_DATABASE_IMAGE }}
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.TEST_DATABASE_PASSWORD }}
+          MYSQL_DATABASE: ${{ secrets.TEST_DATABASE_NAME }}
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping -h localhost" --health-interval=10s --health-timeout=5s --health-retries=10 -v ${{ github.workspace }}/custom-mysql.cnf:/etc/mysql/conf.d/custom.cnf
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -22,12 +32,22 @@ jobs:
       - name: Grant Execute Permission for Gradlew
         run: chmod +x ./backend/bottari/gradlew
 
+      - name: Create MySQL Custom Config for ngram
+        run: |
+          echo "[mysqld]" > custom-mysql.cnf
+          echo "ngram_token_size=${{ secrets.TEST_NGRAM_TOKEN_SIZE }}" >> custom-mysql.cnf
+
       # Webhook 설정
       - name: Determine Webhook
         run: echo "WEBHOOK=${{ secrets.DISCORD_BACKEND_WEBHOOK }}" >> $GITHUB_ENV
 
       - name: Build and Test
         id: test
+        working-directory: ./backend/bottari
+        env:
+          DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+          DATABASE_USERNAME: ${{ secrets.TEST_DATABASE_USERNAME }}
+          DATABASE_PASSWORD: ${{ secrets.TEST_DATABASE_PASSWORD }}
         run: ./gradlew clean build --no-daemon
         continue-on-error: true
 

--- a/.github/workflows/ci-dev-server.yml
+++ b/.github/workflows/ci-dev-server.yml
@@ -60,6 +60,7 @@ jobs:
           DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
           DATABASE_USERNAME: ${{ secrets.TEST_DATABASE_USERNAME }}
           DATABASE_PASSWORD: ${{ secrets.TEST_DATABASE_PASSWORD }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
         run: ./gradlew clean build --no-daemon
         continue-on-error: true
 

--- a/.github/workflows/deploy-dev-server.yml
+++ b/.github/workflows/deploy-dev-server.yml
@@ -58,4 +58,8 @@ jobs:
           DATABASE_PASSWORD='${{ secrets.DATABASE_DEV_PASSWORD }}' \
           FIREBASE_SERVICE_ACCOUNT_JSON='${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}' \
           SPRING_PROFILES_ACTIVE=dev \
-          nohup java -Duser.timezone=Asia/Seoul -jar "$JAR_FILE" --server.port=8080 > app.log 2>&1 &
+          nohup java -Duser.timezone=Asia/Seoul \
+          -javaagent:/home/ubuntu/pinpoint-agent-3.0.3/pinpoint-bootstrap-3.0.3.jar \
+          -Dpinpoint.agentId=dev-bottari-1 \
+          -Dpinpoint.applicationName=dev-bottari \
+          -jar "$JAR_FILE" --server.port=8080 > app.log 2>&1 &

--- a/.github/workflows/deploy-dev-server.yml
+++ b/.github/workflows/deploy-dev-server.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build Jar
         working-directory: ./backend/bottari
-        run: ./gradlew clean build
+        run: ./gradlew clean build -x test
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-prod-server.yml
+++ b/.github/workflows/deploy-prod-server.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Build Jar
         working-directory: ./backend/bottari
-        run: ./gradlew clean build
+        run: ./gradlew clean build -x test
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/backend/bottari/build.gradle
+++ b/backend/bottari/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:9.5.0'
     implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/backend/bottari/docker/local-compose.yml
+++ b/backend/bottari/docker/local-compose.yml
@@ -1,0 +1,10 @@
+services:
+  db:
+    container_name: bottari-mysql
+    image: mysql:8.0.42
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: bottari
+      MYSQL_ROOT_PASSWORD: 1234
+    command: ["--ngram_token_size=1"]

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateCursor.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateCursor.java
@@ -5,6 +5,8 @@ import com.bottari.error.ErrorCode;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -35,7 +37,10 @@ public record BottariTemplateCursor(
             return "";
         }
 
-        return query;
+        return Arrays.stream(query.trim().split("\\s+"))
+                .filter(word -> !word.isBlank())
+                .map(word -> "+" + word)
+                .collect(Collectors.joining(" "));
     }
 
     private static int normalizeSize(final int size) {

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadBottariTemplateResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadBottariTemplateResponse.java
@@ -2,6 +2,7 @@ package com.bottari.bottaritemplate.dto;
 
 import com.bottari.bottaritemplate.domain.BottariTemplate;
 import com.bottari.bottaritemplate.domain.BottariTemplateItem;
+import com.bottari.bottaritemplate.repository.dto.BottariTemplateProjection;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -29,6 +30,24 @@ public record ReadBottariTemplateResponse(
                 bottariTemplate.getMember().getName(),
                 bottariTemplate.getCreatedAt(),
                 bottariTemplate.getTakenCount()
+        );
+    }
+
+    public static ReadBottariTemplateResponse of(
+            final BottariTemplateProjection projection,
+            final List<BottariTemplateItem> bottariTemplateItems
+    ) {
+        final List<BottariTemplateItemResponse> items = bottariTemplateItems.stream()
+                .map(BottariTemplateItemResponse::from)
+                .toList();
+
+        return new ReadBottariTemplateResponse(
+                projection.getBottariTemplateId(),
+                projection.getTitle(),
+                items,
+                projection.getMemberName(),
+                projection.getBottariTemplateCreatedAt(),
+                projection.getTakenCount()
         );
     }
 

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateItemRepository.java
@@ -13,6 +13,9 @@ public interface BottariTemplateItemRepository extends JpaRepository<BottariTemp
 
     List<BottariTemplateItem> findAllByBottariTemplateIn(final List<BottariTemplate> bottariTemplates);
 
+    @Query("SELECT bti FROM BottariTemplateItem bti WHERE bti.bottariTemplate.id IN :templateIds")
+    List<BottariTemplateItem> findAllByBottariTemplateIds(List<Long> templateIds);
+
     @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE BottariTemplateItem bti

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateItemRepository.java
@@ -13,7 +13,11 @@ public interface BottariTemplateItemRepository extends JpaRepository<BottariTemp
 
     List<BottariTemplateItem> findAllByBottariTemplateIn(final List<BottariTemplate> bottariTemplates);
 
-    @Query("SELECT bti FROM BottariTemplateItem bti WHERE bti.bottariTemplate.id IN :templateIds")
+    @Query("""
+            SELECT bti
+            FROM BottariTemplateItem bti
+            WHERE bti.bottariTemplate.id IN :templateIds
+            """)
     List<BottariTemplateItem> findAllByBottariTemplateIds(List<Long> templateIds);
 
     @Modifying(clearAutomatically = true)

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateRepository.java
@@ -1,6 +1,8 @@
 package com.bottari.bottaritemplate.repository;
 
 import com.bottari.bottaritemplate.domain.BottariTemplate;
+import com.bottari.bottaritemplate.repository.dto.BottariTemplateProjection;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -30,40 +32,54 @@ public interface BottariTemplateRepository extends JpaRepository<BottariTemplate
             """)
     List<BottariTemplate> findAllWithMember(final String query);
 
-    @Query("""
-            SELECT bt
-            FROM BottariTemplate bt
-            JOIN FETCH bt.member m
-            WHERE bt.title LIKE CONCAT('%', :query, '%')
-              AND (
-                    bt.createdAt < :lastCreatedAt
-                 OR (bt.createdAt = :lastCreatedAt AND bt.id < :lastId)
-              )
-            ORDER BY bt.createdAt DESC, bt.id DESC
-            """)
-    Slice<BottariTemplate> findNextByCreatedAt(
+    @Query(value = """
+            SELECT STRAIGHT_JOIN
+                       bt.id AS bottariTemplateId,
+                       bt.title AS title,
+                       bt.taken_count AS takenCount,
+                       bt.created_at AS bottariTemplateCreatedAt,
+                       m.id AS memberId,
+                       m.name AS memberName
+            FROM bottari_template bt
+            JOIN member m ON m.id = bt.member_id
+            WHERE (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
+                AND(
+                        bt.created_at < :lastCreatedAt
+                            OR (bt.created_at = :lastCreatedAt AND bt.id < :lastId)
+                        )
+            ORDER BY bt.created_at DESC, bt.id DESC 
+            LIMIT :limit
+        """ ,nativeQuery = true)
+    List<BottariTemplateProjection> findNextByCreatedAt(
             final String query,
             final LocalDateTime lastCreatedAt,
             final Long lastId,
-            final Pageable pageable
+            final int limit
     );
 
-    @Query("""
-            SELECT bt
-            FROM BottariTemplate bt
-            JOIN FETCH bt.member m
-            WHERE bt.title LIKE CONCAT('%', :query, '%')
-              AND (
-                    bt.takenCount < :lastTakenCount
-                 OR (bt.takenCount = :lastTakenCount AND bt.id < :lastId)
-              )
-            ORDER BY bt.takenCount DESC, bt.id DESC
-            """)
-    Slice<BottariTemplate> findNextByTakenCount(
+    @Query(value = """
+            SELECT STRAIGHT_JOIN
+                  bt.id AS bottariTemplateId,
+                  bt.title AS title,
+                  bt.taken_count AS takenCount,
+                  bt.created_at AS bottariTemplateCreatedAt,
+                  m.id AS memberId,
+                  m.name AS memberName
+            FROM bottari_template bt
+            JOIN member m ON m.id = bt.member_id
+            WHERE (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
+                AND (
+                    bt.taken_count < :lastTakenCount
+                        OR (bt.taken_count = :lastTakenCount AND bt.id < :lastId)
+                    )
+            ORDER BY bt.taken_count DESC, bt.id DESC
+            LIMIT :limit
+            """ ,nativeQuery = true)
+    List<BottariTemplateProjection> findNextByTakenCount(
             final String query,
             final Long lastTakenCount,
             final Long lastId,
-            final Pageable pageable
+            final int limit
     );
 
     @Query("""

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateRepository.java
@@ -2,12 +2,9 @@ package com.bottari.bottaritemplate.repository;
 
 import com.bottari.bottaritemplate.domain.BottariTemplate;
 import com.bottari.bottaritemplate.repository.dto.BottariTemplateProjection;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -41,7 +38,7 @@ public interface BottariTemplateRepository extends JpaRepository<BottariTemplate
                        m.id AS memberId,
                        m.name AS memberName
             FROM bottari_template bt
-            JOIN member m ON m.id = bt.member_id
+            JOIN member m ON m.id = bt.member_id 
             WHERE (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
                 AND(
                         bt.created_at < :lastCreatedAt

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/dto/BottariTemplateProjection.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/dto/BottariTemplateProjection.java
@@ -1,0 +1,13 @@
+package com.bottari.bottaritemplate.repository.dto;
+
+import java.time.LocalDateTime;
+
+public interface BottariTemplateProjection {
+
+    Long getBottariTemplateId();
+    String getTitle();
+    Integer getTakenCount();
+    LocalDateTime getBottariTemplateCreatedAt();
+    Long getMemberId();
+    String getMemberName();
+}

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
@@ -2,24 +2,26 @@ package com.bottari.bottaritemplate.service;
 
 import com.bottari.bottari.domain.Bottari;
 import com.bottari.bottari.domain.BottariItem;
+import com.bottari.bottari.repository.BottariItemRepository;
+import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.bottaritemplate.domain.BottariTemplate;
 import com.bottari.bottaritemplate.domain.BottariTemplateCursor;
 import com.bottari.bottaritemplate.domain.BottariTemplateHistory;
-import com.bottari.bottaritemplate.repository.BottariTemplateHistoryRepository;
 import com.bottari.bottaritemplate.domain.BottariTemplateItem;
-import com.bottari.bottaritemplate.repository.BottariTemplateItemRepository;
-import com.bottari.bottaritemplate.repository.BottariTemplateRepository;
 import com.bottari.bottaritemplate.domain.SortProperty;
-import com.bottari.member.domain.Member;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
+import com.bottari.bottaritemplate.repository.BottariTemplateHistoryRepository;
+import com.bottari.bottaritemplate.repository.BottariTemplateItemRepository;
+import com.bottari.bottaritemplate.repository.BottariTemplateRepository;
+import com.bottari.bottaritemplate.repository.dto.BottariTemplateProjection;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
-import com.bottari.bottari.repository.BottariItemRepository;
-import com.bottari.bottari.repository.BottariRepository;
+import com.bottari.member.domain.Member;
 import com.bottari.member.repository.MemberRepository;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -76,10 +78,13 @@ public class BottariTemplateService {
     public ReadNextBottariTemplateResponse getNextAll(final ReadNextBottariTemplateRequest request) {
         final BottariTemplateCursor cursor = request.toCursor();
         final Pageable pageable = cursor.toPageable();
-        final Slice<BottariTemplate> bottariTemplates = getNextBySortProperty(cursor, pageable);
-        final Map<BottariTemplate, List<BottariTemplateItem>> itemsGroupByTemplate = groupingItemsByTemplate(
+        final Slice<BottariTemplateProjection> bottariTemplates = getNextBySortProperty(cursor, pageable);
+        final Map<Long, List<BottariTemplateItem>> itemsGroupByTemplateId = groupingItemsByTemplateId(
                 bottariTemplates.getContent());
-        final List<ReadBottariTemplateResponse> responses = buildReadBottariTemplateResponses(itemsGroupByTemplate);
+        final List<ReadBottariTemplateResponse> responses = buildReadBottariTemplateResponses(
+                itemsGroupByTemplateId,
+                bottariTemplates.getContent()
+        );
 
         return ReadNextBottariTemplateResponse.of(
                 new SliceImpl<>(responses, pageable, bottariTemplates.hasNext()), cursor.property());
@@ -137,20 +142,35 @@ public class BottariTemplateService {
         bottariTemplateRepository.deleteById(id);
     }
 
-    private Slice<BottariTemplate> getNextBySortProperty(
+    private Slice<BottariTemplateProjection> getNextBySortProperty(
             final BottariTemplateCursor cursor,
             final Pageable pageable
     ) {
         final SortProperty property = SortProperty.fromProperty(cursor.property());
+        final int limit = pageable.getPageSize() + 1;
         return switch (property) {
-            case SortProperty.CREATED_AT -> bottariTemplateRepository.findNextByCreatedAt(
-                    cursor.query(), cursor.getCreatedAt(), cursor.lastId(), pageable);
-            case SortProperty.TAKEN_COUNT -> bottariTemplateRepository.findNextByTakenCount(
-                    cursor.query(), cursor.getTakenCount(), cursor.lastId(), pageable);
+            case SortProperty.CREATED_AT -> toSlice(pageable, bottariTemplateRepository.findNextByCreatedAt(
+                    cursor.query(), cursor.getCreatedAt(), cursor.lastId(), limit));
+            case SortProperty.TAKEN_COUNT -> toSlice(pageable, bottariTemplateRepository.findNextByTakenCount(
+                    cursor.query(), cursor.getTakenCount(), cursor.lastId(), limit));
         };
     }
 
-    private Map<BottariTemplate, List<BottariTemplateItem>> groupingItemsByTemplate(final List<BottariTemplate> bottariTemplates) {
+    private Slice<BottariTemplateProjection> toSlice(
+            final Pageable pageable,
+            final List<BottariTemplateProjection> bottariTemplateProjections
+    ) {
+        System.out.println("사이즈 = " + bottariTemplateProjections.size());
+        final boolean hasNext = bottariTemplateProjections.size() > pageable.getPageSize();
+        List<BottariTemplateProjection> projections = new ArrayList<>(bottariTemplateProjections);
+        if (hasNext) {
+            projections = projections.subList(0, pageable.getPageSize());
+        }
+        return new SliceImpl<>(projections, pageable, hasNext);
+    }
+
+    private Map<BottariTemplate, List<BottariTemplateItem>> groupingItemsByTemplate(
+            final List<BottariTemplate> bottariTemplates) {
         final Map<BottariTemplate, List<BottariTemplateItem>> groupByTemplates = new LinkedHashMap<>();
         final List<BottariTemplateItem> items = bottariTemplateItemRepository.findAllByBottariTemplateIn(
                 bottariTemplates);
@@ -160,6 +180,25 @@ public class BottariTemplateService {
         for (final BottariTemplateItem item : items) {
             final BottariTemplate bottariTemplate = item.getBottariTemplate();
             groupByTemplates.get(bottariTemplate).add(item);
+        }
+
+        return groupByTemplates;
+    }
+
+    private Map<Long, List<BottariTemplateItem>> groupingItemsByTemplateId(
+            final List<BottariTemplateProjection> bottariTemplates
+    ) {
+        final Map<Long, List<BottariTemplateItem>> groupByTemplates = new LinkedHashMap<>();
+        List<Long> ids = bottariTemplates.stream()
+                .map(BottariTemplateProjection::getBottariTemplateId)
+                .toList();
+        final List<BottariTemplateItem> items = bottariTemplateItemRepository.findAllByBottariTemplateIds(ids);
+        for (final Long id : ids) {
+            groupByTemplates.put(id, new ArrayList<>());
+        }
+        for (final BottariTemplateItem item : items) {
+            final BottariTemplate bottariTemplate = item.getBottariTemplate();
+            groupByTemplates.get(bottariTemplate.getId()).add(item);
         }
 
         return groupByTemplates;
@@ -175,6 +214,22 @@ public class BottariTemplateService {
                     List.of()
             );
             responses.add(ReadBottariTemplateResponse.of(bottariTemplate, templateItems));
+        }
+
+        return responses;
+    }
+
+    private List<ReadBottariTemplateResponse> buildReadBottariTemplateResponses(
+            final Map<Long, List<BottariTemplateItem>> itemsGroupByTemplate,
+            final List<BottariTemplateProjection> projections
+    ) {
+        final List<ReadBottariTemplateResponse> responses = new ArrayList<>();
+        for (final BottariTemplateProjection projection : projections) {
+            final List<BottariTemplateItem> items = itemsGroupByTemplate.getOrDefault(
+                    projection.getBottariTemplateId(),
+                    List.of()
+            );
+            responses.add(ReadBottariTemplateResponse.of(projection, items));
         }
 
         return responses;
@@ -219,7 +274,9 @@ public class BottariTemplateService {
             final BottariTemplate bottariTemplate,
             final Member member
     ) {
-        return bottariTemplateHistoryRepository.existsByBottariTemplateIdAndMemberId(bottariTemplate.getId(),
-                member.getId());
+        return bottariTemplateHistoryRepository.existsByBottariTemplateIdAndMemberId(
+                bottariTemplate.getId(),
+                member.getId()
+        );
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
@@ -21,7 +21,6 @@ import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.member.domain.Member;
 import com.bottari.member.repository.MemberRepository;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -169,7 +168,8 @@ public class BottariTemplateService {
     }
 
     private Map<BottariTemplate, List<BottariTemplateItem>> groupingItemsByTemplate(
-            final List<BottariTemplate> bottariTemplates) {
+            final List<BottariTemplate> bottariTemplates
+    ) {
         final Map<BottariTemplate, List<BottariTemplateItem>> groupByTemplates = new LinkedHashMap<>();
         final List<BottariTemplateItem> items = bottariTemplateItemRepository.findAllByBottariTemplateIn(
                 bottariTemplates);
@@ -188,7 +188,7 @@ public class BottariTemplateService {
             final List<BottariTemplateProjection> bottariTemplates
     ) {
         final Map<Long, List<BottariTemplateItem>> groupByTemplates = new LinkedHashMap<>();
-        List<Long> ids = bottariTemplates.stream()
+        final List<Long> ids = bottariTemplates.stream()
                 .map(BottariTemplateProjection::getBottariTemplateId)
                 .toList();
         final List<BottariTemplateItem> items = bottariTemplateItemRepository.findAllByBottariTemplateIds(ids);

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
@@ -160,7 +160,6 @@ public class BottariTemplateService {
             final Pageable pageable,
             final List<BottariTemplateProjection> bottariTemplateProjections
     ) {
-        System.out.println("사이즈 = " + bottariTemplateProjections.size());
         final boolean hasNext = bottariTemplateProjections.size() > pageable.getPageSize();
         List<BottariTemplateProjection> projections = new ArrayList<>(bottariTemplateProjections);
         if (hasNext) {

--- a/backend/bottari/src/main/resources/application.yml
+++ b/backend/bottari/src/main/resources/application.yml
@@ -6,9 +6,20 @@ spring:
       ddl-auto: create
     defer-datasource-initialization: true
     open-in-view: true
+    database-platform: org.hibernate.dialect.MySQLDialect
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   sql:
     init:
       mode: always
+      data-locations: classpath:init.sql
 firebase:
   service:
     key-path: ${FIREBASE_SERVICE_ACCOUNT_JSON}

--- a/backend/bottari/src/main/resources/init.sql
+++ b/backend/bottari/src/main/resources/init.sql
@@ -18,8 +18,6 @@ SELECT CONCAT('test_ssaid_', x),
        CONCAT('이', x)
 FROM seq;
 
-
-
 -- 보따리 데이터
 INSERT INTO bottari (title, member_id, created_at)
 VALUES

--- a/backend/bottari/src/main/resources/init.sql
+++ b/backend/bottari/src/main/resources/init.sql
@@ -8,6 +8,18 @@ VALUES ('test_ssaid_1', '다이스'),
        ('test_ssaid_6', '민호떡'),
        ('test_ssaid_7', '김훌라');
 
+INSERT INTO member (ssaid, name)
+WITH RECURSIVE seq AS (
+    SELECT 8 AS x
+    UNION ALL
+    SELECT x + 1 FROM seq WHERE x < 1000
+)
+SELECT CONCAT('test_ssaid_', x),
+       CONCAT('이', x)
+FROM seq;
+
+
+
 -- 보따리 데이터
 INSERT INTO bottari (title, member_id, created_at)
 VALUES

--- a/backend/bottari/src/main/resources/schema.sql
+++ b/backend/bottari/src/main/resources/schema.sql
@@ -1,0 +1,9 @@
+CREATE FULLTEXT INDEX idx_template_title
+    ON bottari_template(title)
+    WITH PARSER ngram;
+
+CREATE INDEX idx_created_at_id
+    ON bottari_template(created_at desc, id desc);
+
+CREATE INDEX idx_taken_count_id
+    ON bottari_template(taken_count desc, id desc);

--- a/backend/bottari/src/test/java/com/bottari/alarm/service/AlarmServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/alarm/service/AlarmServiceTest.java
@@ -26,10 +26,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(AlarmService.class)
 class AlarmServiceTest {
 

--- a/backend/bottari/src/test/java/com/bottari/bottari/repository/BottariDeleteTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottari/repository/BottariDeleteTest.java
@@ -11,9 +11,11 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class BottariDeleteTest {
 
     @Autowired

--- a/backend/bottari/src/test/java/com/bottari/bottari/repository/BottariItemDeleteTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottari/repository/BottariItemDeleteTest.java
@@ -14,9 +14,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class BottariItemDeleteTest {
 
     @Autowired

--- a/backend/bottari/src/test/java/com/bottari/bottari/service/BottariItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottari/service/BottariItemServiceTest.java
@@ -20,10 +20,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(BottariItemService.class)
 class BottariItemServiceTest {
 

--- a/backend/bottari/src/test/java/com/bottari/bottari/service/BottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottari/service/BottariServiceTest.java
@@ -30,10 +30,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({BottariService.class, JpaAuditingConfig.class})
 class BottariServiceTest {
 

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateCursorTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateCursorTest.java
@@ -6,11 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.bottari.error.BusinessException;
 import java.time.LocalDateTime;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.data.domain.Pageable;
 
@@ -20,15 +23,15 @@ class BottariTemplateCursorTest {
     class NormalizationTest {
 
         @DisplayName("query 정규화 테스트")
-        @Test
-        void normalizeQuery() {
-            // given
-            final String blankQuery = " ";
-            final String expected = "";
-
+        @ParameterizedTest
+        @MethodSource
+        void normalizeQuery(
+                final String query,
+                final String expected
+        ) {
             // when
             final BottariTemplateCursor actual = new BottariTemplateCursor(
-                    blankQuery,
+                    query,
                     1L,
                     "info",
                     0,
@@ -38,6 +41,17 @@ class BottariTemplateCursorTest {
 
             // then
             assertThat(actual.query()).isEqualTo(expected);
+        }
+
+        private static Stream<Arguments> normalizeQuery() {
+            return Stream.of(
+                    Arguments.of("자동차 경주", "+자동차 +경주"),
+                    Arguments.of(" 자동차 경주 ", "+자동차 +경주"),
+                    Arguments.of("자동차 경주 입니다", "+자동차 +경주 +입니다"),
+                    Arguments.of("", ""),
+                    Arguments.of(" ", ""),
+                    Arguments.of(null, "")
+            );
         }
 
         @DisplayName("page 정규화 테스트")

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/repository/BottariTemplateDeleteTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/repository/BottariTemplateDeleteTest.java
@@ -11,9 +11,11 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class BottariTemplateDeleteTest {
 
     @Autowired

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/repository/BottariTemplateItemDeleteTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/repository/BottariTemplateItemDeleteTest.java
@@ -14,9 +14,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class BottariTemplateItemDeleteTest {
 
     @Autowired

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
@@ -22,7 +22,7 @@ import com.bottari.member.domain.Member;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -125,15 +125,15 @@ class BottariTemplateServiceTest {
 
             // then
             assertAll(() -> {
-                        assertThat(actual).hasSize(2);
-                        assertThat(actual.get(0).title()).isEqualTo(memberTemplate2.getTitle());
-                        assertThat(actual.get(0).items()).hasSize(1);
-                        assertThat(actual.get(0).items().getFirst().name()).isEqualTo(item3.getName());
-                        assertThat(actual.get(1).title()).isEqualTo(memberTemplate1.getTitle());
-                        assertThat(actual.get(1).items()).hasSize(2);
-                        assertThat(actual.get(1).items().get(0).name()).isEqualTo(item1.getName());
-                        assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName());
-                    }
+                          assertThat(actual).hasSize(2);
+                          assertThat(actual.get(0).title()).isEqualTo(memberTemplate2.getTitle());
+                          assertThat(actual.get(0).items()).hasSize(1);
+                          assertThat(actual.get(0).items().getFirst().name()).isEqualTo(item3.getName());
+                          assertThat(actual.get(1).title()).isEqualTo(memberTemplate1.getTitle());
+                          assertThat(actual.get(1).items()).hasSize(2);
+                          assertThat(actual.get(1).items().get(0).name()).isEqualTo(item1.getName());
+                          assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName());
+                      }
             );
         }
 
@@ -324,7 +324,7 @@ class BottariTemplateServiceTest {
             );
         }
 
-        @Ignore
+        @Disabled
         @DisplayName("검색어로 필터링하여 다음 페이지 템플릿 목록을 조회한다.")
         @Test
         void getNextAll_WithQuery() {
@@ -410,11 +410,12 @@ class BottariTemplateServiceTest {
             final Long actual = bottariTemplateService.create(member.getSsaid(), request);
 
             // then
-            final List<BottariTemplateItem> actualItems = entityManager.createQuery("""
-                            SELECT i
-                            FROM BottariTemplateItem i
-                            WHERE i.bottariTemplate.id =: bottariTemplateId
-                            """, BottariTemplateItem.class)
+            final List<BottariTemplateItem> actualItems = entityManager.createQuery(
+                            """
+                                    SELECT i
+                                    FROM BottariTemplateItem i
+                                    WHERE i.bottariTemplate.id =: bottariTemplateId
+                                    """, BottariTemplateItem.class)
                     .setParameter("bottariTemplateId", actual)
                     .getResultList();
 
@@ -531,12 +532,13 @@ class BottariTemplateServiceTest {
             bottariTemplateService.createBottari(bottariTemplate.getId(), ssaid);
 
             // then
-            final BottariTemplateHistory acutalBottariTemplateHistory = entityManager.createQuery("""
-                                             SELECT bh
-                                             FROM BottariTemplateHistory bh
-                                             WHERE bh.id.memberId = :memberId
-                                             AND bh.id.bottariTemplateId = :bottariTemplateId
-                            """, BottariTemplateHistory.class)
+            final BottariTemplateHistory acutalBottariTemplateHistory = entityManager.createQuery(
+                            """
+                                                     SELECT bh
+                                                     FROM BottariTemplateHistory bh
+                                                     WHERE bh.id.memberId = :memberId
+                                                     AND bh.id.bottariTemplateId = :bottariTemplateId
+                                    """, BottariTemplateHistory.class)
                     .setParameter("memberId", member.getId())
                     .setParameter("bottariTemplateId", bottariTemplate.getId())
                     .getSingleResult();
@@ -573,16 +575,18 @@ class BottariTemplateServiceTest {
 
             // then
             final Long actualHistoryCount = entityManager.createQuery("""
-                                             SELECT COUNT(bh)
-                                             FROM BottariTemplateHistory bh
-                                             WHERE bh.id.memberId = :memberId
-                                             AND bh.id.bottariTemplateId = :bottariTemplateId
-                            """, Long.class)
+                                                                                               SELECT COUNT(bh)
+                                                                                               FROM BottariTemplateHistory bh
+                                                                                               WHERE bh.id.memberId = :memberId
+                                                                                               AND bh.id.bottariTemplateId = :bottariTemplateId
+                                                                              """, Long.class)
                     .setParameter("memberId", member.getId())
                     .setParameter("bottariTemplateId", bottariTemplate.getId())
                     .getSingleResult();
-            final BottariTemplate actualBottariTemplate = entityManager.find(BottariTemplate.class,
-                    bottariTemplate.getId());
+            final BottariTemplate actualBottariTemplate = entityManager.find(
+                    BottariTemplate.class,
+                    bottariTemplate.getId()
+            );
             assertAll(
                     () -> assertThat(actualBottariTemplate.getTakenCount()).isEqualTo(1),
                     () -> assertThat(actualHistoryCount).isEqualTo(1L)

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
@@ -22,14 +22,17 @@ import com.bottari.member.domain.Member;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
+import org.junit.Ignore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({BottariTemplateService.class, JpaAuditingConfig.class})
 class BottariTemplateServiceTest {
 
@@ -321,6 +324,7 @@ class BottariTemplateServiceTest {
             );
         }
 
+        @Ignore
         @DisplayName("검색어로 필터링하여 다음 페이지 템플릿 목록을 조회한다.")
         @Test
         void getNextAll_WithQuery() {
@@ -350,6 +354,8 @@ class BottariTemplateServiceTest {
                     2,
                     "createdAt"
             );
+            entityManager.flush();
+            entityManager.clear();
 
             // when
             final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAll(request);
@@ -480,8 +486,10 @@ class BottariTemplateServiceTest {
             entityManager.persist(member);
 
             // when
-            final Long actualBottariId = bottariTemplateService.createBottari(bottariTemplate.getId(),
-                    member.getSsaid());
+            final Long actualBottariId = bottariTemplateService.createBottari(
+                    bottariTemplate.getId(),
+                    member.getSsaid()
+            );
             final Bottari actualBottari = entityManager.find(Bottari.class, actualBottariId);
             final List<BottariItem> actualBottariItems = entityManager.createQuery(
                             "SELECT i FROM BottariItem i WHERE i.bottari.id = :bottariId",

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
@@ -22,7 +22,7 @@ import com.bottari.member.domain.Member;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.transaction.TestTransaction;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -236,6 +237,17 @@ class BottariTemplateServiceTest {
     @Nested
     class GetNextAllTest {
 
+        @AfterEach
+        void tearDown() {
+            // 쿼리로 데이터베이스 테이블 초기화
+            entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE bottari_template_history").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE bottari_template_item").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE bottari_template").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE member").executeUpdate();
+            entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+        }
+
         @DisplayName("createdAt 기준으로 다음 페이지 템플릿 목록을 조회한다.")
         @Test
         void getNextAll_ByCreatedAt() {
@@ -324,7 +336,6 @@ class BottariTemplateServiceTest {
             );
         }
 
-        @Disabled
         @DisplayName("검색어로 필터링하여 다음 페이지 템플릿 목록을 조회한다.")
         @Test
         void getNextAll_WithQuery() {
@@ -345,6 +356,20 @@ class BottariTemplateServiceTest {
             entityManager.persist(item1);
             entityManager.persist(item2);
             entityManager.persist(item3);
+
+            /*
+             * --- 트랜잭션을 강제로 커밋 ---
+             * 1. 현재 트랜잭션을 커밋하도록 설정
+             * 2. 현재 트랜잭션을 종료 (여기서 실제 DB에 COMMIT 됨)
+             * 3. 다음 로직을 위해 새로운 트랜잭션 시작
+             * 사유:
+             * MySQL의 InnoDB는 커밋된 데이터만 Full-Text Index에 반영하기 때문에,
+             * 테스트 내에서 Full-Text Index를 사용하는 쿼리를 실행하려면
+             * 트랜잭션을 커밋해야 한다.
+             */
+            TestTransaction.flagForCommit();
+            TestTransaction.end();
+            TestTransaction.start();
 
             final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
                     "체크리스트",

--- a/backend/bottari/src/test/java/com/bottari/fcm/FcmMessageSenderTest.java
+++ b/backend/bottari/src/test/java/com/bottari/fcm/FcmMessageSenderTest.java
@@ -33,11 +33,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
         FcmMessageSender.class,
         FcmTokenService.class

--- a/backend/bottari/src/test/java/com/bottari/fcm/service/FcmTokenServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/fcm/service/FcmTokenServiceTest.java
@@ -16,10 +16,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(FcmTokenService.class)
 class FcmTokenServiceTest {
 

--- a/backend/bottari/src/test/java/com/bottari/member/repository/MemberDeleteTest.java
+++ b/backend/bottari/src/test/java/com/bottari/member/repository/MemberDeleteTest.java
@@ -10,9 +10,11 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class MemberDeleteTest {
 
     @Autowired

--- a/backend/bottari/src/test/java/com/bottari/member/service/MemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/member/service/MemberServiceTest.java
@@ -15,10 +15,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(MemberService.class)
 class MemberServiceTest {
 

--- a/backend/bottari/src/test/java/com/bottari/report/repository/ReportDeleteTest.java
+++ b/backend/bottari/src/test/java/com/bottari/report/repository/ReportDeleteTest.java
@@ -12,9 +12,11 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class ReportDeleteTest {
 
     @Autowired

--- a/backend/bottari/src/test/java/com/bottari/report/service/ReportServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/report/service/ReportServiceTest.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(ReportService.class)
 class ReportServiceTest {
 

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamAssignedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamAssignedItemServiceTest.java
@@ -30,11 +30,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
         TeamAssignedItemService.class,
         FcmMessageConverter.class,

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamBottariServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamBottariServiceTest.java
@@ -27,11 +27,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
         TeamBottariService.class,
         JpaAuditingConfig.class,

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamItemFacadeTest.java
@@ -40,11 +40,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
         TeamItemFacade.class,
         TeamSharedItemService.class,

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamMemberServiceTest.java
@@ -32,11 +32,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
         TeamMemberService.class,
         FcmMessageConverter.class,

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamPersonalItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamPersonalItemServiceTest.java
@@ -20,10 +20,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(TeamPersonalItemService.class)
 class TeamPersonalItemServiceTest {
 

--- a/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/teambottari/service/TeamSharedItemServiceTest.java
@@ -29,11 +29,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
         TeamSharedItemService.class,
         FcmMessageConverter.class,

--- a/backend/bottari/src/test/resources/application.yml
+++ b/backend/bottari/src/test/resources/application.yml
@@ -20,5 +20,3 @@ spring:
     init:
       mode: always
       schema-locations: classpath:schema.sql
-
-

--- a/backend/bottari/src/test/resources/application.yml
+++ b/backend/bottari/src/test/resources/application.yml
@@ -1,8 +1,24 @@
 spring:
   application:
     name: bottari
+  jpa:
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true
+    open-in-view: true
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
+        dialect: org.hibernate.dialect.MySQLDialect
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   sql:
     init:
-      mode: never
-  profiles:
-    active: test
+      mode: always
+      schema-locations: classpath:schema.sql
+
+


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 전문 검색 인덱스 적용
    - n gram 은 1로 적용
- bottari_template에 그 외 인덱스 적용
    - (created_at, id)를 내림차순으로 복합 인덱스 적용
    - (taken_count, id)를 내림차순으로 복합 인덱스 적용
- docker compose로 로컬 mysql 환경 통일
- 테스트 데이터베이스를 h2에서 mysql로 변경

<br>

## 🎯 관련 이슈

<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #526 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
## docker compose로 로컬 mysql 환경 통일
이제 로컬 환경에서 실행을 할 때 h2 사용하지 않습니다! 도커로 mysql 환경을 통일하고 실행합니다! 테스트 또한 해당 local-compose 파일로 컨테이너를 띄어서 해야합니다!
## 커서 기반 검색
기존 커서 기반 검색을 최대한 유지하는 방향으로 리팩토링하였습니다! 무한 스크롤 방식이라 페이지 정보는 필요 없지만 현재는 기존과 같은 흐름을 유지하기 위해 일단은 남겨두었습니다!

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 검색어 자동 토큰화로 제목 검색 정확도 및 일관성 향상

- Refactor
  - 프로젝션 기반 조회로 응답 경량화 및 안정적인 페이징 제공
  - 전문검색/정렬 처리를 위한 인덱스 추가로 검색·정렬 속도 개선

- Chores
  - 로컬 개발용 MySQL Compose 서비스 추가
  - 애플리케이션 설정 및 초기 데이터 스크립트 보강
  - 내장 H2 런타임 의존성 제거

- Tests
  - 테스트 환경을 실제 DB 구성으로 전환하여 통합 테스트 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->