### PR TITLE
[BE] SSE 메시지에 화면 갱신에 필요한 페이로드를 담는 방식으로 변경 (Do Not Merge)

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -8,6 +8,7 @@ import com.bottari.sse.dto.CreateTeamSharedItemData;
 import com.bottari.sse.dto.CreateTeamSharedItemInfoData;
 import com.bottari.sse.dto.DeleteAssignedItemData;
 import com.bottari.sse.dto.DeleteTeamSharedItemData;
+import com.bottari.sse.dto.DeleteTeamSharedItemInfoData;
 import com.bottari.sse.dto.ExitTeamMemberData;
 import com.bottari.sse.message.SseEventType;
 import com.bottari.sse.message.SseMessage;
@@ -70,12 +71,20 @@ public class TeamBottariEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDeleteTeamSharedItemEvent(final DeleteTeamSharedItemEvent event) {
-        final SseMessage message = new SseMessage(
+        final List<ReadSharedItemResponse> infos =
+                teamSharedItemService.getAllByTeamBottariId(event.getTeamBottariId());
+        final SseMessage deleteSharedItemInfoMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM_INFO,
+                SseEventType.DELETE,
+                DeleteTeamSharedItemInfoData.of(infos, event)
+        );
+        final SseMessage deleteSharedItemMessage = new SseMessage(
+                SseResourceType.SHARED_ITEM,
                 SseEventType.DELETE,
                 DeleteTeamSharedItemData.from(event)
         );
-        sseService.sendByTeamBottariId(event.getTeamBottariId(), message);
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), deleteSharedItemInfoMessage);
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), deleteSharedItemMessage);
     }
 
     @Async

--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -8,6 +8,7 @@ import com.bottari.sse.dto.CreateTeamMemberData;
 import com.bottari.sse.dto.CreateTeamSharedItemData;
 import com.bottari.sse.dto.CreateTeamSharedItemInfoData;
 import com.bottari.sse.dto.DeleteAssignedItemData;
+import com.bottari.sse.dto.DeleteAssignedItemInfoData;
 import com.bottari.sse.dto.DeleteTeamSharedItemData;
 import com.bottari.sse.dto.DeleteTeamSharedItemInfoData;
 import com.bottari.sse.dto.ExitTeamMemberData;
@@ -146,12 +147,20 @@ public class TeamBottariEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDeleteAssignedItemEvent(final DeleteAssignedItemEvent event) {
-        final SseMessage message = new SseMessage(
+        final List<ReadAssignedItemResponse> idempotentInfos = teamAssignedItemService.getAllByTeamBottariId(
+                event.getTeamBottariId());
+        final SseMessage deleteAssignedItemInfoMessage = new SseMessage(
                 SseResourceType.ASSIGNED_ITEM_INFO,
+                SseEventType.DELETE,
+                DeleteAssignedItemInfoData.of(idempotentInfos, event)
+        );
+        final SseMessage deleteAssignedItemMessage = new SseMessage(
+                SseResourceType.ASSIGNED_ITEM,
                 SseEventType.DELETE,
                 DeleteAssignedItemData.from(event)
         );
-        sseService.sendByTeamBottariId(event.getTeamBottariId(), message);
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), deleteAssignedItemInfoMessage);
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), deleteAssignedItemMessage);
     }
 
     @Async

--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -4,6 +4,7 @@ import com.bottari.sse.dto.ChangeAssignedItemData;
 import com.bottari.sse.dto.CheckTeamItemData;
 import com.bottari.sse.dto.CreateAssignedItemData;
 import com.bottari.sse.dto.CreateTeamMemberData;
+import com.bottari.sse.dto.CreateTeamSharedItemData;
 import com.bottari.sse.dto.CreateTeamSharedItemInfoData;
 import com.bottari.sse.dto.DeleteAssignedItemData;
 import com.bottari.sse.dto.DeleteTeamSharedItemData;
@@ -60,7 +61,7 @@ public class TeamBottariEventListener {
         final SseMessage createSharedItemMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM,
                 SseEventType.CREATE,
-                ""
+                CreateTeamSharedItemData.from(event)
         );
         sseService.sendByTeamBottariId(event.getTeamBottariId(), createSharedItemInfoMessage);
         sseService.sendByTeamBottariId(event.getTeamBottariId(), createSharedItemMessage);

--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -5,6 +5,7 @@ import com.bottari.sse.dto.CheckTeamItemData;
 import com.bottari.sse.dto.CreateAssignedItemData;
 import com.bottari.sse.dto.CreateTeamMemberData;
 import com.bottari.sse.dto.CreateTeamSharedItemData;
+import com.bottari.sse.dto.CreateTeamSharedItemInfoData;
 import com.bottari.sse.dto.DeleteAssignedItemData;
 import com.bottari.sse.dto.DeleteTeamSharedItemData;
 import com.bottari.sse.dto.ExitTeamMemberData;
@@ -46,12 +47,18 @@ public class TeamBottariEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCreateTeamSharedItemEvent(final CreateTeamSharedItemEvent event) {
-        final SseMessage message = new SseMessage(
+        final SseMessage createSharedItemInfoMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM_INFO,
+                SseEventType.CREATE,
+                CreateTeamSharedItemInfoData.from(event)
+        );
+        final SseMessage createSharedItemMessage = new SseMessage(
+                SseResourceType.SHARED_ITEM,
                 SseEventType.CREATE,
                 CreateTeamSharedItemData.from(event)
         );
-        sseService.sendByTeamBottariId(event.getTeamBottariId(), message);
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), createSharedItemInfoMessage);
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), createSharedItemMessage);
     }
 
     @Async

--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -4,7 +4,6 @@ import com.bottari.sse.dto.ChangeAssignedItemData;
 import com.bottari.sse.dto.CheckTeamItemData;
 import com.bottari.sse.dto.CreateAssignedItemData;
 import com.bottari.sse.dto.CreateTeamMemberData;
-import com.bottari.sse.dto.CreateTeamSharedItemData;
 import com.bottari.sse.dto.CreateTeamSharedItemInfoData;
 import com.bottari.sse.dto.DeleteAssignedItemData;
 import com.bottari.sse.dto.DeleteTeamSharedItemData;
@@ -12,6 +11,7 @@ import com.bottari.sse.dto.ExitTeamMemberData;
 import com.bottari.sse.message.SseEventType;
 import com.bottari.sse.message.SseMessage;
 import com.bottari.sse.message.SseResourceType;
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.event.ChangeTeamAssignedItemEvent;
 import com.bottari.teambottari.event.CheckTeamAssignedItemEvent;
 import com.bottari.teambottari.event.CheckTeamSharedItemEvent;
@@ -21,6 +21,8 @@ import com.bottari.teambottari.event.DeleteAssignedItemEvent;
 import com.bottari.teambottari.event.DeleteTeamSharedItemEvent;
 import com.bottari.teambottari.event.ExitTeamMemberEvent;
 import com.bottari.teambottari.service.CreateTeamMemberEvent;
+import com.bottari.teambottari.service.TeamSharedItemService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -32,6 +34,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class TeamBottariEventListener {
 
     private final SseService sseService;
+    private final TeamSharedItemService teamSharedItemService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -47,15 +50,17 @@ public class TeamBottariEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCreateTeamSharedItemEvent(final CreateTeamSharedItemEvent event) {
+        final List<ReadSharedItemResponse> infos =
+                teamSharedItemService.getAllByTeamBottariId(event.getTeamBottariId());
         final SseMessage createSharedItemInfoMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM_INFO,
                 SseEventType.CREATE,
-                CreateTeamSharedItemInfoData.from(event)
+                CreateTeamSharedItemInfoData.of(infos, event)
         );
         final SseMessage createSharedItemMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM,
                 SseEventType.CREATE,
-                CreateTeamSharedItemData.from(event)
+                ""
         );
         sseService.sendByTeamBottariId(event.getTeamBottariId(), createSharedItemInfoMessage);
         sseService.sendByTeamBottariId(event.getTeamBottariId(), createSharedItemMessage);

--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -3,6 +3,7 @@ package com.bottari.sse.component;
 import com.bottari.sse.dto.ChangeAssignedItemData;
 import com.bottari.sse.dto.CheckTeamItemData;
 import com.bottari.sse.dto.CreateAssignedItemData;
+import com.bottari.sse.dto.CreateAssignedItemInfoData;
 import com.bottari.sse.dto.CreateTeamMemberData;
 import com.bottari.sse.dto.CreateTeamSharedItemData;
 import com.bottari.sse.dto.CreateTeamSharedItemInfoData;
@@ -13,6 +14,7 @@ import com.bottari.sse.dto.ExitTeamMemberData;
 import com.bottari.sse.message.SseEventType;
 import com.bottari.sse.message.SseMessage;
 import com.bottari.sse.message.SseResourceType;
+import com.bottari.teambottari.dto.ReadAssignedItemResponse;
 import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.event.ChangeTeamAssignedItemEvent;
 import com.bottari.teambottari.event.CheckTeamAssignedItemEvent;
@@ -23,6 +25,7 @@ import com.bottari.teambottari.event.DeleteAssignedItemEvent;
 import com.bottari.teambottari.event.DeleteTeamSharedItemEvent;
 import com.bottari.teambottari.event.ExitTeamMemberEvent;
 import com.bottari.teambottari.service.CreateTeamMemberEvent;
+import com.bottari.teambottari.service.TeamAssignedItemService;
 import com.bottari.teambottari.service.TeamSharedItemService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +40,7 @@ public class TeamBottariEventListener {
 
     private final SseService sseService;
     private final TeamSharedItemService teamSharedItemService;
+    private final TeamAssignedItemService teamAssignedItemService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -52,12 +56,12 @@ public class TeamBottariEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCreateTeamSharedItemEvent(final CreateTeamSharedItemEvent event) {
-        final List<ReadSharedItemResponse> infos =
+        final List<ReadSharedItemResponse> idempotentInfos =
                 teamSharedItemService.getAllByTeamBottariId(event.getTeamBottariId());
         final SseMessage createSharedItemInfoMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM_INFO,
                 SseEventType.CREATE,
-                CreateTeamSharedItemInfoData.of(infos, event)
+                CreateTeamSharedItemInfoData.of(idempotentInfos, event)
         );
         final SseMessage createSharedItemMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM,
@@ -71,12 +75,12 @@ public class TeamBottariEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDeleteTeamSharedItemEvent(final DeleteTeamSharedItemEvent event) {
-        final List<ReadSharedItemResponse> infos =
+        final List<ReadSharedItemResponse> idempotentInfos =
                 teamSharedItemService.getAllByTeamBottariId(event.getTeamBottariId());
         final SseMessage deleteSharedItemInfoMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM_INFO,
                 SseEventType.DELETE,
-                DeleteTeamSharedItemInfoData.of(infos, event)
+                DeleteTeamSharedItemInfoData.of(idempotentInfos, event)
         );
         final SseMessage deleteSharedItemMessage = new SseMessage(
                 SseResourceType.SHARED_ITEM,
@@ -112,12 +116,20 @@ public class TeamBottariEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCreateAssignedItemEvent(final CreateAssignedItemEvent event) {
-        final SseMessage message = new SseMessage(
+        final List<ReadAssignedItemResponse> idempotentInfos =
+                teamAssignedItemService.getAllByTeamBottariId(event.getTeamBottariId());
+        final SseMessage createAssignedItemInfoMessage = new SseMessage(
                 SseResourceType.ASSIGNED_ITEM_INFO,
+                SseEventType.CREATE,
+                CreateAssignedItemInfoData.of(idempotentInfos, event)
+        );
+        final SseMessage createAssignedItemMessage = new SseMessage(
+                SseResourceType.ASSIGNED_ITEM,
                 SseEventType.CREATE,
                 CreateAssignedItemData.from(event)
         );
-        sseService.sendByTeamBottariId(event.getTeamBottariId(), message);
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), createAssignedItemInfoMessage);
+        sseService.sendByTeamBottariId(event.getTeamBottariId(), createAssignedItemMessage);
     }
 
     @Async

--- a/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/component/TeamBottariEventListener.java
@@ -21,11 +21,11 @@ import com.bottari.teambottari.event.ChangeTeamAssignedItemEvent;
 import com.bottari.teambottari.event.CheckTeamAssignedItemEvent;
 import com.bottari.teambottari.event.CheckTeamSharedItemEvent;
 import com.bottari.teambottari.event.CreateAssignedItemEvent;
+import com.bottari.teambottari.event.CreateTeamMemberEvent;
 import com.bottari.teambottari.event.CreateTeamSharedItemEvent;
 import com.bottari.teambottari.event.DeleteAssignedItemEvent;
 import com.bottari.teambottari.event.DeleteTeamSharedItemEvent;
 import com.bottari.teambottari.event.ExitTeamMemberEvent;
-import com.bottari.teambottari.service.CreateTeamMemberEvent;
 import com.bottari.teambottari.service.TeamAssignedItemService;
 import com.bottari.teambottari.service.TeamSharedItemService;
 import java.util.List;
@@ -97,7 +97,7 @@ public class TeamBottariEventListener {
     public void handleCheckTeamSharedItemEvent(final CheckTeamSharedItemEvent event) {
         final SseMessage message = new SseMessage(
                 SseResourceType.SHARED_ITEM,
-                SseEventType.CHANGE,
+                SseEventType.CHECK,
                 CheckTeamItemData.from(event)
         );
         sseService.sendByTeamBottariId(event.getTeamBottariId(), message);
@@ -108,7 +108,7 @@ public class TeamBottariEventListener {
     public void handleCheckTeamAssignedItemEvent(final CheckTeamAssignedItemEvent event) {
         final SseMessage message = new SseMessage(
                 SseResourceType.ASSIGNED_ITEM,
-                SseEventType.CHANGE,
+                SseEventType.CHECK,
                 CheckTeamItemData.from(event)
         );
         sseService.sendByTeamBottariId(event.getTeamBottariId(), message);

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/CreateAssignedItemData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/CreateAssignedItemData.java
@@ -2,20 +2,15 @@ package com.bottari.sse.dto;
 
 import com.bottari.teambottari.event.CreateAssignedItemEvent;
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record CreateAssignedItemData(
-        Long infoId,
-        String name,
-        List<Long> memberIds,
+        Long teamBottariId,
         LocalDateTime publishedAt
 ) {
 
     public static CreateAssignedItemData from(final CreateAssignedItemEvent event) {
         return new CreateAssignedItemData(
-                event.getInfoId(),
-                event.getName(),
-                event.getMemberIds(),
+                event.getTeamBottariId(),
                 event.getPublishedAt()
         );
     }

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/CreateAssignedItemInfoData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/CreateAssignedItemInfoData.java
@@ -1,0 +1,24 @@
+package com.bottari.sse.dto;
+
+import com.bottari.teambottari.dto.ReadAssignedItemResponse;
+import com.bottari.teambottari.event.CreateAssignedItemEvent;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CreateAssignedItemInfoData(
+        Long teamBottariId,
+        List<ReadAssignedItemResponse> infos,
+        LocalDateTime publishedAt
+) {
+
+    public static CreateAssignedItemInfoData of(
+            final List<ReadAssignedItemResponse> infos,
+            final CreateAssignedItemEvent event
+    ) {
+        return new CreateAssignedItemInfoData(
+                event.getTeamBottariId(),
+                infos,
+                event.getPublishedAt()
+        );
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamMemberData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamMemberData.java
@@ -1,6 +1,6 @@
 package com.bottari.sse.dto;
 
-import com.bottari.teambottari.service.CreateTeamMemberEvent;
+import com.bottari.teambottari.event.CreateTeamMemberEvent;
 import java.time.LocalDateTime;
 
 public record CreateTeamMemberData(

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemData.java
@@ -2,17 +2,16 @@ package com.bottari.sse.dto;
 
 import com.bottari.teambottari.event.CreateTeamSharedItemEvent;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CreateTeamSharedItemData(
-        Long infoId,
-        String name,
+        List<Long> itemIds,
         LocalDateTime publishedAt
 ) {
 
     public static CreateTeamSharedItemData from(final CreateTeamSharedItemEvent event) {
         return new CreateTeamSharedItemData(
-                event.getInfoId(),
-                event.getName(),
+                event.getItemIds(),
                 event.getPublishedAt()
         );
     }

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemData.java
@@ -2,16 +2,15 @@ package com.bottari.sse.dto;
 
 import com.bottari.teambottari.event.CreateTeamSharedItemEvent;
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record CreateTeamSharedItemData(
-        List<Long> itemIds,
+        Long teamBottariId,
         LocalDateTime publishedAt
 ) {
 
     public static CreateTeamSharedItemData from(final CreateTeamSharedItemEvent event) {
         return new CreateTeamSharedItemData(
-                event.getItemIds(),
+                event.getTeamBottariId(),
                 event.getPublishedAt()
         );
     }

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemInfoData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemInfoData.java
@@ -1,0 +1,19 @@
+package com.bottari.sse.dto;
+
+import com.bottari.teambottari.event.CreateTeamSharedItemEvent;
+import java.time.LocalDateTime;
+
+public record CreateTeamSharedItemInfoData(
+        Long infoId,
+        String name,
+        LocalDateTime publishedAt
+) {
+
+    public static CreateTeamSharedItemInfoData from(final CreateTeamSharedItemEvent event) {
+        return new CreateTeamSharedItemInfoData(
+                event.getInfoId(),
+                event.getName(),
+                event.getPublishedAt()
+        );
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemInfoData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemInfoData.java
@@ -1,18 +1,21 @@
 package com.bottari.sse.dto;
 
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
 import com.bottari.teambottari.event.CreateTeamSharedItemEvent;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CreateTeamSharedItemInfoData(
-        Long infoId,
-        String name,
+        List<ReadSharedItemResponse> infos,
         LocalDateTime publishedAt
 ) {
 
-    public static CreateTeamSharedItemInfoData from(final CreateTeamSharedItemEvent event) {
+    public static CreateTeamSharedItemInfoData of(
+            final List<ReadSharedItemResponse> infos,
+            final CreateTeamSharedItemEvent event
+    ) {
         return new CreateTeamSharedItemInfoData(
-                event.getInfoId(),
-                event.getName(),
+                infos,
                 event.getPublishedAt()
         );
     }

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemInfoData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/CreateTeamSharedItemInfoData.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record CreateTeamSharedItemInfoData(
+        Long teamBottariId,
         List<ReadSharedItemResponse> infos,
         LocalDateTime publishedAt
 ) {
@@ -15,6 +16,7 @@ public record CreateTeamSharedItemInfoData(
             final CreateTeamSharedItemEvent event
     ) {
         return new CreateTeamSharedItemInfoData(
+                event.getTeamBottariId(),
                 infos,
                 event.getPublishedAt()
         );

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/DeleteAssignedItemData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/DeleteAssignedItemData.java
@@ -4,15 +4,13 @@ import com.bottari.teambottari.event.DeleteAssignedItemEvent;
 import java.time.LocalDateTime;
 
 public record DeleteAssignedItemData(
-        Long infoId,
-        String name,
+        Long teamBottariId,
         LocalDateTime publishedAt
 ) {
 
     public static DeleteAssignedItemData from(final DeleteAssignedItemEvent event) {
         return new DeleteAssignedItemData(
-                event.getInfoId(),
-                event.getName(),
+                event.getTeamBottariId(),
                 event.getPublishedAt()
         );
     }

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/DeleteAssignedItemInfoData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/DeleteAssignedItemInfoData.java
@@ -1,0 +1,24 @@
+package com.bottari.sse.dto;
+
+import com.bottari.teambottari.dto.ReadAssignedItemResponse;
+import com.bottari.teambottari.event.DeleteAssignedItemEvent;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DeleteAssignedItemInfoData(
+        Long teamBottariId,
+        List<ReadAssignedItemResponse> infos,
+        LocalDateTime publishedAt
+) {
+
+    public static DeleteAssignedItemInfoData of(
+            final List<ReadAssignedItemResponse> infos,
+            final DeleteAssignedItemEvent event
+    ) {
+        return new DeleteAssignedItemInfoData(
+                event.getTeamBottariId(),
+                infos,
+                event.getPublishedAt()
+        );
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/DeleteTeamSharedItemData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/DeleteTeamSharedItemData.java
@@ -4,15 +4,13 @@ import com.bottari.teambottari.event.DeleteTeamSharedItemEvent;
 import java.time.LocalDateTime;
 
 public record DeleteTeamSharedItemData(
-        Long infoId,
-        String name,
+        Long teamBottariId,
         LocalDateTime publishedAt
 ) {
 
     public static DeleteTeamSharedItemData from(final DeleteTeamSharedItemEvent event) {
         return new DeleteTeamSharedItemData(
-                event.getInfoId(),
-                event.getName(),
+                event.getTeamBottariId(),
                 event.getPublishedAt()
         );
     }

--- a/backend/bottari/src/main/java/com/bottari/sse/dto/DeleteTeamSharedItemInfoData.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/dto/DeleteTeamSharedItemInfoData.java
@@ -1,0 +1,24 @@
+package com.bottari.sse.dto;
+
+import com.bottari.teambottari.dto.ReadSharedItemResponse;
+import com.bottari.teambottari.event.DeleteTeamSharedItemEvent;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DeleteTeamSharedItemInfoData(
+        Long teamBottariId,
+        List<ReadSharedItemResponse> infos,
+        LocalDateTime publishedAt
+) {
+
+    public static DeleteTeamSharedItemInfoData of(
+            final List<ReadSharedItemResponse> infos,
+            final DeleteTeamSharedItemEvent event
+    ) {
+        return new DeleteTeamSharedItemInfoData(
+                event.getTeamBottariId(),
+                infos,
+                event.getPublishedAt()
+        );
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/sse/message/SseEventType.java
+++ b/backend/bottari/src/main/java/com/bottari/sse/message/SseEventType.java
@@ -5,5 +5,6 @@ public enum SseEventType {
     CREATE,
     DELETE,
     CHANGE,
+    CHECK,
     ;
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/event/CreateAssignedItemEvent.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/event/CreateAssignedItemEvent.java
@@ -12,5 +12,5 @@ public class CreateAssignedItemEvent extends CustomApplicationEvent {
     private final Long teamBottariId;
     private final Long infoId;
     private final String name;
-    private final List<Long> memberIds;
+    private final List<Long> itemIds;
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/event/CreateTeamMemberEvent.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/event/CreateTeamMemberEvent.java
@@ -1,4 +1,4 @@
-package com.bottari.teambottari.service;
+package com.bottari.teambottari.event;
 
 import com.bottari.support.CustomApplicationEvent;
 import lombok.Getter;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/event/CreateTeamSharedItemEvent.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/event/CreateTeamSharedItemEvent.java
@@ -1,6 +1,7 @@
 package com.bottari.teambottari.event;
 
 import com.bottari.support.CustomApplicationEvent;
+import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +12,5 @@ public class CreateTeamSharedItemEvent extends CustomApplicationEvent {
     private final Long teamBottariId;
     private final Long infoId;
     private final String name;
+    private final List<Long> itemIds;
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
@@ -75,13 +75,11 @@ public class TeamAssignedItemService {
         final List<String> requestAssignedMemberNames = getRequestAssignedMemberNames(request.memberIds());
         final List<TeamMember> teamMembers = getAssignedTeamMembersByRequest(requestAssignedMemberNames, teamBottari);
         final TeamAssignedItemInfo savedTeamAssignedItemInfo = saveTeamAssignedItemInfo(request.name(), teamBottari);
-        saveAssignedItemToTeamMembers(savedTeamAssignedItemInfo, teamMembers);
-        applicationEventPublisher.publishEvent(new CreateAssignedItemEvent(
-                teamBottari.getId(),
-                savedTeamAssignedItemInfo.getId(),
-                savedTeamAssignedItemInfo.getName(),
-                request.memberIds()
-        ));
+        final List<TeamAssignedItem> savedTeamAssignedItems = saveAssignedItemToTeamMembers(
+                savedTeamAssignedItemInfo,
+                teamMembers
+        );
+        publishCreateEvent(savedTeamAssignedItemInfo, savedTeamAssignedItems);
 
         return savedTeamAssignedItemInfo.getId();
     }
@@ -250,14 +248,15 @@ public class TeamAssignedItemService {
         }
     }
 
-    private void saveAssignedItemToTeamMembers(
+    private List<TeamAssignedItem> saveAssignedItemToTeamMembers(
             final TeamAssignedItemInfo savedTeamAssignedItemInfo,
             final List<TeamMember> teamMembers
     ) {
         final List<TeamAssignedItem> teamAssignedItems = teamMembers.stream()
                 .map(member -> new TeamAssignedItem(savedTeamAssignedItemInfo, member))
                 .toList();
-        teamAssignedItemRepository.saveAll(teamAssignedItems);
+
+        return teamAssignedItemRepository.saveAll(teamAssignedItems);
     }
 
     private void publishCheckEvent(final TeamAssignedItem item) {
@@ -320,6 +319,7 @@ public class TeamAssignedItemService {
     }
 
     // 삭제할 담당자 계산: (현재 담당자) - (요청된 담당자)
+
     private void deleteItemsToRemove(
             final Set<Long> currentAssignedMemberIds,
             final Set<Long> requestedAssignMemberIds,
@@ -334,8 +334,8 @@ public class TeamAssignedItemService {
             teamAssignedItemRepository.deleteAllInBatch(itemsToRemove);
         }
     }
-
     // 추가할 담당자 계산: (요청된 담당자) - (현재 담당자)
+
     private void createItemsToAdd(
             final TeamAssignedItemInfo teamAssignedItemInfo,
             final Set<Long> currentTeamMemberIds,
@@ -441,5 +441,20 @@ public class TeamAssignedItemService {
         if (!teamMemberRepository.existsByTeamBottariIdAndMemberId(teamBottari.getId(), member.getId())) {
             throw new BusinessException(ErrorCode.MEMBER_NOT_IN_TEAM_BOTTARI);
         }
+    }
+
+    private void publishCreateEvent(
+            final TeamAssignedItemInfo savedTeamAssignedItemInfo,
+            final List<TeamAssignedItem> savedTeamAssignedItems
+    ) {
+        final List<Long> itemIds = savedTeamAssignedItems.stream()
+                .map(TeamAssignedItem::getId)
+                .toList();
+        applicationEventPublisher.publishEvent(new CreateAssignedItemEvent(
+                savedTeamAssignedItemInfo.getTeamBottari().getId(),
+                savedTeamAssignedItemInfo.getId(),
+                savedTeamAssignedItemInfo.getName(),
+                itemIds
+        ));
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
@@ -107,6 +107,13 @@ public class TeamAssignedItemService {
         validateMemberInTeam(teamAssignedItemInfo.getTeamBottari().getId(), ssaid);
         teamAssignedItemRepository.deleteAllByInfo(teamAssignedItemInfo);
         teamAssignedItemInfoRepository.delete(teamAssignedItemInfo);
+        publishDeleteEvent(id, teamAssignedItemInfo);
+    }
+
+    private void publishDeleteEvent(
+            final Long id,
+            final TeamAssignedItemInfo teamAssignedItemInfo
+    ) {
         applicationEventPublisher.publishEvent(new DeleteAssignedItemEvent(
                 teamAssignedItemInfo.getTeamBottari().getId(),
                 id,

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -19,6 +19,7 @@ import com.bottari.teambottari.dto.ReadTeamMemberInfoResponse;
 import com.bottari.teambottari.dto.ReadTeamMemberNameResponse;
 import com.bottari.teambottari.dto.ReadTeamMemberStatusResponse;
 import com.bottari.teambottari.dto.TeamMemberItemResponse;
+import com.bottari.teambottari.event.CreateTeamMemberEvent;
 import com.bottari.teambottari.repository.TeamAssignedItemRepository;
 import com.bottari.teambottari.repository.TeamBottariRepository;
 import com.bottari.teambottari.repository.TeamMemberRepository;


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- SSE 메시지에 화면 갱신에 필요한 페이로드를 담는 방식으로 변경

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #539 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->

페이로드를 멱등하게 구성하고 클라이언트에서 자원 별 버전 관리를 하는 방안과 변경 트리거만 push하고, 클라이언트가 조회 후 화면을 갱신하는 방안을 혼합해서 적용했다.

다른 자원의 변경이 해당 자원의 변경을 발생시키지 않는 데이터(JOIN이 필요하지 않은 데이터)의 경우, 해당 자원의 변경에 대한 push 메시지 페이로드를 멱등하게 구성했다.

- `TeamMember`, `TeamSharedItemInfo` , `TeamAssignedItemInfo`

다른 자원의 변경이 해당 자원의 변경을 유발할 수 있는 데이터(JOIN이 필요한 데이터)의 경우, 페이로드에 최소한의 정보만 포함한 후 클라이언트에서 화면 갱신에 필요한 데이터를 각자 조회하도록 했다.

- `TeamSharedItem`, `TeamAssignedItem`

SSE 메시지에 해당 자원의 변경이 발생한 행위에 대한 정보를 포함해, 클라이언트에서 이를 통해 화면에 반영해야할 변경 사항을 판단할 수 있도록 했다.

- `CREATE`, `DELETE`, `CHANGE`, `CHECK`

### 참고 문서
보따리 노션 -> 백엔드 위키 -> SSE 아키텍처 -> `SSE에서 트리깅 메시지를 전달하고 GET을 하는 구조를 변경` 문서 참조

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

### 🚨DO NOT MERGE
클라이언트 코드에 현재 `CHECK` 이벤트가 존재하지 않아,
깨질 위험이 존재한다.
때문에, 클라이언트에서 반영된 것을 확인하고 MERGE해야한다.

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 공유/할당 아이템 생성·삭제 시 원본 이벤트와 함께 해당 아이템의 요약(아이템 리스트/요약 정보)이 추가로 실시간 전송됩니다.
  - 다수 아이템 생성 시 관련 아이템 ID 목록이 이벤트에 포함되어 클라이언트에서 일괄 처리 및 일관성 향상이 가능합니다.
  - 체크 이벤트 유형이 추가되어 체크 관련 알림이 별도 타입으로 구분됩니다.

- Refactor
  - 실시간 이벤트 페이로드가 팀 식별자 중심으로 정리되어 클라이언트 처리 일관성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->