### PR TITLE
[AN] Compose 테마 및 홈 화면 초기 설정

### DIFF
--- a/android/Bottari/presentation/src/main/AndroidManifest.xml
+++ b/android/Bottari/presentation/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
             android:name=".view.invite.InviteActivity"
             android:exported="false" />
 
+        <activity
+            android:name=".compose.home.ComposeHomeActivity"
+            android:exported="false" />
+
         <receiver android:name=".receiver.AlarmReceiver" />
         <receiver
             android:name=".receiver.BootReceiver"

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/navigation/Navigation.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/navigation/Navigation.kt
@@ -1,0 +1,22 @@
+package com.bottari.presentation.compose.common.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Navigation(
+    navigationController: NavigationController,
+    modifier: Modifier = Modifier,
+    screens: @Composable (screen: Screen, nav: NavigationController) -> Unit,
+) {
+    val stateHolder = rememberSaveableStateHolder()
+
+    Box(modifier = modifier.fillMaxSize()) {
+        stateHolder.SaveableStateProvider(navigationController.currentScreen) {
+            screens(navigationController.currentScreen, navigationController)
+        }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/navigation/NavigationController.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/navigation/NavigationController.kt
@@ -1,0 +1,44 @@
+package com.bottari.presentation.compose.common.navigation
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.setValue
+
+class NavigationController(
+    initialScreen: Screen,
+) {
+    private val backStack = mutableListOf<Screen>()
+
+    var currentScreen by mutableStateOf(initialScreen)
+        private set
+
+    fun navigate(screen: Screen) {
+        backStack.add(currentScreen)
+        currentScreen = screen
+    }
+
+    fun popBackStack(): Boolean {
+        if (backStack.isNotEmpty()) {
+            currentScreen = backStack.removeAt(backStack.lastIndex)
+            return true
+        }
+        return false
+    }
+
+    fun clearBackStack() {
+        backStack.clear()
+    }
+
+    companion object {
+        val saver =
+            Saver<NavigationController, Pair<Screen, List<Screen>>>(
+                save = { controller -> controller.currentScreen to controller.backStack.toList() },
+                restore = { (screen, stack) ->
+                    val controller = NavigationController(screen)
+                    controller.backStack.addAll(stack)
+                    controller
+                },
+            )
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/navigation/Screen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/navigation/Screen.kt
@@ -3,6 +3,5 @@ package com.bottari.presentation.compose.common.navigation
 import android.os.Parcelable
 
 interface Screen : Parcelable {
-    val labelResId: Int
     val route: String
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/navigation/Screen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/navigation/Screen.kt
@@ -1,0 +1,8 @@
+package com.bottari.presentation.compose.common.navigation
+
+import android.os.Parcelable
+
+interface Screen : Parcelable {
+    val labelResId: Int
+    val route: String
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Color.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Color.kt
@@ -1,0 +1,33 @@
+package com.bottari.presentation.compose.common.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+data class BottariColorSystem(
+    val transparent: Color = Color(0x00000000),
+    val black: Color = Color(0xFF000000),
+    val white: Color = Color(0xFFFFFFFF),
+    val primary: Color = Color(0xFF0064FF),
+    val red: Color = Color(0xFFFF0000),
+    val redSoft: Color = Color(0xFFFF3B30),
+    val gray50: Color = Color(0xFFF8F8F8),
+    val gray100: Color = Color(0xFFF2F2F5),
+    val gray200: Color = Color(0xFFEEEEEE),
+    val gray300: Color = Color(0xFFD1DEE8),
+    val gray400: Color = Color(0xFFC4C4C4),
+    val gray500: Color = Color(0xFFA6A6A6),
+    val gray600: Color = Color(0xFF999999),
+    val gray700: Color = Color(0xFF787878),
+    val productTypePersonal: Color = Color(0xFF0064FF),
+    val productTypeShared: Color = Color(0xFF6EBA76),
+    val productTypeAssigned: Color = Color(0xFF00AEFF),
+)
+
+private val lightColorScheme = BottariColorSystem()
+
+val LocalBottariColorSystem = staticCompositionLocalOf { lightColorScheme }
+
+val LocalBottariBgColor = compositionLocalOf { lightColorScheme.gray50 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Spacing.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Spacing.kt
@@ -1,0 +1,19 @@
+package com.bottari.presentation.compose.common.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class BottariSpacing(
+    val space2xSmall: Dp = 4.dp,
+    val spaceXSmall: Dp = 8.dp,
+    val spaceSmall: Dp = 12.dp,
+    val spaceMedium: Dp = 16.dp,
+    val spaceLarge: Dp = 20.dp,
+    val spaceXLarge: Dp = 24.dp,
+    val space2xLarge: Dp = 28.dp,
+)
+
+val LocalBottariSpacing = staticCompositionLocalOf { BottariSpacing() }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Theme.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Theme.kt
@@ -1,15 +1,11 @@
 package com.bottari.presentation.compose.common.theme
 
 import androidx.activity.SystemBarStyle
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.bottari.presentation.compose.common.theme.BottariTheme.typography

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Theme.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Theme.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import com.bottari.presentation.compose.common.theme.BottariTheme.colors
 import com.bottari.presentation.compose.common.theme.BottariTheme.typography
 
 object BottariTheme {
@@ -35,7 +36,7 @@ val BottariStatusBarStyle =
 @Composable
 fun BottariTheme(content: @Composable () -> Unit) {
     CompositionLocalProvider(
-        LocalBottariBgColor provides LocalBottariBgColor.current,
+        LocalBottariBgColor provides colors.gray50,
     ) {
         ProvideTextStyle(value = typography.medium14.toTextStyle()) {
             content()

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Theme.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Theme.kt
@@ -1,0 +1,52 @@
+package com.bottari.presentation.compose.common.theme
+
+import androidx.activity.SystemBarStyle
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.bottari.presentation.compose.common.theme.BottariTheme.typography
+
+object BottariTheme {
+    val colors: BottariColorSystem
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalBottariColorSystem.current
+
+    val spacing: BottariSpacing
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalBottariSpacing.current
+
+    val typography: BottariTypography
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalBottariTypographySystem.current
+}
+
+val LocalBottariStatusStyle =
+    compositionLocalOf {
+        SystemBarStyle.light(
+            scrim = Color.Black.toArgb(),
+            darkScrim = Color.Black.toArgb(),
+        )
+    }
+
+@Composable
+fun BottariTheme(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+        LocalBottariBgColor provides LocalBottariBgColor.current,
+        LocalBottariStatusStyle provides LocalBottariStatusStyle.current,
+    ) {
+        ProvideTextStyle(value = typography.medium14.toTextStyle()) {
+            content()
+        }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Theme.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Theme.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.bottari.presentation.compose.common.theme.BottariTheme.typography
@@ -27,19 +26,16 @@ object BottariTheme {
         get() = LocalBottariTypographySystem.current
 }
 
-val LocalBottariStatusStyle =
-    compositionLocalOf {
-        SystemBarStyle.light(
-            scrim = Color.Black.toArgb(),
-            darkScrim = Color.Black.toArgb(),
-        )
-    }
+val BottariStatusBarStyle =
+    SystemBarStyle.light(
+        scrim = Color.Black.toArgb(),
+        darkScrim = Color.Black.toArgb(),
+    )
 
 @Composable
 fun BottariTheme(content: @Composable () -> Unit) {
     CompositionLocalProvider(
         LocalBottariBgColor provides LocalBottariBgColor.current,
-        LocalBottariStatusStyle provides LocalBottariStatusStyle.current,
     ) {
         ProvideTextStyle(value = typography.medium14.toTextStyle()) {
             content()

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Typography.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/theme/Typography.kt
@@ -1,0 +1,165 @@
+package com.bottari.presentation.compose.common.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import com.bottari.presentation.R
+
+val Pretendard =
+    FontFamily(
+        Font(R.font.pretendard_regular, FontWeight.W400),
+        Font(R.font.pretendard_medium, FontWeight.W500),
+        Font(R.font.pretendard_semibold, FontWeight.W600),
+        Font(R.font.pretendard_bold, FontWeight.W700),
+    )
+
+@Immutable
+data class BottariTextStyle(
+    val fontFamily: FontFamily = Pretendard,
+    val fontWeight: FontWeight = FontWeight.Medium,
+    val fontSize: Dp = Dp.Unspecified,
+    val lineHeight: Dp = Dp.Unspecified,
+    val letterSpacing: TextUnit = 0.em,
+    val color: Color = Color.Unspecified,
+    val textAlign: TextAlign = TextAlign.Start,
+) {
+    @Composable
+    fun toTextStyle(): TextStyle =
+        TextStyle(
+            fontFamily = fontFamily,
+            fontWeight = fontWeight,
+            fontSize = with(LocalDensity.current) { fontSize.toSp() },
+            lineHeight = with(LocalDensity.current) { lineHeight.toSp() },
+            letterSpacing = letterSpacing,
+            color = color,
+            textAlign = textAlign,
+        )
+
+    companion object {
+        @Stable
+        val Default = BottariTextStyle()
+    }
+}
+
+@Immutable
+data class BottariTypography(
+    val bold32: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W700,
+            lineHeight = 32.dp,
+            fontSize = 32.dp,
+        ),
+    val bold22: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W700,
+            lineHeight = 22.dp,
+            fontSize = 22.dp,
+        ),
+    val bold20: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W700,
+            lineHeight = 20.dp,
+            fontSize = 20.dp,
+        ),
+    val bold18: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W700,
+            lineHeight = 18.dp,
+            fontSize = 18.dp,
+        ),
+    val bold12: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W700,
+            lineHeight = 12.dp,
+            fontSize = 12.dp,
+        ),
+    val semiBold20: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W600,
+            lineHeight = 20.dp,
+            fontSize = 20.dp,
+        ),
+    val semiBold16: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W600,
+            lineHeight = 16.dp,
+            fontSize = 16.dp,
+        ),
+    val medium36: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W500,
+            lineHeight = 36.dp,
+            fontSize = 36.dp,
+        ),
+    val medium20: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W500,
+            lineHeight = 20.dp,
+            fontSize = 20.dp,
+        ),
+    val medium16: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W500,
+            lineHeight = 16.dp,
+            fontSize = 16.dp,
+        ),
+    val medium14: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W500,
+            lineHeight = 14.dp,
+            fontSize = 14.dp,
+        ),
+    val medium12: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W500,
+            lineHeight = 12.dp,
+            fontSize = 12.dp,
+        ),
+    val regular16: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W400,
+            lineHeight = 16.dp,
+            fontSize = 16.dp,
+        ),
+    val regular14: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W400,
+            lineHeight = 14.dp,
+            fontSize = 14.dp,
+        ),
+    val regular12: BottariTextStyle =
+        BottariTextStyle(
+            fontFamily = Pretendard,
+            fontWeight = FontWeight.W400,
+            lineHeight = 12.dp,
+            fontSize = 12.dp,
+        ),
+)
+
+val LocalBottariTypographySystem = staticCompositionLocalOf { BottariTypography() }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/ComposeHomeActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/ComposeHomeActivity.kt
@@ -1,0 +1,27 @@
+package com.bottari.presentation.compose.home
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import com.bottari.presentation.compose.common.theme.BottariTheme
+import com.bottari.presentation.compose.common.theme.LocalBottariStatusStyle
+
+class ComposeHomeActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            BottariTheme {
+                enableEdgeToEdge(LocalBottariStatusStyle.current)
+                HomeScreen()
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent = Intent(context, ComposeHomeActivity::class.java)
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/ComposeHomeActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/ComposeHomeActivity.kt
@@ -6,18 +6,15 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import com.bottari.presentation.compose.common.theme.BottariStatusBarStyle
 import com.bottari.presentation.compose.common.theme.BottariTheme
-import com.bottari.presentation.compose.common.theme.LocalBottariStatusStyle
 
 class ComposeHomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        enableEdgeToEdge(BottariStatusBarStyle)
         setContent {
-            BottariTheme {
-                enableEdgeToEdge(LocalBottariStatusStyle.current)
-                HomeScreen()
-            }
+            BottariTheme { HomeScreen() }
         }
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeBottomNavigationBar.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeBottomNavigationBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,21 +37,23 @@ fun HomeBottomNavigationBar(
         containerColor = BottariTheme.colors.white,
         modifier = modifier.clip(RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp)),
     ) {
-        screens.forEach { screen ->
-            NavigationBarItem(
-                icon = { HomeNavigationBarIcon(screen) },
-                alwaysShowLabel = false,
-                selected = screen == selectedTab,
-                onClick = { onTabSelected(screen) },
-                colors =
-                    NavigationBarItemDefaults.colors(
-                        indicatorColor = BottariTheme.colors.transparent,
-                        selectedIconColor = selectedColor,
-                        selectedTextColor = selectedColor,
-                        unselectedIconColor = unselectedColor,
-                        unselectedTextColor = unselectedColor,
-                    ),
-            )
+        key(selectedTab) {
+            screens.forEach { screen ->
+                NavigationBarItem(
+                    icon = { HomeNavigationBarIcon(screen) },
+                    alwaysShowLabel = false,
+                    selected = screen == selectedTab,
+                    onClick = { onTabSelected(screen) },
+                    colors =
+                        NavigationBarItemDefaults.colors(
+                            indicatorColor = BottariTheme.colors.transparent,
+                            selectedIconColor = selectedColor,
+                            selectedTextColor = selectedColor,
+                            unselectedIconColor = unselectedColor,
+                            unselectedTextColor = unselectedColor,
+                        ),
+                )
+            }
         }
     }
 }
@@ -69,12 +72,12 @@ private fun HomeNavigationBarIcon(
     ) {
         Icon(
             painter = painterResource(id = iconRes),
-            contentDescription = stringResource(screen.labelResId),
+            contentDescription = stringResource(screen.labelResId()),
             modifier = modifier.size(32.dp),
         )
 
         Text(
-            text = stringResource(screen.labelResId),
+            text = stringResource(screen.labelResId()),
             style = BottariTheme.typography.medium12.toTextStyle(),
         )
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeBottomNavigationBar.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeBottomNavigationBar.kt
@@ -1,0 +1,101 @@
+package com.bottari.presentation.compose.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bottari.presentation.R
+import com.bottari.presentation.compose.common.navigation.Screen
+import com.bottari.presentation.compose.common.theme.BottariTheme
+
+@Composable
+fun HomeBottomNavigationBar(
+    screens: List<HomeScreenRoute>,
+    selectedTab: Screen,
+    onTabSelected: (Screen) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val selectedColor = BottariTheme.colors.black
+    val unselectedColor = BottariTheme.colors.gray500
+
+    NavigationBar(
+        containerColor = BottariTheme.colors.white,
+        modifier = modifier.clip(RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp)),
+    ) {
+        screens.forEach { screen ->
+            NavigationBarItem(
+                icon = { HomeNavigationBarIcon(screen) },
+                alwaysShowLabel = false,
+                selected = screen == selectedTab,
+                onClick = { onTabSelected(screen) },
+                colors =
+                    NavigationBarItemDefaults.colors(
+                        indicatorColor = BottariTheme.colors.transparent,
+                        selectedIconColor = selectedColor,
+                        selectedTextColor = selectedColor,
+                        unselectedIconColor = unselectedColor,
+                        unselectedTextColor = unselectedColor,
+                    ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeNavigationBarIcon(
+    screen: HomeScreenRoute,
+    modifier: Modifier = Modifier,
+) {
+    val iconRes = remember(screen) { screen.toIconResId() }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier,
+    ) {
+        Icon(
+            painter = painterResource(id = iconRes),
+            contentDescription = stringResource(screen.labelResId),
+            modifier = modifier.size(32.dp),
+        )
+
+        Text(
+            text = stringResource(screen.labelResId),
+            style = BottariTheme.typography.medium12.toTextStyle(),
+        )
+    }
+}
+
+private fun HomeScreenRoute.toIconResId(): Int =
+    when (this) {
+        HomeScreenRoute.Personal -> R.drawable.ic_personal
+        HomeScreenRoute.Team -> R.drawable.ic_team
+        HomeScreenRoute.Template -> R.drawable.ic_template
+        HomeScreenRoute.More -> R.drawable.ic_more_horizontal
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeBottomNavigationBarPreview() {
+    BottariTheme {
+        HomeBottomNavigationBar(
+            screens = HomeScreenRoute.entries.toList(),
+            selectedTab = HomeScreenRoute.Personal,
+            onTabSelected = {},
+        )
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -23,11 +24,16 @@ import com.bottari.presentation.compose.home.template.TemplateBottariScreen
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
-    navigateToPersonalBottariEdit: () -> Unit = {}, // 다른 Activity로 가는 로직이 필요할 경우 여기에 추가
+    navigateToPersonalBottariEdit: () -> Unit = {}, // Todo: 다른 Activity로 가는 로직
 ) {
     val navController =
         rememberSaveable(saver = NavigationController.saver) {
             NavigationController(HomeScreenRoute.Personal)
+        }
+
+    val currentScreen =
+        remember(navController.currentScreen) {
+            navController.currentScreen as HomeScreenRoute
         }
 
     Scaffold(
@@ -36,7 +42,7 @@ fun HomeScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = stringResource(navController.currentScreen.labelResId),
+                        text = stringResource(currentScreen.labelResId()),
                         style = BottariTheme.typography.bold20.toTextStyle(),
                     )
                 },
@@ -50,7 +56,7 @@ fun HomeScreen(
         bottomBar = {
             HomeBottomNavigationBar(
                 screens = HomeScreenRoute.entries,
-                selectedTab = navController.currentScreen,
+                selectedTab = currentScreen,
                 onTabSelected = { tab -> navController.navigate(tab) },
             )
         },

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreen.kt
@@ -1,0 +1,113 @@
+package com.bottari.presentation.compose.home
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.bottari.presentation.compose.common.navigation.Navigation
+import com.bottari.presentation.compose.common.navigation.NavigationController
+import com.bottari.presentation.compose.common.theme.BottariTheme
+import com.bottari.presentation.compose.common.theme.LocalBottariBgColor
+import com.bottari.presentation.compose.home.more.MoreBottariScreen
+import com.bottari.presentation.compose.home.personal.PersonalBottariScreen
+import com.bottari.presentation.compose.home.team.TeamBottariScreen
+import com.bottari.presentation.compose.home.template.TemplateBottariScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(
+    navigateToPersonalBottariEdit: () -> Unit = {}, // 다른 Activity로 가는 로직이 필요할 경우 여기에 추가
+) {
+    val navController =
+        rememberSaveable(saver = NavigationController.saver) {
+            NavigationController(HomeScreenRoute.Personal)
+        }
+
+    Scaffold(
+        containerColor = LocalBottariBgColor.current,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(navController.currentScreen.labelResId),
+                        style = BottariTheme.typography.bold20.toTextStyle(),
+                    )
+                },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = BottariTheme.colors.gray50,
+                        titleContentColor = BottariTheme.colors.black,
+                    ),
+            )
+        },
+        bottomBar = {
+            HomeBottomNavigationBar(
+                screens = HomeScreenRoute.entries,
+                selectedTab = navController.currentScreen,
+                onTabSelected = { tab -> navController.navigate(tab) },
+            )
+        },
+    ) { innerPadding ->
+        HomeScreenRouter(
+            navController = navController,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@Composable
+fun HomeScreenRouter(
+    navController: NavigationController,
+    modifier: Modifier = Modifier,
+) {
+    Navigation(
+        navigationController = navController,
+        modifier = modifier,
+    ) { screen, nav ->
+        when (screen) {
+            HomeScreenRoute.Personal ->
+                PersonalBottariScreen(
+                    onNavigateToTeam = { nav.navigate(HomeScreenRoute.Team) },
+                    onNavigateToTemplate = { nav.navigate(HomeScreenRoute.Template) },
+                    onNavigateToMore = { nav.navigate(HomeScreenRoute.More) },
+                )
+
+            HomeScreenRoute.Team ->
+                TeamBottariScreen(
+                    onNavigateToPersonal = { nav.navigate(HomeScreenRoute.Personal) },
+                    onNavigateToTemplate = { nav.navigate(HomeScreenRoute.Template) },
+                    onNavigateToMore = { nav.navigate(HomeScreenRoute.More) },
+                )
+
+            HomeScreenRoute.Template ->
+                TemplateBottariScreen(
+                    onNavigateToPersonal = { nav.navigate(HomeScreenRoute.Personal) },
+                    onNavigateToTeam = { nav.navigate(HomeScreenRoute.Team) },
+                    onNavigateToMore = { nav.navigate(HomeScreenRoute.More) },
+                )
+
+            HomeScreenRoute.More ->
+                MoreBottariScreen(
+                    onNavigateToPersonal = { nav.navigate(HomeScreenRoute.Personal) },
+                    onNavigateToTeam = { nav.navigate(HomeScreenRoute.Team) },
+                    onNavigateToTemplate = { nav.navigate(HomeScreenRoute.Template) },
+                )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeScreenPreview() {
+    BottariTheme {
+        HomeScreen()
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreenRoute.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreenRoute.kt
@@ -1,0 +1,17 @@
+package com.bottari.presentation.compose.home
+
+import androidx.annotation.StringRes
+import com.bottari.presentation.R
+import com.bottari.presentation.compose.common.navigation.Screen
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+enum class HomeScreenRoute(
+    @StringRes override val labelResId: Int,
+    override val route: String,
+) : Screen {
+    Personal(R.string.home_nav_personal_bottari_title_text, "personal"),
+    Team(R.string.home_nav_team_bottari_title_text, "team"),
+    Template(R.string.home_nav_template_title_text, "template"),
+    More(R.string.home_nav_more_title_text, "more"),
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreenRoute.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreenRoute.kt
@@ -1,17 +1,24 @@
 package com.bottari.presentation.compose.home
 
-import androidx.annotation.StringRes
 import com.bottari.presentation.R
 import com.bottari.presentation.compose.common.navigation.Screen
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 enum class HomeScreenRoute(
-    @StringRes override val labelResId: Int,
     override val route: String,
 ) : Screen {
-    Personal(R.string.home_nav_personal_bottari_title_text, "personal"),
-    Team(R.string.home_nav_team_bottari_title_text, "team"),
-    Template(R.string.home_nav_template_title_text, "template"),
-    More(R.string.home_nav_more_title_text, "more"),
+    Personal("personal"),
+    Team("team"),
+    Template("template"),
+    More("more"),
+    ;
+
+    fun labelResId(): Int =
+        when (this) {
+            Personal -> R.string.home_nav_personal_bottari_title_text
+            Team -> R.string.home_nav_team_bottari_title_text
+            Template -> R.string.home_nav_template_title_text
+            More -> R.string.home_nav_more_title_text
+        }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/MoreBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/MoreBottariScreen.kt
@@ -1,0 +1,25 @@
+package com.bottari.presentation.compose.home.more
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun MoreBottariScreen(
+    onNavigateToPersonal: () -> Unit,
+    onNavigateToTeam: () -> Unit,
+    onNavigateToTemplate: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(text = "우리 보따리")
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/MoreBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/MoreBottariScreen.kt
@@ -20,6 +20,6 @@ fun MoreBottariScreen(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = "우리 보따리")
+        Text(text = "더보기")
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/personal/PersonalBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/personal/PersonalBottariScreen.kt
@@ -1,0 +1,25 @@
+package com.bottari.presentation.compose.home.personal
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun PersonalBottariScreen(
+    onNavigateToTeam: () -> Unit,
+    onNavigateToTemplate: () -> Unit,
+    onNavigateToMore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(text = "개인 보따리")
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/team/TeamBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/team/TeamBottariScreen.kt
@@ -1,0 +1,25 @@
+package com.bottari.presentation.compose.home.team
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun TeamBottariScreen(
+    onNavigateToPersonal: () -> Unit,
+    onNavigateToTemplate: () -> Unit,
+    onNavigateToMore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(text = "우리 보따리")
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/template/TemplateBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/template/TemplateBottariScreen.kt
@@ -20,6 +20,6 @@ fun TemplateBottariScreen(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = "우리 보따리")
+        Text(text = "모두의 보따리")
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/template/TemplateBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/template/TemplateBottariScreen.kt
@@ -1,0 +1,25 @@
+package com.bottari.presentation.compose.home.template
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun TemplateBottariScreen(
+    onNavigateToPersonal: () -> Unit,
+    onNavigateToTeam: () -> Unit,
+    onNavigateToMore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(text = "우리 보따리")
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseActivity
 import com.bottari.presentation.common.extension.showSnackbar
+import com.bottari.presentation.compose.home.ComposeHomeActivity
 import com.bottari.presentation.databinding.ActivityMainBinding
 import com.bottari.presentation.util.DeeplinkHelper.getInviteCode
 import com.bottari.presentation.util.DeeplinkHelper.validateUri
@@ -22,7 +23,6 @@ import com.bottari.presentation.view.common.PermissionDescriptionDialog
 import com.bottari.presentation.view.common.alert.CustomAlertDialog
 import com.bottari.presentation.view.common.alert.DialogListener
 import com.bottari.presentation.view.common.alert.DialogPresetType
-import com.bottari.presentation.view.home.HomeActivity
 import com.bottari.presentation.view.invite.InviteActivity
 
 class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::inflate) {
@@ -127,7 +127,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     }
 
     private fun navigateToHome() {
-        val intent = HomeActivity.newIntent(this)
+//        val intent = HomeActivity.newIntent(this)
+//        startActivity(intent)
+//        finish()
+        val intent = Intent(this, ComposeHomeActivity::class.java)
         startActivity(intent)
         finish()
     }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 컴포즈 마이그레이션을 위한 테마를 생성함
- 기존 XML에 정의된 리소스를 컴포즈를 위한 리소스 생성

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #538 

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Compose 기반 홈 화면 도입: 하단 탭 내비게이션(개인, 팀, 템플릿, 더보기) 및 각 탭용 화면 컴포저블과 하단 바 컴포넌트 추가.
  - 화면별 상태 보존을 지원하는 Navigation 컴포저블 및 간단한 내비게이션 컨트롤러 추가.
  - 테마 시스템 추가: 색상 팔레트, 배경색, 간격, 타이포그래피 토큰 및 BottariTheme 제공.
  - Compose 호스트 액티비티 추가 및 매니페스트에 비내보내기(activity 등록).

- Chores
  - 앱 진입 흐름을 새 Compose 홈 화면으로 연결하도록 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->