### PR TITLE
[AN] 더보기 화면 마이그레이션

### DIFF
--- a/android/Bottari/gradle/libs.versions.toml
+++ b/android/Bottari/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ threetenabp = "1.4.9"
 composeBom = "2025.09.00"
 activityCompose = "1.10.1"
 lifecycleViewmodelCompose = "2.9.4"
+runtimeLivedata = "1.9.1"
 
 # Network
 retrofit = "3.0.0"
@@ -96,6 +97,7 @@ androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
 
 # --- Network ---
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }

--- a/android/Bottari/presentation/build.gradle.kts
+++ b/android/Bottari/presentation/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.runtime.livedata)
 
     implementation(libs.material)
     implementation(libs.cardstackview)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/component/BottariBox.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/component/BottariBox.kt
@@ -1,0 +1,52 @@
+package com.bottari.presentation.compose.common.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bottari.presentation.compose.common.modifier.dropShadow
+import com.bottari.presentation.compose.common.theme.BottariTheme
+
+@Composable
+fun BottariBox(
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(12.dp),
+    contentPadding: PaddingValues = PaddingValues(16.dp),
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Box(
+        modifier =
+            modifier
+                .dropShadow(shape = shape)
+                .background(
+                    shape = shape,
+                    color = BottariTheme.colors.white,
+                ).padding(contentPadding),
+    ) {
+        content()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CardBoxPreview() {
+    BottariTheme {
+        Box(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            BottariBox(
+                content = {
+                    Text(text = "보따리")
+                },
+            )
+        }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/modifier/DropShadow.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/modifier/DropShadow.kt
@@ -22,8 +22,8 @@ fun Modifier.dropShadow(
     color: Color = Color.Black.copy(0.25f),
     blur: Dp = 1.dp,
     offsetY: Dp = 1.dp,
-    offsetX: Dp = 1.dp,
-    spread: Dp = 1.dp,
+    offsetX: Dp = 0.dp,
+    spread: Dp = 0.dp,
 ) = composed {
     val density = LocalDensity.current
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/modifier/dropShadow.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/common/modifier/dropShadow.kt
@@ -1,0 +1,62 @@
+package com.bottari.presentation.compose.common.modifier
+
+import android.graphics.BlurMaskFilter
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Modifier.dropShadow(
+    shape: Shape,
+    color: Color = Color.Black.copy(0.25f),
+    blur: Dp = 1.dp,
+    offsetY: Dp = 1.dp,
+    offsetX: Dp = 1.dp,
+    spread: Dp = 1.dp,
+) = composed {
+    val density = LocalDensity.current
+
+    val paint =
+        remember(color, blur) {
+            Paint().apply {
+                this.color = color
+                val blurPx = with(density) { blur.toPx() }
+                if (blurPx > 0f) {
+                    this.asFrameworkPaint().maskFilter =
+                        BlurMaskFilter(blurPx, BlurMaskFilter.Blur.NORMAL)
+                }
+            }
+        }
+
+    drawBehind {
+        val spreadPx = spread.toPx()
+        val offsetXPx = offsetX.toPx()
+        val offsetYPx = offsetY.toPx()
+
+        val shadowWidth = size.width + spreadPx
+        val shadowHeight = size.height + spreadPx
+
+        if (shadowWidth <= 0f || shadowHeight <= 0f) return@drawBehind
+
+        val shadowSize = Size(shadowWidth, shadowHeight)
+        val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
+
+        drawIntoCanvas { canvas ->
+            canvas.save()
+            canvas.translate(offsetXPx, offsetYPx)
+            canvas.drawOutline(shadowOutline, paint)
+            canvas.restore()
+        }
+    }
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/ComposeHomeActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/ComposeHomeActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import com.bottari.presentation.compose.common.theme.BottariStatusBarStyle
 import com.bottari.presentation.compose.common.theme.BottariTheme
 
@@ -14,8 +15,17 @@ class ComposeHomeActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge(BottariStatusBarStyle)
         setContent {
-            BottariTheme { HomeScreen() }
+            BottariTheme {
+                HomeScreen(
+                    navigateToBrowser = { url -> navigateToBrowser(url) },
+                )
+            }
         }
+    }
+
+    private fun navigateToBrowser(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+        startActivity(intent)
     }
 
     companion object {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/HomeScreen.kt
@@ -23,9 +23,7 @@ import com.bottari.presentation.compose.home.template.TemplateBottariScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen(
-    navigateToPersonalBottariEdit: () -> Unit = {}, // Todo: 다른 Activity로 가는 로직
-) {
+fun HomeScreen(navigateToBrowser: (String) -> Unit) {
     val navController =
         rememberSaveable(saver = NavigationController.saver) {
             NavigationController(HomeScreenRoute.Personal)
@@ -63,6 +61,7 @@ fun HomeScreen(
     ) { innerPadding ->
         HomeScreenRouter(
             navController = navController,
+            navigateToBrowser = navigateToBrowser,
             modifier = Modifier.padding(innerPadding),
         )
     }
@@ -71,6 +70,7 @@ fun HomeScreen(
 @Composable
 fun HomeScreenRouter(
     navController: NavigationController,
+    navigateToBrowser: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Navigation(
@@ -101,9 +101,7 @@ fun HomeScreenRouter(
 
             HomeScreenRoute.More ->
                 MoreBottariScreen(
-                    onNavigateToPersonal = { nav.navigate(HomeScreenRoute.Personal) },
-                    onNavigateToTeam = { nav.navigate(HomeScreenRoute.Team) },
-                    onNavigateToTemplate = { nav.navigate(HomeScreenRoute.Template) },
+                    onNavigateToBrowser = navigateToBrowser,
                 )
         }
     }
@@ -113,6 +111,6 @@ fun HomeScreenRouter(
 @Composable
 private fun HomeScreenPreview() {
     BottariTheme {
-        HomeScreen()
+        HomeScreen(navigateToBrowser = {})
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/MoreBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/MoreBottariScreen.kt
@@ -1,25 +1,119 @@
 package com.bottari.presentation.compose.home.more
 
+import android.content.Context
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.bottari.presentation.BuildConfig
+import com.bottari.presentation.R
+import com.bottari.presentation.compose.common.component.BottariBox
+import com.bottari.presentation.compose.common.theme.BottariTheme
+import com.bottari.presentation.compose.home.more.component.NicknameBox
+import com.bottari.presentation.view.home.more.MoreUiState
+import com.bottari.presentation.view.home.more.MoreViewModel
 
 @Composable
 fun MoreBottariScreen(
-    onNavigateToPersonal: () -> Unit,
-    onNavigateToTeam: () -> Unit,
-    onNavigateToTemplate: () -> Unit,
+    onNavigateToBrowser: (String) -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: MoreViewModel = viewModel(),
 ) {
+    val uiState = viewModel.uiState.observeAsState().value ?: MoreUiState()
+
     Column(
-        modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(
+                    horizontal = BottariTheme.spacing.spaceLarge,
+                    vertical = BottariTheme.spacing.spaceXSmall,
+                ),
+        verticalArrangement = Arrangement.spacedBy(BottariTheme.spacing.spaceXSmall),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = "더보기")
+        NicknameBox(
+            nickname = uiState.editingNickname,
+            onChangeNickname = viewModel::updateNickname,
+            onSaveNickname = viewModel::saveNickname,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        SettingItem(
+            text = stringResource(R.string.setting_privacy_policy_title_text),
+            onClick = { onNavigateToBrowser(BuildConfig.USER_FEEDBACK_URL) },
+        )
+        SettingItem(
+            text = stringResource(R.string.setting_user_feedback_title_text),
+            onClick = { onNavigateToBrowser(BuildConfig.USER_FEEDBACK_URL) },
+        )
+        SettingVersionItem(text = stringResource(R.string.setting_version_text))
+    }
+}
+
+@Composable
+private fun SettingItem(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BottariBox(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = text,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onClick)
+                    .padding(vertical = BottariTheme.spacing.spaceSmall),
+            color = BottariTheme.colors.black,
+            style = BottariTheme.typography.medium16.toTextStyle(),
+        )
+    }
+}
+
+@Composable
+private fun SettingVersionItem(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    BottariBox(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = text,
+            modifier = Modifier.align(Alignment.CenterStart),
+            color = BottariTheme.colors.black,
+            style = BottariTheme.typography.medium16.toTextStyle(),
+        )
+        Text(
+            text =
+                getAppVersionName(context)
+                    ?: stringResource(R.string.setting_unknown_version_text),
+            modifier = Modifier.align(Alignment.CenterEnd),
+            color = BottariTheme.colors.black,
+            style = BottariTheme.typography.medium16.toTextStyle(),
+        )
+    }
+}
+
+private fun getAppVersionName(context: Context): String? {
+    val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+    return packageInfo?.versionName
+}
+
+@Preview
+@Composable
+private fun MoreBottariScreenPreview() {
+    BottariTheme {
+        MoreBottariScreen(onNavigateToBrowser = {})
     }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/MoreBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/MoreBottariScreen.kt
@@ -51,7 +51,7 @@ fun MoreBottariScreen(
         )
         SettingItem(
             text = stringResource(R.string.setting_privacy_policy_title_text),
-            onClick = { onNavigateToBrowser(BuildConfig.USER_FEEDBACK_URL) },
+            onClick = { onNavigateToBrowser(BuildConfig.PRIVACY_POLICY_URL) },
         )
         SettingItem(
             text = stringResource(R.string.setting_user_feedback_title_text),

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameBox.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameBox.kt
@@ -1,14 +1,9 @@
 package com.bottari.presentation.compose.home.more.component
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -22,14 +17,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -109,56 +101,15 @@ fun NicknameBox(
     }
 }
 
-@Composable
-private fun NicknameTextField(
-    textFieldValue: TextFieldValue,
-    onValueChange: (TextFieldValue) -> Unit,
-    onSaveNickname: () -> Unit,
-    isEditing: Boolean,
-    focusRequester: FocusRequester,
-) {
-    BasicTextField(
-        value = textFieldValue,
-        onValueChange = onValueChange,
-        modifier =
-            Modifier
-                .padding(top = 4.dp)
-                .focusRequester(focusRequester)
-                .fillMaxWidth(),
-        textStyle =
-            BottariTheme.typography.medium16
-                .toTextStyle()
-                .copy(color = BottariTheme.colors.black),
-        singleLine = true,
-        readOnly = !isEditing,
-        cursorBrush = SolidColor(BottariTheme.colors.transparent),
-        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
-        keyboardActions = KeyboardActions(onDone = { onSaveNickname() }),
-        decorationBox = { innerTextField ->
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-                contentAlignment = Alignment.CenterStart,
-            ) {
-                if (textFieldValue.text.isEmpty() && isEditing) {
-                    Text(
-                        text = stringResource(R.string.profile_nickname_hint_text),
-                        color = BottariTheme.colors.gray500,
-                        style = BottariTheme.typography.medium16.toTextStyle(),
-                    )
-                }
-                innerTextField()
-            }
-        },
-    )
-}
-
 @Preview
 @Composable
 private fun NicknameTextFieldPreview() {
     var nickname by remember { mutableStateOf("오이") }
-    NicknameBox(
-        nickname = nickname,
-        onChangeNickname = { nickname = it },
-        onSaveNickname = {},
-    )
+    BottariTheme {
+        NicknameBox(
+            nickname = nickname,
+            onChangeNickname = { nickname = it },
+            onSaveNickname = {},
+        )
+    }
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameBox.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameBox.kt
@@ -1,0 +1,164 @@
+package com.bottari.presentation.compose.home.more.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bottari.presentation.R
+import com.bottari.presentation.compose.common.component.BottariBox
+import com.bottari.presentation.compose.common.theme.BottariTheme
+
+@Composable
+fun NicknameBox(
+    nickname: String,
+    onChangeNickname: (String) -> Unit,
+    onSaveNickname: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isEditing by rememberSaveable { mutableStateOf(false) }
+    var textFieldValue by remember(nickname) {
+        mutableStateOf(TextFieldValue(text = nickname, selection = TextRange(nickname.length)))
+    }
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(isEditing) {
+        if (isEditing) {
+            focusRequester.requestFocus()
+            keyboardController?.show()
+            textFieldValue = textFieldValue.copy(selection = TextRange(textFieldValue.text.length))
+            return@LaunchedEffect
+        }
+        keyboardController?.hide()
+        focusManager.clearFocus()
+    }
+
+    BottariBox(
+        modifier = modifier,
+        contentPadding = PaddingValues(0.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = stringResource(R.string.profile_nickname_title),
+                    modifier = Modifier.align(Alignment.Start),
+                    color = BottariTheme.colors.black,
+                    style = BottariTheme.typography.semiBold20.toTextStyle(),
+                )
+                NicknameTextField(
+                    textFieldValue = textFieldValue,
+                    onValueChange = { newValue ->
+                        textFieldValue = newValue
+                        onChangeNickname(newValue.text)
+                    },
+                    onSaveNickname = onSaveNickname,
+                    isEditing = isEditing,
+                    focusRequester = focusRequester,
+                )
+            }
+            IconButton(
+                onClick = {
+                    if (isEditing.not()) {
+                        onSaveNickname()
+                    }
+                    isEditing = isEditing.not()
+                },
+                modifier = Modifier.align(Alignment.CenterVertically),
+            ) {
+                val iconRes = if (isEditing) R.drawable.ic_confirm else R.drawable.ic_pen
+                Icon(
+                    painter = painterResource(iconRes),
+                    contentDescription = stringResource(R.string.common_btn_nickname_edit_description),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NicknameTextField(
+    textFieldValue: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    onSaveNickname: () -> Unit,
+    isEditing: Boolean,
+    focusRequester: FocusRequester,
+) {
+    BasicTextField(
+        value = textFieldValue,
+        onValueChange = onValueChange,
+        modifier =
+            Modifier
+                .padding(top = 4.dp)
+                .focusRequester(focusRequester)
+                .fillMaxWidth(),
+        textStyle =
+            BottariTheme.typography.medium16
+                .toTextStyle()
+                .copy(color = BottariTheme.colors.black),
+        singleLine = true,
+        readOnly = !isEditing,
+        cursorBrush = SolidColor(BottariTheme.colors.transparent),
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { onSaveNickname() }),
+        decorationBox = { innerTextField ->
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (textFieldValue.text.isEmpty() && isEditing) {
+                    Text(
+                        text = stringResource(R.string.profile_nickname_hint_text),
+                        color = BottariTheme.colors.gray500,
+                        style = BottariTheme.typography.medium16.toTextStyle(),
+                    )
+                }
+                innerTextField()
+            }
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun NicknameTextFieldPreview() {
+    var nickname by remember { mutableStateOf("오이") }
+    NicknameBox(
+        nickname = nickname,
+        onChangeNickname = { nickname = it },
+        onSaveNickname = {},
+    )
+}

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameBox.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameBox.kt
@@ -84,9 +84,7 @@ fun NicknameBox(
             }
             IconButton(
                 onClick = {
-                    if (isEditing.not()) {
-                        onSaveNickname()
-                    }
+                    if (isEditing) onSaveNickname()
                     isEditing = isEditing.not()
                 },
                 modifier = Modifier.align(Alignment.CenterVertically),

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameBox.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameBox.kt
@@ -77,7 +77,10 @@ fun NicknameBox(
                         textFieldValue = newValue
                         onChangeNickname(newValue.text)
                     },
-                    onSaveNickname = onSaveNickname,
+                    onSaveNickname = {
+                        isEditing = false
+                        onSaveNickname()
+                    },
                     isEditing = isEditing,
                     focusRequester = focusRequester,
                 )

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameTextField.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameTextField.kt
@@ -48,7 +48,7 @@ fun NicknameTextField(
                 .copy(color = BottariTheme.colors.black),
         singleLine = true,
         readOnly = !isEditing,
-        cursorBrush = SolidColor(BottariTheme.colors.transparent),
+        cursorBrush = SolidColor(BottariTheme.colors.black),
         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(onDone = { onSaveNickname() }),
         decorationBox = { innerTextField ->

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameTextField.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/more/component/NicknameTextField.kt
@@ -1,0 +1,86 @@
+package com.bottari.presentation.compose.home.more.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bottari.presentation.R
+import com.bottari.presentation.compose.common.theme.BottariTheme
+
+@Composable
+fun NicknameTextField(
+    textFieldValue: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    onSaveNickname: () -> Unit,
+    isEditing: Boolean,
+    focusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = textFieldValue,
+        onValueChange = onValueChange,
+        modifier =
+            modifier
+                .padding(top = 4.dp)
+                .focusRequester(focusRequester)
+                .fillMaxWidth(),
+        textStyle =
+            BottariTheme.typography.medium16
+                .toTextStyle()
+                .copy(color = BottariTheme.colors.black),
+        singleLine = true,
+        readOnly = !isEditing,
+        cursorBrush = SolidColor(BottariTheme.colors.transparent),
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { onSaveNickname() }),
+        decorationBox = { innerTextField ->
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (textFieldValue.text.isEmpty() && isEditing) {
+                    Text(
+                        text = stringResource(R.string.profile_nickname_hint_text),
+                        color = BottariTheme.colors.gray500,
+                        style = BottariTheme.typography.medium16.toTextStyle(),
+                    )
+                }
+                innerTextField()
+            }
+        },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NicknameTextFieldPreview() {
+    var textFieldValue by remember { mutableStateOf(TextFieldValue()) }
+    val focusRequester = remember { FocusRequester() }
+    BottariTheme {
+        NicknameTextField(
+            textFieldValue = textFieldValue,
+            onValueChange = { textFieldValue = it },
+            onSaveNickname = {},
+            isEditing = true,
+            focusRequester = focusRequester,
+        )
+    }
+}

--- a/android/Bottari/presentation/src/main/res/values/strings.xml
+++ b/android/Bottari/presentation/src/main/res/values/strings.xml
@@ -175,6 +175,8 @@
     <string name="setting_toolbar_title_text">설정</string>
     <string name="setting_privacy_policy_title_text">개인정보 처리 방침</string>
     <string name="setting_user_feedback_title_text">의견 보내기</string>
+    <string name="setting_version_text">보따리 버전</string>
+    <string name="setting_unknown_version_text">알 수 없음</string>
 
     <!-- Checklist -->
     <string name="checklist_fetch_failure_text">체크리스트를 불러오지 못했어요</string>


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 더보기 화면 View System -> Compose 마이그레이션

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #551 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- Compose 마이그레이션
- 버전 정보 추가

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- 기존의 View System 관련 파일은 아직 제거하지 않았습니다.

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 홈에서 외부 브라우저로 이동 기능 추가
  - 더보기 화면에 닉네임 즉시 편집·저장 UI(닉네임 박스·텍스트필드) 추가
  - 카드형 공용 컴포넌트(BottariBox) 추가 및 그림자 효과 적용 가능 Modifier 추가
  - 앱 버전 표시 항목 추가

- 리팩터링/스타일
  - 홈 네비게이션을 단일 브라우저 콜백으로 단순화
  - 더보기 화면 레이아웃·간격 및 상태 연동 개선

- 기타
  - Compose LiveData 의존성 추가
  - 버전 표기용 문자열 리소스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->