### PR TITLE
[BE] 템플릿 해시태그 엔티티 생성

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtag.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtag.java
@@ -1,0 +1,47 @@
+package com.bottari.bottaritemplate.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@SQLDelete(sql = "UPDATE bottari_template_hashtag SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class BottariTemplateHashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bottari_template_id")
+    private BottariTemplate bottariTemplate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag")
+    private Hashtag hashtag;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public BottariTemplateHashtag(
+            final BottariTemplate bottariTemplate,
+            final Hashtag hashtag
+    ) {
+        this.bottariTemplate = bottariTemplate;
+        this.hashtag = hashtag;
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/Hashtag.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/Hashtag.java
@@ -1,0 +1,57 @@
+package com.bottari.bottaritemplate.domain;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Hashtag {
+
+    private static final int MIN_NAME_LENGTH = 2;
+    private static final int MAX_NAME_LENGTH = 10;
+    private static final Pattern VALID_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣_]+$");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    public Hashtag(final String name) {
+        validateName(name);
+        this.name = name;
+    }
+
+    private void validateName(final String name) {
+        if (name == null || name.isBlank()) {
+            throw new BusinessException(ErrorCode.HASHTAG_NAME_BLANK);
+        }
+
+        if (name.contains(" ") || name.contains("\t") || name.contains("\n")) {
+            throw new BusinessException(ErrorCode.HASHTAG_NAME_CONTAINS_WHITESPACE);
+        }
+
+        if (name.length() < MIN_NAME_LENGTH) {
+            throw new BusinessException(ErrorCode.HASHTAG_NAME_TOO_SHORT, "최소 " + MIN_NAME_LENGTH + "자 이상 입력 가능합니다.");
+        }
+
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new BusinessException(ErrorCode.HASHTAG_NAME_TOO_LONG, "최대 " + MAX_NAME_LENGTH + "자까지 입력 가능합니다.");
+        }
+
+        if (!VALID_NAME_PATTERN.matcher(name).matches()) {
+            throw new BusinessException(ErrorCode.HASHTAG_NAME_INVALID_CHARACTER);
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -57,6 +57,13 @@ public enum ErrorCode {
     // ===== BOTTARI_TEMPLATE_ITEM 관련 =====
     BOTTARI_TEMPLATE_ITEM_DUPLICATE_IN_REQUEST(HttpStatus.BAD_REQUEST, "요청에 중복된 보따리 템플릿 물품이 있습니다."),
 
+    // ===== HASHTAG 관련 =====
+    HASHTAG_NAME_BLANK(HttpStatus.BAD_REQUEST, "해시태그는 공백일 수 없습니다."),
+    HASHTAG_NAME_TOO_SHORT(HttpStatus.BAD_REQUEST, "해시태그 제목이 너무 짧습니다."),
+    HASHTAG_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "해시태그 제목이 너무 깁니다."),
+    HASHTAG_NAME_CONTAINS_WHITESPACE(HttpStatus.BAD_REQUEST, "해시태그에는 공백을 포함할 수 없습니다."),
+    HASHTAG_NAME_INVALID_CHARACTER(HttpStatus.BAD_REQUEST, "해시태그는 한글, 영문, 숫자, 언더스코어(_)만 사용할 수 있습니다."),
+
     // ===== TEAM_BOTTARI 관련 =====
     TEAM_BOTTARI_NOT_FOUND(HttpStatus.NOT_FOUND, "팀 보따리를 찾을 수 없습니다."),
     TEAM_BOTTARI_INVITE_CODE_GENERATION_FAILED(

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/HashtagTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/HashtagTest.java
@@ -1,0 +1,92 @@
+package com.bottari.bottaritemplate.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bottari.error.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HashtagTest {
+
+    @Nested
+    @DisplayName("해시태그 생성")
+    class CreateTest {
+
+        @DisplayName("유효한 해시태그를 생성한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"여행", "캠핑", "travel", "CAMPING", "여행123", "travel24", "캠핑_준비", "123_test", "한글Eng"})
+        void create_Success(final String name) {
+            // when
+            final Hashtag hashTag = new Hashtag(name);
+
+            // then
+            assertThat(hashTag.getName()).isEqualTo(name);
+        }
+
+        @DisplayName("해시태그가 null이거나 공백인 경우, 예외를 던진다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   ", "\t", "\n"})
+        void create_Exception_Blank(final String name) {
+            // when & then
+            assertThatThrownBy(() -> new Hashtag(name))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해시태그는 공백일 수 없습니다.");
+        }
+
+        @DisplayName("해시태그가 null인 경우, 예외를 던진다.")
+        @Test
+        void create_Exception_Null() {
+            // when & then
+            assertThatThrownBy(() -> new Hashtag(null))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해시태그는 공백일 수 없습니다.");
+        }
+
+        @DisplayName("해시태그에 공백이 포함된 경우, 예외를 던진다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"여행 캠핑", "travel test", "캠핑\t준비", "여행\n리스트", " 여행", "캠핑 "})
+        void create_Exception_ContainsWhitespace(final String name) {
+            // when & then
+            assertThatThrownBy(() -> new Hashtag(name))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해시태그에는 공백을 포함할 수 없습니다.");
+        }
+
+        @DisplayName("해시태그가 2글자 미만인 경우, 예외를 던진다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"a", "1", "가", "_"})
+        void create_Exception_TooShort(final String name) {
+            // when & then
+            assertThatThrownBy(() -> new Hashtag(name))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해시태그 제목이 너무 짧습니다. - 최소 2자 이상 입력 가능합니다.");
+        }
+
+        @DisplayName("해시태그가 10글자를 초과하는 경우, 예외를 던진다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"12345678901", "가나다라마바사아자차카", "travel_2024_long"})
+        void create_Exception_TooLong(final String name) {
+            // when & then
+            assertThatThrownBy(() -> new Hashtag(name))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해시태그 제목이 너무 깁니다. - 최대 10자까지 입력 가능합니다.");
+        }
+
+        @DisplayName("해시태그에 특수문자(언더스코어 제외)가 포함된 경우, 예외를 던진다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"여행!", "캠핑@준비", "travel#tag", "test$name", "tag%ing", "name^tag",
+                "tag&name", "test*tag", "tag()", "tag[]", "tag{}", "tag|name", "tag\\name",
+                "tag:name", "tag;name", "tag'name", "tag\"name", "tag<name", "tag>name",
+                "tag?name", "tag/name", "tag+name", "tag=name", "tag~name", "tag`name", "tag.name", "tag,name"})
+        void create_Exception_InvalidCharacter(final String name) {
+            // when & then
+            assertThatThrownBy(() -> new Hashtag(name))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해시태그는 한글, 영문, 숫자, 언더스코어(_)만 사용할 수 있습니다.");
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 템플릿 해시태그 엔티티 생성

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #561

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- `Hashtag` 테이블 생성
- `BottariTemplateHashtag` 테이블 생성 (BottariTemplate과 Hashtag의 중간 테이블)

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해시태그 도입 및 템플릿과의 연결 지원으로 콘텐츠 분류/탐색 기반 마련.
- 개선
  - 해시태그 이름 규칙 검증 추가: 공백 불가, 2–10자, 한글/영문/숫자/언더스코어만 허용.
  - 규칙 위반 시 명확한 오류 메시지로 안내하여 입력 품질 향상.
- 테스트
  - 유효/무효 입력 케이스 전반에 대한 단위 테스트 추가로 안정성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->