### PR TITLE
[BE] 템플릿 조회 응답에 해시태그 추가

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadBottariTemplateResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadBottariTemplateResponse.java
@@ -2,6 +2,7 @@ package com.bottari.bottaritemplate.dto;
 
 import com.bottari.bottaritemplate.domain.BottariTemplate;
 import com.bottari.bottaritemplate.domain.BottariTemplateItem;
+import com.bottari.bottaritemplate.domain.Hashtag;
 import com.bottari.bottaritemplate.repository.dto.BottariTemplateProjection;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,12 +13,14 @@ public record ReadBottariTemplateResponse(
         List<BottariTemplateItemResponse> items,
         String author,
         LocalDateTime createdAt,
-        int takenCount
+        int takenCount,
+        List<HashtagResponse> hashtags
 ) {
 
     public static ReadBottariTemplateResponse of(
             final BottariTemplate bottariTemplate,
-            final List<BottariTemplateItem> bottariTemplateItems
+            final List<BottariTemplateItem> bottariTemplateItems,
+            final List<Hashtag> hashtags
     ) {
         final List<BottariTemplateItemResponse> items = bottariTemplateItems.stream()
                 .map(BottariTemplateItemResponse::from)
@@ -29,13 +32,15 @@ public record ReadBottariTemplateResponse(
                 items,
                 bottariTemplate.getMember().getName(),
                 bottariTemplate.getCreatedAt(),
-                bottariTemplate.getTakenCount()
+                bottariTemplate.getTakenCount(),
+                hashtags.stream().map(HashtagResponse::from).toList()
         );
     }
 
     public static ReadBottariTemplateResponse of(
             final BottariTemplateProjection projection,
-            final List<BottariTemplateItem> bottariTemplateItems
+            final List<BottariTemplateItem> bottariTemplateItems,
+            final List<Hashtag> hashtags
     ) {
         final List<BottariTemplateItemResponse> items = bottariTemplateItems.stream()
                 .map(BottariTemplateItemResponse::from)
@@ -47,7 +52,8 @@ public record ReadBottariTemplateResponse(
                 items,
                 projection.getMemberName(),
                 projection.getBottariTemplateCreatedAt(),
-                projection.getTakenCount()
+                projection.getTakenCount(),
+                hashtags.stream().map(HashtagResponse::from).toList()
         );
     }
 
@@ -60,6 +66,18 @@ public record ReadBottariTemplateResponse(
             return new BottariTemplateItemResponse(
                     bottariTemplateItem.getId(),
                     bottariTemplateItem.getName()
+            );
+        }
+    }
+
+    public record HashtagResponse(
+            Long id,
+            String name
+    ) {
+        public static HashtagResponse from(final Hashtag hashtag) {
+            return new HashtagResponse(
+                    hashtag.getId(),
+                    hashtag.getName()
             );
         }
     }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateHashtagRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateHashtagRepository.java
@@ -1,0 +1,28 @@
+package com.bottari.bottaritemplate.repository;
+
+import com.bottari.bottaritemplate.domain.BottariTemplate;
+import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface BottariTemplateHashtagRepository extends JpaRepository<BottariTemplateHashtag, Long> {
+
+    @Query("""
+             SELECT bth
+             FROM BottariTemplateHashtag bth
+             JOIN FETCH bth.hashtag h
+             WHERE bth.bottariTemplate.id = :bottariTemplateId
+            """)
+    List<BottariTemplateHashtag> findAllByBottariTemplateId(final Long bottariTemplateId);
+
+    List<BottariTemplateHashtag> findAllByBottariTemplateIn(final List<BottariTemplate> bottariTemplateItems);
+
+    @Query("""
+            SELECT bth
+            FROM BottariTemplateHashtag bth
+            JOIN FETCH bth.hashtag h
+            WHERE bth.bottariTemplate.id IN :templateIds
+            """)
+    List<BottariTemplateHashtag> findAllByBottariTemplateIds(final List<Long> templateIds);
+}

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateItemRepository.java
@@ -18,7 +18,7 @@ public interface BottariTemplateItemRepository extends JpaRepository<BottariTemp
             FROM BottariTemplateItem bti
             WHERE bti.bottariTemplate.id IN :templateIds
             """)
-    List<BottariTemplateItem> findAllByBottariTemplateIds(List<Long> templateIds);
+    List<BottariTemplateItem> findAllByBottariTemplateIds(final List<Long> templateIds);
 
     @Modifying(clearAutomatically = true)
     @Query("""

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/BottariTemplateControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/BottariTemplateControllerTest.java
@@ -14,6 +14,7 @@ import com.bottari.bottaritemplate.domain.SortProperty;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse.BottariTemplateItemResponse;
+import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse.HashtagResponse;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.bottaritemplate.service.BottariTemplateService;
 import com.bottari.log.LogFormatter;
@@ -57,7 +58,11 @@ class BottariTemplateControllerTest {
                 ),
                 "author_1",
                 LocalDateTime.now(),
-                0
+                0,
+                List.of(
+                        new HashtagResponse(1L, "hashtag_1"),
+                        new HashtagResponse(2L, "hashtag_2")
+                )
         );
         given(bottariTemplateService.getById(1L))
                 .willReturn(response);
@@ -83,7 +88,11 @@ class BottariTemplateControllerTest {
                         ),
                         "author_1",
                         LocalDateTime.now(),
-                        0
+                        0,
+                        List.of(
+                                new HashtagResponse(1L, "hashtag_1"),
+                                new HashtagResponse(2L, "hashtag_2")
+                        )
                 ),
                 new ReadBottariTemplateResponse(
                         2L,
@@ -93,7 +102,11 @@ class BottariTemplateControllerTest {
                         ),
                         "author_2",
                         LocalDateTime.now(),
-                        0
+                        0,
+                        List.of(
+                                new HashtagResponse(1L, "hashtag_1"),
+                                new HashtagResponse(2L, "hashtag_2")
+                        )
                 )
         );
         given(bottariTemplateService.getBySsaid("ssaid"))
@@ -120,7 +133,11 @@ class BottariTemplateControllerTest {
                         ),
                         "author_1",
                         LocalDateTime.now(),
-                        0
+                        0,
+                        List.of(
+                                new HashtagResponse(1L, "hashtag_1"),
+                                new HashtagResponse(2L, "hashtag_2")
+                        )
                 ),
                 new ReadBottariTemplateResponse(
                         2L,
@@ -130,7 +147,11 @@ class BottariTemplateControllerTest {
                         ),
                         "author_2",
                         LocalDateTime.now(),
-                        0
+                        0,
+                        List.of(
+                                new HashtagResponse(1L, "hashtag_1"),
+                                new HashtagResponse(2L, "hashtag_2")
+                        )
                 )
         );
         given(bottariTemplateService.getAll(anyString()))
@@ -156,7 +177,11 @@ class BottariTemplateControllerTest {
                         ),
                         "author_1",
                         LocalDateTime.now().minusDays(2),
-                        5
+                        5,
+                        List.of(
+                                new HashtagResponse(1L, "호떡짱짱"),
+                                new HashtagResponse(2L, "혼자여행")
+                        )
                 ),
                 new ReadBottariTemplateResponse(
                         2L,
@@ -166,7 +191,11 @@ class BottariTemplateControllerTest {
                         ),
                         "author_2",
                         LocalDateTime.now().minusDays(1),
-                        3
+                        3,
+                        List.of(
+                                new HashtagResponse(3L, "캠핑"),
+                                new HashtagResponse(4L, "가족나들이")
+                        )
                 )
         );
         final ReadNextBottariTemplateResponse response = new ReadNextBottariTemplateResponse(

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.bottari.bottari.domain.Bottari;
 import com.bottari.bottari.domain.BottariItem;
 import com.bottari.bottaritemplate.domain.BottariTemplate;
+import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
 import com.bottari.bottaritemplate.domain.BottariTemplateHistory;
 import com.bottari.bottaritemplate.domain.BottariTemplateItem;
+import com.bottari.bottaritemplate.domain.Hashtag;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
@@ -17,6 +19,7 @@ import com.bottari.config.JpaAuditingConfig;
 import com.bottari.error.BusinessException;
 import com.bottari.fixture.BottariTemplateFixture;
 import com.bottari.fixture.BottariTemplateItemFixture;
+import com.bottari.fixture.HashtagFixture;
 import com.bottari.fixture.MemberFixture;
 import com.bottari.member.domain.Member;
 import jakarta.persistence.EntityManager;
@@ -56,14 +59,26 @@ class BottariTemplateServiceTest {
             final BottariTemplate template1 = BottariTemplateFixture.BOTTARI_TEMPLATE.get(member);
             final BottariTemplateItem item1 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_1.get(template1);
             final BottariTemplateItem item2 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_2.get(template1);
+            final Hashtag hashtag1 = HashtagFixture.HASHTAG_1.get();
+            final Hashtag hashtag2 = HashtagFixture.HASHTAG_2.get();
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(template1, hashtag1);
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(template1, hashtag2);
             entityManager.persist(template1);
             entityManager.persist(item1);
             entityManager.persist(item2);
+            entityManager.persist(hashtag1);
+            entityManager.persist(hashtag2);
+            entityManager.persist(templateHashtag1);
+            entityManager.persist(templateHashtag2);
 
             final BottariTemplate template2 = BottariTemplateFixture.BOTTARI_TEMPLATE_2.get(member);
             final BottariTemplateItem item3 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_3.get(template2);
+            final Hashtag hashtag3 = HashtagFixture.HASHTAG_3.get();
+            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(template2, hashtag3);
             entityManager.persist(template2);
             entityManager.persist(item3);
+            entityManager.persist(hashtag3);
+            entityManager.persist(templateHashtag3);
 
             // when
             final ReadBottariTemplateResponse actual = bottariTemplateService.getById(template1.getId());
@@ -73,7 +88,10 @@ class BottariTemplateServiceTest {
                     () -> assertThat(actual.title()).isEqualTo(template1.getTitle()),
                     () -> assertThat(actual.items()).hasSize(2),
                     () -> assertThat(actual.items().get(0).name()).isEqualTo(item1.getName()),
-                    () -> assertThat(actual.items().get(1).name()).isEqualTo(item2.getName())
+                    () -> assertThat(actual.items().get(1).name()).isEqualTo(item2.getName()),
+                    () -> assertThat(actual.hashtags()).hasSize(2),
+                    () -> assertThat(actual.hashtags().get(0).name()).isEqualTo(hashtag1.getName()),
+                    () -> assertThat(actual.hashtags().get(1).name()).isEqualTo(hashtag2.getName())
             );
         }
 
@@ -105,36 +123,53 @@ class BottariTemplateServiceTest {
             final BottariTemplate memberTemplate1 = BottariTemplateFixture.BOTTARI_TEMPLATE.get(member);
             final BottariTemplateItem item1 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_1.get(memberTemplate1);
             final BottariTemplateItem item2 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_2.get(memberTemplate1);
+            final Hashtag hashtag1 = HashtagFixture.HASHTAG_1.get();
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(memberTemplate1, hashtag1);
             entityManager.persist(memberTemplate1);
             entityManager.persist(item1);
             entityManager.persist(item2);
+            entityManager.persist(hashtag1);
+            entityManager.persist(templateHashtag1);
 
             final BottariTemplate memberTemplate2 = BottariTemplateFixture.BOTTARI_TEMPLATE_2.get(member);
             final BottariTemplateItem item3 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_3.get(memberTemplate2);
+            final Hashtag hashtag2 = HashtagFixture.HASHTAG_2.get();
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(memberTemplate2, hashtag2);
             entityManager.persist(memberTemplate2);
             entityManager.persist(item3);
+            entityManager.persist(hashtag2);
+            entityManager.persist(templateHashtag2);
 
             final BottariTemplate anotherMemberBottariTemplate = BottariTemplateFixture.BOTTARI_TEMPLATE.get(
                     anotherMember);
             final BottariTemplateItem item4 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_4.get(
                     anotherMemberBottariTemplate);
+            final Hashtag hashtag3 = HashtagFixture.HASHTAG_3.get();
+            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(anotherMemberBottariTemplate,
+                    hashtag3);
             entityManager.persist(anotherMemberBottariTemplate);
             entityManager.persist(item4);
+            entityManager.persist(hashtag3);
+            entityManager.persist(templateHashtag3);
 
             // when
             final List<ReadBottariTemplateResponse> actual = bottariTemplateService.getBySsaid(member.getSsaid());
 
             // then
             assertAll(() -> {
-                          assertThat(actual).hasSize(2);
-                          assertThat(actual.get(0).title()).isEqualTo(memberTemplate2.getTitle());
-                          assertThat(actual.get(0).items()).hasSize(1);
-                          assertThat(actual.get(0).items().getFirst().name()).isEqualTo(item3.getName());
-                          assertThat(actual.get(1).title()).isEqualTo(memberTemplate1.getTitle());
-                          assertThat(actual.get(1).items()).hasSize(2);
-                          assertThat(actual.get(1).items().get(0).name()).isEqualTo(item1.getName());
-                          assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName());
-                      }
+                        assertThat(actual).hasSize(2);
+                        assertThat(actual.get(0).title()).isEqualTo(memberTemplate2.getTitle());
+                        assertThat(actual.get(0).items()).hasSize(1);
+                        assertThat(actual.get(0).items().getFirst().name()).isEqualTo(item3.getName());
+                        assertThat(actual.get(0).hashtags()).hasSize(1);
+                        assertThat(actual.get(0).hashtags().getFirst().name()).isEqualTo(hashtag2.getName());
+                        assertThat(actual.get(1).title()).isEqualTo(memberTemplate1.getTitle());
+                        assertThat(actual.get(1).items()).hasSize(2);
+                        assertThat(actual.get(1).items().get(0).name()).isEqualTo(item1.getName());
+                        assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName());
+                        assertThat(actual.get(1).hashtags()).hasSize(1);
+                        assertThat(actual.get(1).hashtags().getFirst().name()).isEqualTo(hashtag1.getName());
+                    }
             );
         }
 
@@ -166,14 +201,22 @@ class BottariTemplateServiceTest {
             final BottariTemplate olderTemplate = BottariTemplateFixture.BOTTARI_TEMPLATE.get(member);
             final BottariTemplateItem item1 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_1.get(olderTemplate);
             final BottariTemplateItem item2 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_2.get(olderTemplate);
+            final Hashtag hashtag1 = HashtagFixture.HASHTAG_1.get();
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(olderTemplate, hashtag1);
             entityManager.persist(olderTemplate);
             entityManager.persist(item1);
             entityManager.persist(item2);
+            entityManager.persist(hashtag1);
+            entityManager.persist(templateHashtag1);
 
             final BottariTemplate newerTemplate = BottariTemplateFixture.ANOTHER_BOTTARI_TEMPLATE.get(member);
             final BottariTemplateItem item3 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_3.get(newerTemplate);
+            final Hashtag hashtag2 = HashtagFixture.HASHTAG_2.get();
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(newerTemplate, hashtag2);
             entityManager.persist(newerTemplate);
             entityManager.persist(item3);
+            entityManager.persist(hashtag2);
+            entityManager.persist(templateHashtag2);
 
             // when
             final List<ReadBottariTemplateResponse> actual = bottariTemplateService.getAll(empty_query);
@@ -184,10 +227,14 @@ class BottariTemplateServiceTest {
                     () -> assertThat(actual.get(0).title()).isEqualTo(newerTemplate.getTitle()),
                     () -> assertThat(actual.get(0).items()).hasSize(1),
                     () -> assertThat(actual.get(0).items().getFirst().name()).isEqualTo(item3.getName()),
+                    () -> assertThat(actual.get(0).hashtags()).hasSize(1),
+                    () -> assertThat(actual.get(0).hashtags().getFirst().name()).isEqualTo(hashtag2.getName()),
                     () -> assertThat(actual.get(1).title()).isEqualTo(olderTemplate.getTitle()),
                     () -> assertThat(actual.get(1).items()).hasSize(2),
                     () -> assertThat(actual.get(1).items().get(0).name()).isEqualTo(item1.getName()),
-                    () -> assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName())
+                    () -> assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName()),
+                    () -> assertThat(actual.get(1).hashtags()).hasSize(1),
+                    () -> assertThat(actual.get(1).hashtags().getFirst().name()).isEqualTo(hashtag1.getName())
             );
         }
 
@@ -203,19 +250,31 @@ class BottariTemplateServiceTest {
             final BottariTemplate template1 = BottariTemplateFixture.BOTTARI_TEMPLATE.get(member);
             final BottariTemplateItem item1 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_1.get(template1);
             final BottariTemplateItem item2 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_2.get(template1);
+            final Hashtag hashtag1 = HashtagFixture.HASHTAG_1.get();
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(template1, hashtag1);
             entityManager.persist(template1);
             entityManager.persist(item1);
             entityManager.persist(item2);
+            entityManager.persist(hashtag1);
+            entityManager.persist(templateHashtag1);
 
             final BottariTemplate template2 = BottariTemplateFixture.BOTTARI_TEMPLATE_2.get(member);
             final BottariTemplateItem item3 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_3.get(template2);
+            final Hashtag hashtag2 = HashtagFixture.HASHTAG_2.get();
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(template2, hashtag2);
             entityManager.persist(template2);
             entityManager.persist(item3);
+            entityManager.persist(hashtag2);
+            entityManager.persist(templateHashtag2);
 
             final BottariTemplate template3 = new BottariTemplate("subject", member);
             final BottariTemplateItem item4 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_4.get(template3);
+            final Hashtag hashtag3 = HashtagFixture.HASHTAG_3.get();
+            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(template3, hashtag3);
             entityManager.persist(template3);
             entityManager.persist(item4);
+            entityManager.persist(hashtag3);
+            entityManager.persist(templateHashtag3);
 
             // when
             final List<ReadBottariTemplateResponse> actual = bottariTemplateService.getAll(query);
@@ -227,9 +286,13 @@ class BottariTemplateServiceTest {
                     () -> assertThat(actual.get(1).items()).hasSize(2),
                     () -> assertThat(actual.get(1).items().get(0).name()).isEqualTo(item1.getName()),
                     () -> assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName()),
+                    () -> assertThat(actual.get(1).hashtags()).hasSize(1),
+                    () -> assertThat(actual.get(1).hashtags().getFirst().name()).isEqualTo(hashtag1.getName()),
                     () -> assertThat(actual.getFirst().title()).isEqualTo(template2.getTitle()),
                     () -> assertThat(actual.getFirst().items()).hasSize(1),
-                    () -> assertThat(actual.getFirst().items().getFirst().name()).isEqualTo(item3.getName())
+                    () -> assertThat(actual.getFirst().items().getFirst().name()).isEqualTo(item3.getName()),
+                    () -> assertThat(actual.getFirst().hashtags()).hasSize(1),
+                    () -> assertThat(actual.getFirst().hashtags().getFirst().name()).isEqualTo(hashtag2.getName())
             );
         }
     }
@@ -243,6 +306,8 @@ class BottariTemplateServiceTest {
             entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
             entityManager.createNativeQuery("TRUNCATE TABLE bottari_template_history").executeUpdate();
             entityManager.createNativeQuery("TRUNCATE TABLE bottari_template_item").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE bottari_template_hashtag").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE hashtag").executeUpdate();
             entityManager.createNativeQuery("TRUNCATE TABLE bottari_template").executeUpdate();
             entityManager.createNativeQuery("TRUNCATE TABLE member").executeUpdate();
             entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
@@ -269,6 +334,20 @@ class BottariTemplateServiceTest {
             entityManager.persist(item2);
             entityManager.persist(item3);
 
+            final Hashtag hashtag1 = new Hashtag("hashtag1");
+            final Hashtag hashtag2 = new Hashtag("hashtag2");
+            final Hashtag hashtag3 = new Hashtag("hashtag3");
+            entityManager.persist(hashtag1);
+            entityManager.persist(hashtag2);
+            entityManager.persist(hashtag3);
+
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(template1, hashtag1);
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(template2, hashtag2);
+            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(template3, hashtag3);
+            entityManager.persist(templateHashtag1);
+            entityManager.persist(templateHashtag2);
+            entityManager.persist(templateHashtag3);
+
             final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
                     "",
                     null,
@@ -284,6 +363,12 @@ class BottariTemplateServiceTest {
             // then
             assertAll(
                     () -> assertThat(actual.contents()).hasSize(2),
+                    () -> assertThat(actual.contents().get(0).hashtags()).hasSize(1),
+                    () -> assertThat(actual.contents().get(0).hashtags().getFirst().name()).isEqualTo(
+                            hashtag3.getName()),
+                    () -> assertThat(actual.contents().get(1).hashtags()).hasSize(1),
+                    () -> assertThat(actual.contents().get(1).hashtags().getFirst().name()).isEqualTo(
+                            hashtag2.getName()),
                     () -> assertThat(actual.currentPage()).isEqualTo(0),
                     () -> assertThat(actual.size()).isEqualTo(2),
                     () -> assertThat(actual.hasNext()).isTrue(),
@@ -311,6 +396,16 @@ class BottariTemplateServiceTest {
             entityManager.persist(item1);
             entityManager.persist(item2);
 
+            final Hashtag hashtag1 = new Hashtag("hashtag1");
+            final Hashtag hashtag2 = new Hashtag("hashtag2");
+            entityManager.persist(hashtag1);
+            entityManager.persist(hashtag2);
+
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(template1, hashtag1);
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(template2, hashtag2);
+            entityManager.persist(templateHashtag1);
+            entityManager.persist(templateHashtag2);
+
             final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
                     "",
                     null,
@@ -326,6 +421,9 @@ class BottariTemplateServiceTest {
             // then
             assertAll(
                     () -> assertThat(actual.contents()).hasSize(1),
+                    () -> assertThat(actual.contents().getFirst().hashtags()).hasSize(1),
+                    () -> assertThat(actual.contents().getFirst().hashtags().getFirst().name()).isEqualTo(
+                            hashtag2.getName()),
                     () -> assertThat(actual.currentPage()).isEqualTo(0),
                     () -> assertThat(actual.size()).isEqualTo(1),
                     () -> assertThat(actual.hasNext()).isTrue(),
@@ -356,6 +454,20 @@ class BottariTemplateServiceTest {
             entityManager.persist(item1);
             entityManager.persist(item2);
             entityManager.persist(item3);
+
+            final Hashtag hashtag1 = new Hashtag("여행");
+            final Hashtag hashtag2 = new Hashtag("캠핑");
+            final Hashtag hashtag3 = new Hashtag("출장");
+            entityManager.persist(hashtag1);
+            entityManager.persist(hashtag2);
+            entityManager.persist(hashtag3);
+
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(template1, hashtag1);
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(template2, hashtag2);
+            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(template3, hashtag3);
+            entityManager.persist(templateHashtag1);
+            entityManager.persist(templateHashtag2);
+            entityManager.persist(templateHashtag3);
 
             /*
              * --- 트랜잭션을 강제로 커밋 ---
@@ -389,7 +501,11 @@ class BottariTemplateServiceTest {
             assertAll(
                     () -> assertThat(actual.contents()).hasSize(2),
                     () -> assertThat(actual.contents().get(0).title()).isEqualTo("출장 체크리스트"),
+                    () -> assertThat(actual.contents().get(0).hashtags()).hasSize(1),
+                    () -> assertThat(actual.contents().get(0).hashtags().getFirst().name()).isEqualTo("출장"),
                     () -> assertThat(actual.contents().get(1).title()).isEqualTo("여행용 체크리스트"),
+                    () -> assertThat(actual.contents().get(1).hashtags()).hasSize(1),
+                    () -> assertThat(actual.contents().get(1).hashtags().getFirst().name()).isEqualTo("여행"),
                     () -> assertThat(actual.hasNext()).isFalse(),
                     () -> assertThat(actual.last()).isTrue()
             );
@@ -600,11 +716,11 @@ class BottariTemplateServiceTest {
 
             // then
             final Long actualHistoryCount = entityManager.createQuery("""
-                                                                                               SELECT COUNT(bh)
-                                                                                               FROM BottariTemplateHistory bh
-                                                                                               WHERE bh.id.memberId = :memberId
-                                                                                               AND bh.id.bottariTemplateId = :bottariTemplateId
-                                                                              """, Long.class)
+                                             SELECT COUNT(bh)
+                                             FROM BottariTemplateHistory bh
+                                             WHERE bh.id.memberId = :memberId
+                                             AND bh.id.bottariTemplateId = :bottariTemplateId
+                            """, Long.class)
                     .setParameter("memberId", member.getId())
                     .setParameter("bottariTemplateId", bottariTemplate.getId())
                     .getSingleResult();

--- a/backend/bottari/src/test/java/com/bottari/fixture/HashtagFixture.java
+++ b/backend/bottari/src/test/java/com/bottari/fixture/HashtagFixture.java
@@ -1,0 +1,21 @@
+package com.bottari.fixture;
+
+import com.bottari.bottaritemplate.domain.Hashtag;
+
+public enum HashtagFixture {
+
+    HASHTAG_1("hashtag1"),
+    HASHTAG_2("hashtag2"),
+    HASHTAG_3("hashtag3"),
+    ;
+
+    private final String name;
+
+    HashtagFixture(final String name) {
+        this.name = name;
+    }
+
+    public Hashtag get() {
+        return new Hashtag(name);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 템플릿 조회 응답에 해시태그 추가
- 기존 조회 로직에 추가

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #565

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 모든 템플릿 조회 API는 `ReadBottariTemplateResponse` DTO 기반으로 응답하므로, 해당 DTO 필드에 해시태그 리스트를 추가하였음
  - `BottariTemplateItemResponse`와 일관성을 맞추기 위해 `ReadBottariTemplateResponse` 이너 클래스로 `HashtagResponse`를 추가하여 구현함
  - 템플릿에 따른 해시태그 조회 서비스 로직은 `BottariTemplateItem`의 조회 로직과 `TeamMember`(N:N 관계에 관한 로직)를 참고하여 일관적으로 적용하였음
  - 이로 인해 깨지는 테스트 수정함
- 템플릿 조회 서비스 테스트에서 given에 해시태그 데이터를 추가하였고, assert에서 해당 해시태그 데이터와 일치하는지에 대한 부분을 추가하여 템플릿에 따른 해시태그를 잘 조회하는지 검증하였음
  - 템플릿 아이템이랑 비슷함

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- 머지좀

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 템플릿 상세, 목록, 다음 페이지 조회 응답에 각 템플릿의 해시태그가 포함됩니다.
  * 해시태그 정보는 ID와 이름으로 제공되어 클라이언트에서 표시·선택이 가능합니다.
  * 기존 응답(항목, 작성자, 생성일, 사용 횟수)은 그대로 유지되며 해시태그 필드가 추가되었습니다.
  * 여러 템플릿을 한 번에 조회하는 경우에도 각 템플릿별 해시태그가 함께 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->