### PR TITLE
[BE] 해시태그에 해당하는 템플릿 조회 기능 추가

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateApiDocs.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateApiDocs.java
@@ -2,7 +2,8 @@ package com.bottari.bottaritemplate.controller;
 
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
-import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
+import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByHashtagRequest;
+import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByTitleRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.error.ApiErrorCodes;
 import com.bottari.error.ErrorCode;
@@ -47,17 +48,31 @@ public interface BottariTemplateApiDocs {
             final String query
     );
 
-    @Operation(summary = "커서 기반 보따리 템플릿 목록 조회")
+    @Operation(summary = "커서 기반 제목으로 보따리 템플릿 목록 조회")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "커서 기반 보따리 템플릿 목록 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "커서 기반 제목으로 보따리 템플릿 목록 조회 성공"),
     })
     @ApiErrorCodes({
             ErrorCode.DATE_FORMAT_INVALID,
             ErrorCode.NUMBER_FORMAT_INVALID,
             ErrorCode.BOTTARI_TEMPLATE_INVALID_SORT_TYPE
     })
-    ResponseEntity<ReadNextBottariTemplateResponse> readNextAll(
-            final ReadNextBottariTemplateRequest request
+    ResponseEntity<ReadNextBottariTemplateResponse> readNextAllByTitle(
+            final ReadNextBottariTemplateByTitleRequest request
+    );
+
+    @Operation(summary = "커서 기반 해시태그로 보따리 템플릿 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "커서 기반 해시태그로 보따리 템플릿 목록 조회 성공"),
+    })
+    @ApiErrorCodes({
+            ErrorCode.DATE_FORMAT_INVALID,
+            ErrorCode.NUMBER_FORMAT_INVALID,
+            ErrorCode.BOTTARI_TEMPLATE_INVALID_SORT_TYPE,
+            ErrorCode.HASHTAG_ID_MISSING
+    })
+    ResponseEntity<ReadNextBottariTemplateResponse> readNextAllByHashtag(
+            final ReadNextBottariTemplateByHashtagRequest request
     );
 
     @Operation(summary = "보따리 템플릿 생성")

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateController.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateController.java
@@ -3,7 +3,7 @@ package com.bottari.bottaritemplate.controller;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByHashtagRequest;
-import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
+import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByTitleRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.bottaritemplate.service.BottariTemplateService;
 import com.bottari.config.MemberIdentifier;
@@ -62,9 +62,9 @@ public class BottariTemplateController implements BottariTemplateApiDocs {
     @GetMapping("/cursor")
     @Override
     public ResponseEntity<ReadNextBottariTemplateResponse> readNextAll(
-            @ModelAttribute final ReadNextBottariTemplateRequest request
+            @ModelAttribute final ReadNextBottariTemplateByTitleRequest request
     ) {
-        final ReadNextBottariTemplateResponse response = bottariTemplateService.getNextAll(request);
+        final ReadNextBottariTemplateResponse response = bottariTemplateService.getNextAllByTitle(request);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateController.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateController.java
@@ -2,6 +2,7 @@ package com.bottari.bottaritemplate.controller;
 
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
+import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByHashtagRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.bottaritemplate.service.BottariTemplateService;
@@ -64,6 +65,15 @@ public class BottariTemplateController implements BottariTemplateApiDocs {
             @ModelAttribute final ReadNextBottariTemplateRequest request
     ) {
         final ReadNextBottariTemplateResponse response = bottariTemplateService.getNextAll(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/hashtag")
+    public ResponseEntity<ReadNextBottariTemplateResponse> readNextAllByHashtag(
+            @ModelAttribute final ReadNextBottariTemplateByHashtagRequest request
+    ) {
+        final ReadNextBottariTemplateResponse response = bottariTemplateService.getNextAllByHashTag(request);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateController.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/BottariTemplateController.java
@@ -59,9 +59,9 @@ public class BottariTemplateController implements BottariTemplateApiDocs {
     }
 
     // TODO: 연동 후, readAll로 대치
-    @GetMapping("/cursor")
+    @GetMapping("/title")
     @Override
-    public ResponseEntity<ReadNextBottariTemplateResponse> readNextAll(
+    public ResponseEntity<ReadNextBottariTemplateResponse> readNextAllByTitle(
             @ModelAttribute final ReadNextBottariTemplateByTitleRequest request
     ) {
         final ReadNextBottariTemplateResponse response = bottariTemplateService.getNextAllByTitle(request);
@@ -70,6 +70,7 @@ public class BottariTemplateController implements BottariTemplateApiDocs {
     }
 
     @GetMapping("/hashtag")
+    @Override
     public ResponseEntity<ReadNextBottariTemplateResponse> readNextAllByHashtag(
             @ModelAttribute final ReadNextBottariTemplateByHashtagRequest request
     ) {

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateCursor.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateCursor.java
@@ -1,0 +1,107 @@
+package com.bottari.bottaritemplate.domain;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+public abstract class BottariTemplateCursor {
+
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN);
+    private static final int DEFAULT_SIZE = 10;
+
+    private final Long lastId;
+    private final String lastInfo;
+    private final int page;
+    private final int size;
+    private final String property;
+
+    public BottariTemplateCursor(
+            final Long lastId,
+            final String lastInfo,
+            final int page,
+            final int size,
+            final String property
+    ) {
+        this.size = normalizeSize(size);
+        this.page = normalizePage(page);
+        this.lastId = normalizeLastId(lastId);
+        this.property = normalizeProperty(property);
+        this.lastInfo = normalizeLastInfo(property, lastInfo);
+    }
+
+    private static int normalizeSize(final int size) {
+        if (size <= 0) {
+            return DEFAULT_SIZE;
+        }
+
+        return size;
+    }
+
+    private static int normalizePage(final int page) {
+        if (page < 0) {
+            return 0;
+        }
+
+        return page;
+    }
+
+    private static Long normalizeLastId(final Long lastId) {
+        if (lastId == null) {
+            return Long.MAX_VALUE;
+        }
+
+        return lastId;
+    }
+
+    private static String normalizeProperty(final String property) {
+        if (property == null || property.isBlank()) {
+            return SortProperty.CREATED_AT.getProperty();
+        }
+
+        return property;
+    }
+
+    private static String normalizeLastInfo(
+            final String property,
+            final String lastInfo
+    ) {
+        if (SortProperty.CREATED_AT.equalsProperty(property) && (lastInfo == null || lastInfo.isBlank())) {
+            return LocalDateTime.now().plusDays(1).format(DATE_TIME_FORMATTER);
+        }
+        if (SortProperty.TAKEN_COUNT.equalsProperty(property) && (lastInfo == null || lastInfo.isBlank())) {
+            return String.valueOf(Integer.MAX_VALUE);
+        }
+
+        return lastInfo;
+    }
+
+    public Pageable toPageable() {
+        return PageRequest.of(page, size);
+    }
+
+    public LocalDateTime getCreatedAt() {
+        try {
+            return LocalDateTime.parse(lastInfo, DATE_TIME_FORMATTER);
+        } catch (final DateTimeParseException e) {
+            throw new BusinessException(
+                    ErrorCode.DATE_FORMAT_INVALID,
+                    "보따리 템플릿의 생성일자는 (%s) 형식이어야 합니다.".formatted(DATE_TIME_PATTERN)
+            );
+        }
+    }
+
+    public Integer getTakenCount() {
+        try {
+            return Integer.parseInt(lastInfo);
+        } catch (final NumberFormatException e) {
+            throw new BusinessException(ErrorCode.NUMBER_FORMAT_INVALID, "보따리 템플릿의 가져간 횟수는 숫자여야 합니다.");
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateFetcher.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateFetcher.java
@@ -1,0 +1,10 @@
+package com.bottari.bottaritemplate.domain;
+
+import com.bottari.bottaritemplate.repository.dto.BottariTemplateProjection;
+import org.springframework.data.domain.Slice;
+
+@FunctionalInterface
+public interface BottariTemplateFetcher<T extends BottariTemplateCursor> {
+
+    Slice<BottariTemplateProjection> fetch(final T cursor);
+}

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtag.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtag.java
@@ -31,7 +31,7 @@ public class BottariTemplateHashtag {
     private BottariTemplate bottariTemplate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "hashtag")
+    @JoinColumn(name = "hashtag_id")
     private Hashtag hashtag;
 
     @Column(name = "deleted_at")

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursor.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursor.java
@@ -25,6 +25,7 @@ public class BottariTemplateHashtagCursor extends BottariTemplateCursor {
         if (hashtagId == null) {
             throw new BusinessException(ErrorCode.HASHTAG_ID_MISSING);
         }
+
         return hashtagId;
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursor.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursor.java
@@ -2,107 +2,29 @@ package com.bottari.bottaritemplate.domain;
 
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import lombok.Getter;
 
-public record BottariTemplateHashtagCursor(
-        Long hashtagId,
-        Long lastId,
-        String lastInfo,
-        int page,
-        int size,
-        String property
-) {
+@Getter
+public class BottariTemplateHashtagCursor extends BottariTemplateCursor {
 
-    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN);
-    private static final int DEFAULT_SIZE = 10;
+    private final Long hashtagId;
 
-    public BottariTemplateHashtagCursor {
-        hashtagId = validateHashtagId(hashtagId);
-        size = normalizeSize(size);
-        page = normalizePage(page);
-        lastId = normalizeLastId(lastId);
-        property = normalizeProperty(property);
-        lastInfo = normalizeLastInfo(property, lastInfo);
+    public BottariTemplateHashtagCursor(
+            final Long hashtagId,
+            final Long lastId,
+            final String lastInfo,
+            final int page,
+            final int size,
+            final String property
+    ) {
+        super(lastId, lastInfo, page, size, property);
+        this.hashtagId = validateHashtagId(hashtagId);
     }
 
-    private static Long validateHashtagId(final Long hashtagId) {
+    private Long validateHashtagId(final Long hashtagId) {
         if (hashtagId == null) {
             throw new BusinessException(ErrorCode.HASHTAG_ID_MISSING);
         }
         return hashtagId;
-    }
-
-    private static int normalizeSize(final int size) {
-        if (size <= 0) {
-            return DEFAULT_SIZE;
-        }
-
-        return size;
-    }
-
-    private static int normalizePage(final int page) {
-        if (page < 0) {
-            return 0;
-        }
-
-        return page;
-    }
-
-    private static Long normalizeLastId(final Long lastId) {
-        if (lastId == null) {
-            return Long.MAX_VALUE;
-        }
-
-        return lastId;
-    }
-
-    private static String normalizeProperty(final String property) {
-        if (property == null || property.isBlank()) {
-            return SortProperty.CREATED_AT.getProperty();
-        }
-
-        return property;
-    }
-
-    private static String normalizeLastInfo(
-            final String property,
-            final String lastInfo
-    ) {
-        if (SortProperty.CREATED_AT.equalsProperty(property) && (lastInfo == null || lastInfo.isBlank())) {
-            return LocalDateTime.now().plusDays(1).format(DATE_TIME_FORMATTER);
-        }
-        if (SortProperty.TAKEN_COUNT.equalsProperty(property) && (lastInfo == null || lastInfo.isBlank())) {
-            return String.valueOf(Integer.MAX_VALUE);
-        }
-
-        return lastInfo;
-    }
-
-    public Pageable toPageable() {
-        return PageRequest.of(page, size);
-    }
-
-    public LocalDateTime getCreatedAt() {
-        try {
-            return LocalDateTime.parse(lastInfo, DATE_TIME_FORMATTER);
-        } catch (final DateTimeParseException e) {
-            throw new BusinessException(
-                    ErrorCode.DATE_FORMAT_INVALID,
-                    "보따리 템플릿의 생성일자는 (%s) 형식이어야 합니다.".formatted(DATE_TIME_PATTERN)
-            );
-        }
-    }
-
-    public Integer getTakenCount() {
-        try {
-            return Integer.parseInt(lastInfo);
-        } catch (final NumberFormatException e) {
-            throw new BusinessException(ErrorCode.NUMBER_FORMAT_INVALID, "보따리 템플릿의 가져간 횟수는 숫자여야 합니다.");
-        }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursor.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursor.java
@@ -1,0 +1,108 @@
+package com.bottari.bottaritemplate.domain;
+
+import com.bottari.error.BusinessException;
+import com.bottari.error.ErrorCode;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public record BottariTemplateHashtagCursor(
+        Long hashtagId,
+        Long lastId,
+        String lastInfo,
+        int page,
+        int size,
+        String property
+) {
+
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN);
+    private static final int DEFAULT_SIZE = 10;
+
+    public BottariTemplateHashtagCursor {
+        hashtagId = validateHashtagId(hashtagId);
+        size = normalizeSize(size);
+        page = normalizePage(page);
+        lastId = normalizeLastId(lastId);
+        property = normalizeProperty(property);
+        lastInfo = normalizeLastInfo(property, lastInfo);
+    }
+
+    private static Long validateHashtagId(final Long hashtagId) {
+        if (hashtagId == null) {
+            throw new BusinessException(ErrorCode.HASHTAG_ID_MISSING);
+        }
+        return hashtagId;
+    }
+
+    private static int normalizeSize(final int size) {
+        if (size <= 0) {
+            return DEFAULT_SIZE;
+        }
+
+        return size;
+    }
+
+    private static int normalizePage(final int page) {
+        if (page < 0) {
+            return 0;
+        }
+
+        return page;
+    }
+
+    private static Long normalizeLastId(final Long lastId) {
+        if (lastId == null) {
+            return Long.MAX_VALUE;
+        }
+
+        return lastId;
+    }
+
+    private static String normalizeProperty(final String property) {
+        if (property == null || property.isBlank()) {
+            return SortProperty.CREATED_AT.getProperty();
+        }
+
+        return property;
+    }
+
+    private static String normalizeLastInfo(
+            final String property,
+            final String lastInfo
+    ) {
+        if (SortProperty.CREATED_AT.equalsProperty(property) && (lastInfo == null || lastInfo.isBlank())) {
+            return LocalDateTime.now().plusDays(1).format(DATE_TIME_FORMATTER);
+        }
+        if (SortProperty.TAKEN_COUNT.equalsProperty(property) && (lastInfo == null || lastInfo.isBlank())) {
+            return String.valueOf(Integer.MAX_VALUE);
+        }
+
+        return lastInfo;
+    }
+
+    public Pageable toPageable() {
+        return PageRequest.of(page, size);
+    }
+
+    public LocalDateTime getCreatedAt() {
+        try {
+            return LocalDateTime.parse(lastInfo, DATE_TIME_FORMATTER);
+        } catch (final DateTimeParseException e) {
+            throw new BusinessException(
+                    ErrorCode.DATE_FORMAT_INVALID,
+                    "보따리 템플릿의 생성일자는 (%s) 형식이어야 합니다.".formatted(DATE_TIME_PATTERN)
+            );
+        }
+    }
+
+    public Integer getTakenCount() {
+        try {
+            return Integer.parseInt(lastInfo);
+        } catch (final NumberFormatException e) {
+            throw new BusinessException(ErrorCode.NUMBER_FORMAT_INVALID, "보따리 템플릿의 가져간 횟수는 숫자여야 합니다.");
+        }
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateTitleCursor.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateTitleCursor.java
@@ -1,114 +1,34 @@
 package com.bottari.bottaritemplate.domain;
 
-import com.bottari.error.BusinessException;
-import com.bottari.error.ErrorCode;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import lombok.Getter;
 
-public record BottariTemplateTitleCursor(
-        String query,
-        Long lastId,
-        String lastInfo,
-        int page,
-        int size,
-        String property
-) {
+@Getter
+public class BottariTemplateTitleCursor extends BottariTemplateCursor {
 
-    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN);
-    private static final int DEFAULT_SIZE = 10;
+    private final String title;
 
-    public BottariTemplateTitleCursor {
-        query = normalizeQuery(query);
-        size = normalizeSize(size);
-        page = normalizePage(page);
-        lastId = normalizeLastId(lastId);
-        property = normalizeProperty(property);
-        lastInfo = normalizeLastInfo(property, lastInfo);
+    public BottariTemplateTitleCursor(
+            final String title,
+            final Long lastId,
+            final String lastInfo,
+            final int page,
+            final int size,
+            final String property
+    ) {
+        super(lastId, lastInfo, page, size, property);
+        this.title = normalizeTile(title);
     }
 
-    private static String normalizeQuery(final String query) {
-        if (query == null || query.isBlank()) {
+    private String normalizeTile(final String title) {
+        if (title == null || title.isBlank()) {
             return "";
         }
 
-        return Arrays.stream(query.trim().split("\\s+"))
+        return Arrays.stream(title.trim().split("\\s+"))
                 .filter(word -> !word.isBlank())
                 .map(word -> "+" + word)
                 .collect(Collectors.joining(" "));
-    }
-
-    private static int normalizeSize(final int size) {
-        if (size <= 0) {
-            return DEFAULT_SIZE;
-        }
-
-        return size;
-    }
-
-    private static int normalizePage(final int page) {
-        if (page < 0) {
-            return 0;
-        }
-
-        return page;
-    }
-
-    private static Long normalizeLastId(final Long lastId) {
-        if (lastId == null) {
-            return Long.MAX_VALUE;
-        }
-
-        return lastId;
-    }
-
-    private static String normalizeProperty(final String property) {
-        if (property == null || property.isBlank()) {
-            return SortProperty.CREATED_AT.getProperty();
-        }
-
-        return property;
-    }
-
-    private static String normalizeLastInfo(
-            final String property,
-            final String lastInfo
-    ) {
-        if (SortProperty.CREATED_AT.equalsProperty(property) && (lastInfo == null || lastInfo.isBlank())) {
-            return LocalDateTime.now().plusDays(1).format(DATE_TIME_FORMATTER);
-        }
-        if (SortProperty.TAKEN_COUNT.equalsProperty(property) && (lastInfo == null || lastInfo.isBlank())) {
-            return String.valueOf(Long.MAX_VALUE);
-        }
-
-        return lastInfo;
-    }
-
-    public Pageable toPageable() {
-        return PageRequest.of(page, size);
-    }
-
-    public LocalDateTime getCreatedAt() {
-        try {
-            return LocalDateTime.parse(lastInfo, DATE_TIME_FORMATTER);
-        } catch (final DateTimeParseException e) {
-            throw new BusinessException(
-                    ErrorCode.DATE_FORMAT_INVALID,
-                    "보따리 템플릿의 생성일자는 (%s) 형식이어야 합니다.".formatted(DATE_TIME_PATTERN)
-            );
-        }
-    }
-
-    public Long getTakenCount() {
-        try {
-            return Long.parseLong(lastInfo);
-        } catch (final NumberFormatException e) {
-            throw new BusinessException(ErrorCode.NUMBER_FORMAT_INVALID, "보따리 템플릿의 가져간 횟수는 숫자여야 합니다.");
-        }
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateTitleCursor.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateTitleCursor.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-public record BottariTemplateCursor(
+public record BottariTemplateTitleCursor(
         String query,
         Long lastId,
         String lastInfo,
@@ -23,7 +23,7 @@ public record BottariTemplateCursor(
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN);
     private static final int DEFAULT_SIZE = 10;
 
-    public BottariTemplateCursor {
+    public BottariTemplateTitleCursor {
         query = normalizeQuery(query);
         size = normalizeSize(size);
         page = normalizePage(page);

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadNextBottariTemplateByHashtagRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadNextBottariTemplateByHashtagRequest.java
@@ -1,0 +1,23 @@
+package com.bottari.bottaritemplate.dto;
+
+import com.bottari.bottaritemplate.domain.BottariTemplateHashtagCursor;
+
+public record ReadNextBottariTemplateByHashtagRequest(
+        Long hashtagId,
+        Long lastId,
+        String lastInfo,
+        int page,
+        int size,
+        String property
+) {
+    public BottariTemplateHashtagCursor toCursor() {
+        return new BottariTemplateHashtagCursor(
+                hashtagId,
+                lastId,
+                lastInfo,
+                page,
+                size,
+                property
+        );
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadNextBottariTemplateByHashtagRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadNextBottariTemplateByHashtagRequest.java
@@ -10,6 +10,7 @@ public record ReadNextBottariTemplateByHashtagRequest(
         int size,
         String property
 ) {
+
     public BottariTemplateHashtagCursor toCursor() {
         return new BottariTemplateHashtagCursor(
                 hashtagId,

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadNextBottariTemplateByTitleRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadNextBottariTemplateByTitleRequest.java
@@ -2,7 +2,7 @@ package com.bottari.bottaritemplate.dto;
 
 import com.bottari.bottaritemplate.domain.BottariTemplateTitleCursor;
 
-public record ReadNextBottariTemplateRequest(
+public record ReadNextBottariTemplateByTitleRequest(
         String query,
         Long lastId,
         String lastInfo,

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadNextBottariTemplateRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadNextBottariTemplateRequest.java
@@ -1,6 +1,6 @@
 package com.bottari.bottaritemplate.dto;
 
-import com.bottari.bottaritemplate.domain.BottariTemplateCursor;
+import com.bottari.bottaritemplate.domain.BottariTemplateTitleCursor;
 
 public record ReadNextBottariTemplateRequest(
         String query,
@@ -11,8 +11,8 @@ public record ReadNextBottariTemplateRequest(
         String property
 ) {
 
-    public BottariTemplateCursor toCursor() {
-        return new BottariTemplateCursor(
+    public BottariTemplateTitleCursor toCursor() {
+        return new BottariTemplateTitleCursor(
                 query,
                 lastId,
                 lastInfo,

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateHashtagRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateHashtagRepository.java
@@ -2,7 +2,11 @@ package com.bottari.bottaritemplate.repository;
 
 import com.bottari.bottaritemplate.domain.BottariTemplate;
 import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
+import com.bottari.bottaritemplate.repository.dto.BottariTemplateProjection;
+import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -25,4 +29,55 @@ public interface BottariTemplateHashtagRepository extends JpaRepository<BottariT
             WHERE bth.bottariTemplate.id IN :templateIds
             """)
     List<BottariTemplateHashtag> findAllByBottariTemplateIds(final List<Long> templateIds);
+
+    @Query("""
+            SELECT 
+                   bt.id AS bottariTemplateId,
+                   bt.title AS title,
+                   bt.takenCount AS takenCount,
+                   bt.createdAt AS bottariTemplateCreatedAt,
+                   m.id AS memberId,
+                   m.name AS memberName
+            FROM BottariTemplateHashtag bth
+            JOIN bth.bottariTemplate bt
+            JOIN bt.member m
+            WHERE bth.hashtag.id = :hashtagId
+                AND (
+                        bt.createdAt < :lastCreatedAt
+                    OR (bt.createdAt = :lastCreatedAt AND bt.id < :lastId)
+                )
+            ORDER BY bt.createdAt DESC, bt.id DESC
+            """)
+    Slice<BottariTemplateProjection> findNextByCreatedAt(
+            final Long hashtagId,
+            final LocalDateTime lastCreatedAt,
+            final Long lastId,
+            final Pageable pageable
+    );
+
+    @Query("""
+            SELECT
+                 bt.id AS bottariTemplateId,
+                 bt.title AS title,
+                 bt.takenCount AS takenCount,
+                 bt.createdAt AS bottariTemplateCreatedAt,
+                 m.id AS memberId,
+                 m.name AS memberName
+            FROM BottariTemplateHashtag bth
+            JOIN bth.bottariTemplate bt
+            JOIN bt.member m
+            WHERE bth.hashtag.id = :hashtagId
+                AND (
+                        bt.takenCount < :lastTakenCount
+                    OR (bt.takenCount = :lastTakenCount AND bt.id < :lastId)
+                )
+            ORDER BY bt.takenCount DESC, bt.id DESC
+            """
+    )
+    Slice<BottariTemplateProjection> findNextByTakenCount(
+            final Long hashtagId,
+            final Integer lastTakenCount,
+            final Long lastId,
+            final Pageable pageable
+    );
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateRepository.java
@@ -30,23 +30,23 @@ public interface BottariTemplateRepository extends JpaRepository<BottariTemplate
     List<BottariTemplate> findAllWithMember(final String query);
 
     @Query(value = """
-            SELECT STRAIGHT_JOIN
-                       bt.id AS bottariTemplateId,
-                       bt.title AS title,
-                       bt.taken_count AS takenCount,
-                       bt.created_at AS bottariTemplateCreatedAt,
-                       m.id AS memberId,
-                       m.name AS memberName
-            FROM bottari_template bt
-            JOIN member m ON m.id = bt.member_id 
-            WHERE (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
-                AND(
-                        bt.created_at < :lastCreatedAt
-                            OR (bt.created_at = :lastCreatedAt AND bt.id < :lastId)
-                        )
-            ORDER BY bt.created_at DESC, bt.id DESC 
-            LIMIT :limit
-        """ ,nativeQuery = true)
+                SELECT STRAIGHT_JOIN
+                           bt.id AS bottariTemplateId,
+                           bt.title AS title,
+                           bt.taken_count AS takenCount,
+                           bt.created_at AS bottariTemplateCreatedAt,
+                           m.id AS memberId,
+                           m.name AS memberName
+                FROM bottari_template bt
+                JOIN member m ON m.id = bt.member_id 
+                WHERE (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
+                    AND(
+                            bt.created_at < :lastCreatedAt
+                                OR (bt.created_at = :lastCreatedAt AND bt.id < :lastId)
+                            )
+                ORDER BY bt.created_at DESC, bt.id DESC 
+                LIMIT :limit
+            """, nativeQuery = true)
     List<BottariTemplateProjection> findNextByCreatedAt(
             final String query,
             final LocalDateTime lastCreatedAt,
@@ -71,10 +71,10 @@ public interface BottariTemplateRepository extends JpaRepository<BottariTemplate
                     )
             ORDER BY bt.taken_count DESC, bt.id DESC
             LIMIT :limit
-            """ ,nativeQuery = true)
+            """, nativeQuery = true)
     List<BottariTemplateProjection> findNextByTakenCount(
             final String query,
-            final Long lastTakenCount,
+            final Integer lastTakenCount,
             final Long lastId,
             final int limit
     );

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
@@ -7,12 +7,14 @@ import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.bottaritemplate.domain.BottariTemplate;
 import com.bottari.bottaritemplate.domain.BottariTemplateCursor;
 import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
+import com.bottari.bottaritemplate.domain.BottariTemplateHashtagCursor;
 import com.bottari.bottaritemplate.domain.BottariTemplateHistory;
 import com.bottari.bottaritemplate.domain.BottariTemplateItem;
 import com.bottari.bottaritemplate.domain.Hashtag;
 import com.bottari.bottaritemplate.domain.SortProperty;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
+import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByHashtagRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.bottaritemplate.repository.BottariTemplateHashtagRepository;
@@ -104,6 +106,24 @@ public class BottariTemplateService {
                 new SliceImpl<>(responses, pageable, bottariTemplates.hasNext()), cursor.property());
     }
 
+    public ReadNextBottariTemplateResponse getNextAllByHashTag(final ReadNextBottariTemplateByHashtagRequest request) {
+        final BottariTemplateHashtagCursor cursor = request.toCursor();
+        final Pageable pageable = cursor.toPageable();
+        final Slice<BottariTemplateProjection> bottariTemplates = getNextBySortProperty(cursor, pageable);
+        final Map<Long, List<BottariTemplateItem>> itemsGroupByTemplateId =
+                groupingItemsByTemplateId(bottariTemplates.getContent());
+        final Map<Long, List<Hashtag>> hashtagsGroupByTemplateId =
+                groupingHashtagsByTemplateId(bottariTemplates.getContent());
+        final List<ReadBottariTemplateResponse> responses = buildReadBottariTemplateResponses(
+                itemsGroupByTemplateId,
+                hashtagsGroupByTemplateId,
+                bottariTemplates.getContent()
+        );
+
+        return ReadNextBottariTemplateResponse.of(
+                new SliceImpl<>(responses, pageable, bottariTemplates.hasNext()), cursor.property());
+    }
+
     @Transactional
     public Long create(
             final String ssaid,
@@ -170,6 +190,19 @@ public class BottariTemplateService {
         };
     }
 
+    private Slice<BottariTemplateProjection> getNextBySortProperty(
+            final BottariTemplateHashtagCursor cursor,
+            final Pageable pageable
+    ) {
+        final SortProperty property = SortProperty.fromProperty(cursor.property());
+        return switch (property) {
+            case SortProperty.CREATED_AT -> bottariTemplateHashtagRepository.findNextByCreatedAt(
+                    cursor.hashtagId(), cursor.getCreatedAt(), cursor.lastId(), pageable);
+            case SortProperty.TAKEN_COUNT -> bottariTemplateHashtagRepository.findNextByTakenCount(
+                    cursor.hashtagId(), cursor.getTakenCount(), cursor.lastId(), pageable);
+        };
+    }
+
     private Slice<BottariTemplateProjection> toSlice(
             final Pageable pageable,
             final List<BottariTemplateProjection> bottariTemplateProjections
@@ -199,7 +232,8 @@ public class BottariTemplateService {
         return groupByTemplates;
     }
 
-    private Map<BottariTemplate, List<Hashtag>> groupingHashtagsByTemplate(final List<BottariTemplate> bottariTemplateItems) {
+    private Map<BottariTemplate, List<Hashtag>> groupingHashtagsByTemplate(
+            final List<BottariTemplate> bottariTemplateItems) {
         final Map<BottariTemplate, List<Hashtag>> groupByTemplates = new LinkedHashMap<>();
         final List<BottariTemplateHashtag> bottariTemplateHashtags =
                 bottariTemplateHashtagRepository.findAllByBottariTemplateIn(bottariTemplateItems);

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
@@ -6,6 +6,7 @@ import com.bottari.bottari.repository.BottariItemRepository;
 import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.bottaritemplate.domain.BottariTemplate;
 import com.bottari.bottaritemplate.domain.BottariTemplateCursor;
+import com.bottari.bottaritemplate.domain.BottariTemplateFetcher;
 import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
 import com.bottari.bottaritemplate.domain.BottariTemplateHashtagCursor;
 import com.bottari.bottaritemplate.domain.BottariTemplateHistory;
@@ -33,7 +34,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
@@ -154,10 +154,10 @@ public class BottariTemplateService {
 
     private <T extends BottariTemplateCursor> ReadNextBottariTemplateResponse getNextAll(
             final T cursor,
-            final Function<T, Slice<BottariTemplateProjection>> fetchFunction
+            final BottariTemplateFetcher<T> bottariTemplateFetcher
     ) {
         final Pageable pageable = cursor.toPageable();
-        final Slice<BottariTemplateProjection> bottariTemplates = fetchFunction.apply(cursor);
+        final Slice<BottariTemplateProjection> bottariTemplates = bottariTemplateFetcher.fetch(cursor);
         final Map<Long, List<BottariTemplateItem>> itemsGroupByTemplateId =
                 groupingItemsByTemplateId(bottariTemplates.getContent());
         final Map<Long, List<Hashtag>> hashtagsGroupByTemplateId =

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
@@ -5,7 +5,7 @@ import com.bottari.bottari.domain.BottariItem;
 import com.bottari.bottari.repository.BottariItemRepository;
 import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.bottaritemplate.domain.BottariTemplate;
-import com.bottari.bottaritemplate.domain.BottariTemplateCursor;
+import com.bottari.bottaritemplate.domain.BottariTemplateTitleCursor;
 import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
 import com.bottari.bottaritemplate.domain.BottariTemplateHashtagCursor;
 import com.bottari.bottaritemplate.domain.BottariTemplateHistory;
@@ -89,7 +89,7 @@ public class BottariTemplateService {
     }
 
     public ReadNextBottariTemplateResponse getNextAll(final ReadNextBottariTemplateRequest request) {
-        final BottariTemplateCursor cursor = request.toCursor();
+        final BottariTemplateTitleCursor cursor = request.toCursor();
         final Pageable pageable = cursor.toPageable();
         final Slice<BottariTemplateProjection> bottariTemplates = getNextBySortProperty(cursor, pageable);
         final Map<Long, List<BottariTemplateItem>> itemsGroupByTemplateId =
@@ -177,7 +177,7 @@ public class BottariTemplateService {
     }
 
     private Slice<BottariTemplateProjection> getNextBySortProperty(
-            final BottariTemplateCursor cursor,
+            final BottariTemplateTitleCursor cursor,
             final Pageable pageable
     ) {
         final SortProperty property = SortProperty.fromProperty(cursor.property());

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/BottariTemplateService.java
@@ -5,17 +5,18 @@ import com.bottari.bottari.domain.BottariItem;
 import com.bottari.bottari.repository.BottariItemRepository;
 import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.bottaritemplate.domain.BottariTemplate;
-import com.bottari.bottaritemplate.domain.BottariTemplateTitleCursor;
+import com.bottari.bottaritemplate.domain.BottariTemplateCursor;
 import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
 import com.bottari.bottaritemplate.domain.BottariTemplateHashtagCursor;
 import com.bottari.bottaritemplate.domain.BottariTemplateHistory;
 import com.bottari.bottaritemplate.domain.BottariTemplateItem;
+import com.bottari.bottaritemplate.domain.BottariTemplateTitleCursor;
 import com.bottari.bottaritemplate.domain.Hashtag;
 import com.bottari.bottaritemplate.domain.SortProperty;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByHashtagRequest;
-import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
+import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByTitleRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.bottaritemplate.repository.BottariTemplateHashtagRepository;
 import com.bottari.bottaritemplate.repository.BottariTemplateHistoryRepository;
@@ -32,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
@@ -88,40 +90,14 @@ public class BottariTemplateService {
         return buildReadBottariTemplateResponses(bottariTemplates, itemsGroupByTemplate, hashtagsGroupByTemplate);
     }
 
-    public ReadNextBottariTemplateResponse getNextAll(final ReadNextBottariTemplateRequest request) {
+    public ReadNextBottariTemplateResponse getNextAllByTitle(final ReadNextBottariTemplateByTitleRequest request) {
         final BottariTemplateTitleCursor cursor = request.toCursor();
-        final Pageable pageable = cursor.toPageable();
-        final Slice<BottariTemplateProjection> bottariTemplates = getNextBySortProperty(cursor, pageable);
-        final Map<Long, List<BottariTemplateItem>> itemsGroupByTemplateId =
-                groupingItemsByTemplateId(bottariTemplates.getContent());
-        final Map<Long, List<Hashtag>> hashtagsGroupByTemplateId =
-                groupingHashtagsByTemplateId(bottariTemplates.getContent());
-        final List<ReadBottariTemplateResponse> responses = buildReadBottariTemplateResponses(
-                itemsGroupByTemplateId,
-                hashtagsGroupByTemplateId,
-                bottariTemplates.getContent()
-        );
-
-        return ReadNextBottariTemplateResponse.of(
-                new SliceImpl<>(responses, pageable, bottariTemplates.hasNext()), cursor.property());
+        return getNextAll(cursor, c -> getNextBySortProperty(c, c.toPageable()));
     }
 
     public ReadNextBottariTemplateResponse getNextAllByHashTag(final ReadNextBottariTemplateByHashtagRequest request) {
         final BottariTemplateHashtagCursor cursor = request.toCursor();
-        final Pageable pageable = cursor.toPageable();
-        final Slice<BottariTemplateProjection> bottariTemplates = getNextBySortProperty(cursor, pageable);
-        final Map<Long, List<BottariTemplateItem>> itemsGroupByTemplateId =
-                groupingItemsByTemplateId(bottariTemplates.getContent());
-        final Map<Long, List<Hashtag>> hashtagsGroupByTemplateId =
-                groupingHashtagsByTemplateId(bottariTemplates.getContent());
-        final List<ReadBottariTemplateResponse> responses = buildReadBottariTemplateResponses(
-                itemsGroupByTemplateId,
-                hashtagsGroupByTemplateId,
-                bottariTemplates.getContent()
-        );
-
-        return ReadNextBottariTemplateResponse.of(
-                new SliceImpl<>(responses, pageable, bottariTemplates.hasNext()), cursor.property());
+        return getNextAll(cursor, c -> getNextBySortProperty(c, c.toPageable()));
     }
 
     @Transactional
@@ -176,17 +152,37 @@ public class BottariTemplateService {
         bottariTemplateRepository.deleteById(id);
     }
 
+    private <T extends BottariTemplateCursor> ReadNextBottariTemplateResponse getNextAll(
+            final T cursor,
+            final Function<T, Slice<BottariTemplateProjection>> fetchFunction
+    ) {
+        final Pageable pageable = cursor.toPageable();
+        final Slice<BottariTemplateProjection> bottariTemplates = fetchFunction.apply(cursor);
+        final Map<Long, List<BottariTemplateItem>> itemsGroupByTemplateId =
+                groupingItemsByTemplateId(bottariTemplates.getContent());
+        final Map<Long, List<Hashtag>> hashtagsGroupByTemplateId =
+                groupingHashtagsByTemplateId(bottariTemplates.getContent());
+        final List<ReadBottariTemplateResponse> responses = buildReadBottariTemplateResponses(
+                itemsGroupByTemplateId,
+                hashtagsGroupByTemplateId,
+                bottariTemplates.getContent()
+        );
+
+        return ReadNextBottariTemplateResponse.of(
+                new SliceImpl<>(responses, pageable, bottariTemplates.hasNext()), cursor.getProperty());
+    }
+
     private Slice<BottariTemplateProjection> getNextBySortProperty(
             final BottariTemplateTitleCursor cursor,
             final Pageable pageable
     ) {
-        final SortProperty property = SortProperty.fromProperty(cursor.property());
+        final SortProperty property = SortProperty.fromProperty(cursor.getProperty());
         final int limit = pageable.getPageSize() + 1;
         return switch (property) {
             case SortProperty.CREATED_AT -> toSlice(pageable, bottariTemplateRepository.findNextByCreatedAt(
-                    cursor.query(), cursor.getCreatedAt(), cursor.lastId(), limit));
+                    cursor.getTitle(), cursor.getCreatedAt(), cursor.getLastId(), limit));
             case SortProperty.TAKEN_COUNT -> toSlice(pageable, bottariTemplateRepository.findNextByTakenCount(
-                    cursor.query(), cursor.getTakenCount(), cursor.lastId(), limit));
+                    cursor.getTitle(), cursor.getTakenCount(), cursor.getLastId(), limit));
         };
     }
 
@@ -194,12 +190,12 @@ public class BottariTemplateService {
             final BottariTemplateHashtagCursor cursor,
             final Pageable pageable
     ) {
-        final SortProperty property = SortProperty.fromProperty(cursor.property());
+        final SortProperty property = SortProperty.fromProperty(cursor.getProperty());
         return switch (property) {
             case SortProperty.CREATED_AT -> bottariTemplateHashtagRepository.findNextByCreatedAt(
-                    cursor.hashtagId(), cursor.getCreatedAt(), cursor.lastId(), pageable);
+                    cursor.getHashtagId(), cursor.getCreatedAt(), cursor.getLastId(), pageable);
             case SortProperty.TAKEN_COUNT -> bottariTemplateHashtagRepository.findNextByTakenCount(
-                    cursor.hashtagId(), cursor.getTakenCount(), cursor.lastId(), pageable);
+                    cursor.getHashtagId(), cursor.getTakenCount(), cursor.getLastId(), pageable);
         };
     }
 

--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
     HASHTAG_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "해시태그 제목이 너무 깁니다."),
     HASHTAG_NAME_CONTAINS_WHITESPACE(HttpStatus.BAD_REQUEST, "해시태그에는 공백을 포함할 수 없습니다."),
     HASHTAG_NAME_INVALID_CHARACTER(HttpStatus.BAD_REQUEST, "해시태그는 한글, 영문, 숫자, 언더스코어(_)만 사용할 수 있습니다."),
+    HASHTAG_ID_MISSING(HttpStatus.BAD_REQUEST,"해시태그로 템플릿 검색시 해시태그 아이디는 필수입니다."),
 
     // ===== TEAM_BOTTARI 관련 =====
     TEAM_BOTTARI_NOT_FOUND(HttpStatus.NOT_FOUND, "팀 보따리를 찾을 수 없습니다."),

--- a/backend/bottari/src/main/resources/init.sql
+++ b/backend/bottari/src/main/resources/init.sql
@@ -129,10 +129,10 @@ VALUES ('여행'),
        ('등산');
 
 INSERT INTO bottari_template_hashtag (bottari_template_id, hashtag_id)
-VALUES (1,1),
-       (4,1),
-       (6,2),
-       (7,3);
+VALUES (1, 1),
+       (4, 1),
+       (6, 2),
+       (7, 3);
 
 -- 보따리 템플릿 아이템 데이터
 INSERT INTO bottari_template_item (name, bottari_template_id)

--- a/backend/bottari/src/main/resources/init.sql
+++ b/backend/bottari/src/main/resources/init.sql
@@ -118,10 +118,21 @@ INSERT INTO bottari_template (title, member_id, created_at, taken_count)
 VALUES ('기본 여행 템플릿', 1, '2024-01-15 10:00:00',5),
        ('출장 기본 템플릿', 1, '2024-01-16 14:30:00',2),
        ('캠핑 필수품', 2, '2024-01-17 09:15:00',3),
-       ('해외여행 체크리스트', 2, '2024-01-18 16:45:00',5),
+       ('해외여행 체크리스트', 2, '2024-01-18 16:45:00',4),
        ('아이 외출 필수품', 4, '2024-01-19 11:20:00',0),
        ('운동 기본템', 3, '2024-01-20 08:00:00',0),
        ('등산 준비물', 5, '2024-01-21 13:10:00',0);
+
+INSERT INTO hashtag (name)
+VALUES ('여행'),
+       ('운동'),
+       ('등산');
+
+INSERT INTO bottari_template_hashtag (bottari_template_id, hashtag_id)
+VALUES (1,1),
+       (4,1),
+       (6,2),
+       (7,3);
 
 -- 보따리 템플릿 아이템 데이터
 INSERT INTO bottari_template_item (name, bottari_template_id)

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/BottariTemplateControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/BottariTemplateControllerTest.java
@@ -209,7 +209,7 @@ class BottariTemplateControllerTest {
                 2L,
                 "2024-12-20T10:30:00Z"
         );
-        given(bottariTemplateService.getNextAll(any()))
+        given(bottariTemplateService.getNextAllByTitle(any()))
                 .willReturn(response);
 
         // when & then

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/BottariTemplateControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/BottariTemplateControllerTest.java
@@ -114,7 +114,7 @@ class BottariTemplateControllerTest {
 
         // when & then
         mockMvc.perform(get("/templates/me")
-                        .header("ssaid", ssaid))
+                                .header("ssaid", ssaid))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(responses)));
     }
@@ -214,10 +214,69 @@ class BottariTemplateControllerTest {
 
         // when & then
         mockMvc.perform(get("/templates/cursor")
-                        .param("query", "")
-                        .param("page", "0")
-                        .param("size", "2")
-                        .param("property", "createdAt"))
+                                .param("query", "")
+                                .param("page", "0")
+                                .param("size", "2")
+                                .param("property", "createdAt"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+    }
+
+    @DisplayName("특정 해쉬태그를 가진 보따리 템플릿 목록을 페이징하여 조회한다.")
+    @Test
+    void readNextAllByHashtag() throws Exception {
+        // given
+        final List<ReadBottariTemplateResponse> contents = List.of(
+                new ReadBottariTemplateResponse(
+                        1L,
+                        "여행용 체크리스트",
+                        List.of(
+                                new BottariTemplateItemResponse(1L, "여권"),
+                                new BottariTemplateItemResponse(2L, "항공권")
+                        ),
+                        "author_1",
+                        LocalDateTime.now().minusDays(2),
+                        5,
+                        List.of(
+                                new HashtagResponse(1L, "호떡짱짱"),
+                                new HashtagResponse(2L, "혼자여행")
+                        )
+                ),
+                new ReadBottariTemplateResponse(
+                        2L,
+                        "캠핑 준비물",
+                        List.of(
+                                new BottariTemplateItemResponse(3L, "텐트")
+                        ),
+                        "author_2",
+                        LocalDateTime.now().minusDays(1),
+                        3,
+                        List.of(
+                                new HashtagResponse(3L, "캠핑"),
+                                new HashtagResponse(4L, "가족나들이")
+                        )
+                )
+        );
+        final ReadNextBottariTemplateResponse response = new ReadNextBottariTemplateResponse(
+                contents,
+                0,
+                2,
+                true,
+                true,
+                false,
+                SortProperty.CREATED_AT.getProperty(),
+                2L,
+                "2024-12-20T10:30:00Z"
+        );
+        given(bottariTemplateService.getNextAllByHashTag(any()))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/templates/hashtag")
+                                .param("hashtagId", "1")
+                                .param("page", "0")
+                                .param("size", "2")
+                                .param("property", "createdAt"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(response)));
     }
@@ -237,9 +296,9 @@ class BottariTemplateControllerTest {
 
         // when & then
         mockMvc.perform(post("/templates")
-                        .header("ssaid", ssaid)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                                .header("ssaid", ssaid)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/templates/1"));
     }
@@ -255,8 +314,8 @@ class BottariTemplateControllerTest {
 
         // when & then
         mockMvc.perform(post("/templates/" + id + "/create-bottari")
-                        .header("ssaid", ssaid)
-                        .contentType(MediaType.APPLICATION_JSON))
+                                .header("ssaid", ssaid)
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/bottaries/1"));
     }
@@ -272,7 +331,7 @@ class BottariTemplateControllerTest {
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.delete("/templates/" + id)
-                        .header("ssaid", ssaid))
+                                .header("ssaid", ssaid))
                 .andExpect(status().isNoContent());
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/BottariTemplateControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/BottariTemplateControllerTest.java
@@ -213,7 +213,7 @@ class BottariTemplateControllerTest {
                 .willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/templates/cursor")
+        mockMvc.perform(get("/templates/title")
                                 .param("query", "")
                                 .param("page", "0")
                                 .param("size", "2")

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursorTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursorTest.java
@@ -1,0 +1,269 @@
+package com.bottari.bottaritemplate.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.bottari.error.BusinessException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.data.domain.Pageable;
+
+class BottariTemplateHashtagCursorTest {
+
+    @Nested
+    class NormalizationTest {
+
+        @DisplayName("hashtag id가 null인 경우 예외가 발생한다.")
+        @Test
+        void normalizeHashtagId_Exception_IdIsNull() {
+            // when & then
+            assertThatThrownBy(() -> new BottariTemplateHashtagCursor(
+                    null,
+                    1L,
+                    "info",
+                    0,
+                    10,
+                    "createdAt"
+            )).isInstanceOf(BusinessException.class)
+                    .hasMessage("해시태그로 템플릿 검색시 해시태그 아이디는 필수입니다.");
+        }
+
+        @DisplayName("page 정규화 테스트")
+        @ParameterizedTest
+        @CsvSource({
+                "-1, 0",
+                "-100, 0",
+                "0, 0",
+                "1, 1",
+                "100, 100"
+        })
+        void normalizePage(
+                final int page,
+                final int expected
+        ) {
+            // when
+            final BottariTemplateHashtagCursor actual = new BottariTemplateHashtagCursor(
+                    1L,
+                    1L,
+                    "info",
+                    page,
+                    10,
+                    "createdAt"
+            );
+
+            // then
+            assertThat(actual.page()).isEqualTo(expected);
+        }
+
+        @DisplayName("size 정규화 테스트")
+        @ParameterizedTest
+        @CsvSource({
+                "-1, 10",
+                "0, 10",
+                "1, 1",
+                "50, 50"
+        })
+        void normalizeSize(
+                final int size,
+                final int expected
+        ) {
+            // when
+            final BottariTemplateHashtagCursor actual = new BottariTemplateHashtagCursor(
+                    1L,
+                    1L,
+                    null,
+                    0,
+                    size,
+                    "createdAt"
+            );
+
+            // then
+            assertThat(actual.size()).isEqualTo(expected);
+        }
+
+        @DisplayName("lastId 정규화 테스트")
+        @Test
+        void normalizeLastId() {
+            // given
+            final Long nullLastId = null;
+
+            // when
+            final BottariTemplateHashtagCursor actual = new BottariTemplateHashtagCursor(
+                    1L,
+                    nullLastId,
+                    null,
+                    0,
+                    10,
+                    "createdAt"
+            );
+
+            // then
+            assertThat(actual.lastId()).isEqualTo(Long.MAX_VALUE);
+        }
+
+        @DisplayName("property 정규화 테스트")
+        @ParameterizedTest
+        @ValueSource(strings = {" ", "\t", "\n"})
+        void normalizeProperty(final String input) {
+            // given
+            final String expected = "createdAt";
+
+            // when
+            final BottariTemplateHashtagCursor actual = new BottariTemplateHashtagCursor(
+                    1L,
+                    1L,
+                    "info",
+                    0,
+                    10,
+                    input
+            );
+
+            // then
+            assertThat(actual.property()).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class ToPageableTest {
+
+        @DisplayName("page와 size로 Pageable 객체를 생성한다.")
+        @ParameterizedTest
+        @CsvSource({
+                "0, 10",
+                "1, 20",
+                "5, 50"
+        })
+        void toPageable(
+                final int page,
+                final int size
+        ) {
+            // given
+            final BottariTemplateHashtagCursor cursor = new BottariTemplateHashtagCursor(
+                    1L,
+                    1L,
+                    "info",
+                    page,
+                    size,
+                    "createdAt"
+            );
+
+            // when
+            final Pageable actual = cursor.toPageable();
+
+            // then
+            assertAll(
+                    () -> assertThat(actual.getPageNumber()).isEqualTo(page),
+                    () -> assertThat(actual.getPageSize()).isEqualTo(size)
+            );
+        }
+    }
+
+    @Nested
+    class GetCreatedAtTest {
+
+        @DisplayName("LocalDateTime으로 파싱한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "2024-01-01T00:00:01",
+                "2023-12-31T23:59:59",
+                "2024-06-15T12:30:45"
+        })
+        void getCreatedAt(final String dateString) {
+            // given
+            final BottariTemplateHashtagCursor cursor = new BottariTemplateHashtagCursor(
+                    1L,
+                    1L,
+                    dateString,
+                    0,
+                    10,
+                    "createdAt"
+            );
+
+            // when
+            final LocalDateTime actual = cursor.getCreatedAt();
+
+            // then
+            assertThat(actual.toString()).isEqualTo(dateString);
+        }
+
+        @DisplayName("잘못된 날짜 형식으로 예외를 던진다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "2024-01-01",
+                "invalid-date",
+                "2024/01/01 00:00:00"
+        })
+        void getCreatedAt_Exception_InvalidDateTimeFormat(final String invalidDate) {
+            // given
+            final BottariTemplateHashtagCursor cursor = new BottariTemplateHashtagCursor(
+                    1L,
+                    1L,
+                    invalidDate,
+                    0,
+                    10,
+                    "createdAt"
+            );
+
+            // when & then
+            assertThatThrownBy(cursor::getCreatedAt)
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("유효하지 않은 날짜 형식입니다. - 보따리 템플릿의 생성일자는 (yyyy-MM-dd'T'HH:mm:ss) 형식이어야 합니다.");
+        }
+    }
+
+    @Nested
+    class GetTakenCountTest {
+
+        @DisplayName("유효한 숫자 문자열을 Integer으로 파싱한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"0", "1", "100", "2147483647"})
+        void getTakenCount(final String numberString) {
+            // given
+            final BottariTemplateHashtagCursor cursor = new BottariTemplateHashtagCursor(
+                    1L,
+                    1L,
+                    numberString,
+                    0,
+                    10,
+                    "takenCount"
+            );
+
+            // when
+            final Integer actual = cursor.getTakenCount();
+
+            // then
+            assertThat(actual).isEqualTo(Integer.parseInt(numberString));
+        }
+
+        @DisplayName("잘못된 숫자 형식으로 예외를 던진다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "invalid-number",
+                "12.34",
+                "1,000",
+                "9223372036854775807" // Long.MAX_VALUE
+        })
+        void getTakenCount_Exception_InvalidNumberFormat(final String invalidNumber) {
+            // given
+            final BottariTemplateHashtagCursor cursor = new BottariTemplateHashtagCursor(
+                    1L,
+                    1L,
+                    invalidNumber,
+                    0,
+                    10,
+                    "takenCount"
+            );
+
+            // when & then
+            assertThatThrownBy(cursor::getTakenCount)
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("유효하지 않은 숫자 형식입니다. - 보따리 템플릿의 가져간 횟수는 숫자여야 합니다.");
+        }
+    }
+}

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursorTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtagCursorTest.java
@@ -58,7 +58,7 @@ class BottariTemplateHashtagCursorTest {
             );
 
             // then
-            assertThat(actual.page()).isEqualTo(expected);
+            assertThat(actual.getPage()).isEqualTo(expected);
         }
 
         @DisplayName("size 정규화 테스트")
@@ -84,7 +84,7 @@ class BottariTemplateHashtagCursorTest {
             );
 
             // then
-            assertThat(actual.size()).isEqualTo(expected);
+            assertThat(actual.getSize()).isEqualTo(expected);
         }
 
         @DisplayName("lastId 정규화 테스트")
@@ -104,7 +104,7 @@ class BottariTemplateHashtagCursorTest {
             );
 
             // then
-            assertThat(actual.lastId()).isEqualTo(Long.MAX_VALUE);
+            assertThat(actual.getLastId()).isEqualTo(Long.MAX_VALUE);
         }
 
         @DisplayName("property 정규화 테스트")
@@ -125,7 +125,7 @@ class BottariTemplateHashtagCursorTest {
             );
 
             // then
-            assertThat(actual.property()).isEqualTo(expected);
+            assertThat(actual.getProperty()).isEqualTo(expected);
         }
     }
 

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateTitleCursorTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateTitleCursorTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.data.domain.Pageable;
 
-class BottariTemplateCursorTest {
+class BottariTemplateTitleCursorTest {
 
     @Nested
     class NormalizationTest {
@@ -30,7 +30,7 @@ class BottariTemplateCursorTest {
                 final String expected
         ) {
             // when
-            final BottariTemplateCursor actual = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor actual = new BottariTemplateTitleCursor(
                     query,
                     1L,
                     "info",
@@ -68,7 +68,7 @@ class BottariTemplateCursorTest {
                 final int expected
         ) {
             // when
-            final BottariTemplateCursor actual = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor actual = new BottariTemplateTitleCursor(
                     "",
                     1L,
                     "info",
@@ -94,7 +94,7 @@ class BottariTemplateCursorTest {
                 final int expected
         ) {
             // when
-            final BottariTemplateCursor actual = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor actual = new BottariTemplateTitleCursor(
                     "",
                     1L,
                     null,
@@ -114,7 +114,7 @@ class BottariTemplateCursorTest {
             final Long nullLastId = null;
 
             // when
-            final BottariTemplateCursor actual = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor actual = new BottariTemplateTitleCursor(
                     "",
                     nullLastId,
                     null,
@@ -135,7 +135,7 @@ class BottariTemplateCursorTest {
             final String expected = "createdAt";
 
             // when
-            final BottariTemplateCursor actual = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor actual = new BottariTemplateTitleCursor(
                     "",
                     1L,
                     "info",
@@ -164,7 +164,7 @@ class BottariTemplateCursorTest {
                 final int size
         ) {
             // given
-            final BottariTemplateCursor cursor = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor cursor = new BottariTemplateTitleCursor(
                     "",
                     1L,
                     "info",
@@ -196,7 +196,7 @@ class BottariTemplateCursorTest {
         })
         void getCreatedAt(final String dateString) {
             // given
-            final BottariTemplateCursor cursor = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor cursor = new BottariTemplateTitleCursor(
                     "",
                     1L,
                     dateString,
@@ -221,7 +221,7 @@ class BottariTemplateCursorTest {
         })
         void getCreatedAt_Exception_InvalidDateTimeFormat(final String invalidDate) {
             // given
-            final BottariTemplateCursor cursor = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor cursor = new BottariTemplateTitleCursor(
                     "",
                     1L,
                     invalidDate,
@@ -245,7 +245,7 @@ class BottariTemplateCursorTest {
         @ValueSource(strings = {"0", "1", "100", "9223372036854775807"})
         void getTakenCount(final String numberString) {
             // given
-            final BottariTemplateCursor cursor = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor cursor = new BottariTemplateTitleCursor(
                     "",
                     1L,
                     numberString,
@@ -271,7 +271,7 @@ class BottariTemplateCursorTest {
         })
         void getTakenCount_Exception_InvalidNumberFormat(final String invalidNumber) {
             // given
-            final BottariTemplateCursor cursor = new BottariTemplateCursor(
+            final BottariTemplateTitleCursor cursor = new BottariTemplateTitleCursor(
                     "",
                     1L,
                     invalidNumber,

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateTitleCursorTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateTitleCursorTest.java
@@ -40,7 +40,7 @@ class BottariTemplateTitleCursorTest {
             );
 
             // then
-            assertThat(actual.query()).isEqualTo(expected);
+            assertThat(actual.getTitle()).isEqualTo(expected);
         }
 
         private static Stream<Arguments> normalizeQuery() {
@@ -78,7 +78,7 @@ class BottariTemplateTitleCursorTest {
             );
 
             // then
-            assertThat(actual.page()).isEqualTo(expected);
+            assertThat(actual.getPage()).isEqualTo(expected);
         }
 
         @DisplayName("size 정규화 테스트")
@@ -104,7 +104,7 @@ class BottariTemplateTitleCursorTest {
             );
 
             // then
-            assertThat(actual.size()).isEqualTo(expected);
+            assertThat(actual.getSize()).isEqualTo(expected);
         }
 
         @DisplayName("lastId 정규화 테스트")
@@ -124,7 +124,7 @@ class BottariTemplateTitleCursorTest {
             );
 
             // then
-            assertThat(actual.lastId()).isEqualTo(Long.MAX_VALUE);
+            assertThat(actual.getLastId()).isEqualTo(Long.MAX_VALUE);
         }
 
         @DisplayName("property 정규화 테스트")
@@ -145,7 +145,7 @@ class BottariTemplateTitleCursorTest {
             );
 
             // then
-            assertThat(actual.property()).isEqualTo(expected);
+            assertThat(actual.getProperty()).isEqualTo(expected);
         }
     }
 
@@ -240,9 +240,9 @@ class BottariTemplateTitleCursorTest {
     @Nested
     class GetTakenCountTest {
 
-        @DisplayName("유효한 숫자 문자열을 Long으로 파싱한다.")
+        @DisplayName("유효한 숫자 문자열을 Integer으로 파싱한다.")
         @ParameterizedTest
-        @ValueSource(strings = {"0", "1", "100", "9223372036854775807"})
+        @ValueSource(strings = {"0", "1", "100", "2147483647"})
         void getTakenCount(final String numberString) {
             // given
             final BottariTemplateTitleCursor cursor = new BottariTemplateTitleCursor(
@@ -255,7 +255,7 @@ class BottariTemplateTitleCursorTest {
             );
 
             // when
-            final Long actual = cursor.getTakenCount();
+            final Integer actual = cursor.getTakenCount();
 
             // then
             assertThat(actual).isEqualTo(Long.parseLong(numberString));
@@ -267,7 +267,7 @@ class BottariTemplateTitleCursorTest {
                 "invalid-number",
                 "12.34",
                 "1,000",
-                "9223372036854775808" // Long.MAX_VALUE + 1
+                "9223372036854775807" // Long.MAX_VALUE
         })
         void getTakenCount_Exception_InvalidNumberFormat(final String invalidNumber) {
             // given

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
@@ -13,6 +13,7 @@ import com.bottari.bottaritemplate.domain.BottariTemplateItem;
 import com.bottari.bottaritemplate.domain.Hashtag;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
+import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByHashtagRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.config.JpaAuditingConfig;
@@ -145,8 +146,10 @@ class BottariTemplateServiceTest {
             final BottariTemplateItem item4 = BottariTemplateItemFixture.BOTTARI_TEMPLATE_ITEM_4.get(
                     anotherMemberBottariTemplate);
             final Hashtag hashtag3 = HashtagFixture.HASHTAG_3.get();
-            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(anotherMemberBottariTemplate,
-                    hashtag3);
+            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(
+                    anotherMemberBottariTemplate,
+                    hashtag3
+            );
             entityManager.persist(anotherMemberBottariTemplate);
             entityManager.persist(item4);
             entityManager.persist(hashtag3);
@@ -157,19 +160,19 @@ class BottariTemplateServiceTest {
 
             // then
             assertAll(() -> {
-                        assertThat(actual).hasSize(2);
-                        assertThat(actual.get(0).title()).isEqualTo(memberTemplate2.getTitle());
-                        assertThat(actual.get(0).items()).hasSize(1);
-                        assertThat(actual.get(0).items().getFirst().name()).isEqualTo(item3.getName());
-                        assertThat(actual.get(0).hashtags()).hasSize(1);
-                        assertThat(actual.get(0).hashtags().getFirst().name()).isEqualTo(hashtag2.getName());
-                        assertThat(actual.get(1).title()).isEqualTo(memberTemplate1.getTitle());
-                        assertThat(actual.get(1).items()).hasSize(2);
-                        assertThat(actual.get(1).items().get(0).name()).isEqualTo(item1.getName());
-                        assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName());
-                        assertThat(actual.get(1).hashtags()).hasSize(1);
-                        assertThat(actual.get(1).hashtags().getFirst().name()).isEqualTo(hashtag1.getName());
-                    }
+                          assertThat(actual).hasSize(2);
+                          assertThat(actual.get(0).title()).isEqualTo(memberTemplate2.getTitle());
+                          assertThat(actual.get(0).items()).hasSize(1);
+                          assertThat(actual.get(0).items().getFirst().name()).isEqualTo(item3.getName());
+                          assertThat(actual.get(0).hashtags()).hasSize(1);
+                          assertThat(actual.get(0).hashtags().getFirst().name()).isEqualTo(hashtag2.getName());
+                          assertThat(actual.get(1).title()).isEqualTo(memberTemplate1.getTitle());
+                          assertThat(actual.get(1).items()).hasSize(2);
+                          assertThat(actual.get(1).items().get(0).name()).isEqualTo(item1.getName());
+                          assertThat(actual.get(1).items().get(1).name()).isEqualTo(item2.getName());
+                          assertThat(actual.get(1).hashtags()).hasSize(1);
+                          assertThat(actual.get(1).hashtags().getFirst().name()).isEqualTo(hashtag1.getName());
+                      }
             );
         }
 
@@ -532,6 +535,170 @@ class BottariTemplateServiceTest {
     }
 
     @Nested
+    class GetNextAllByHashTagTest {
+
+        @DisplayName("createdAt 기준으로 다음 페이지 템플릿 목록을 조회한다.")
+        @Test
+        void getNextAllByHashTag_ByCreatedAt() {
+            // given
+            final Member member = new Member("ssaid", "name");
+            entityManager.persist(member);
+
+            final BottariTemplate template1 = new BottariTemplate("template1", member);
+            final BottariTemplate template2 = new BottariTemplate("template2", member);
+            final BottariTemplate template3 = new BottariTemplate("template3", member);
+            entityManager.persist(template1);
+            entityManager.persist(template2);
+            entityManager.persist(template3);
+
+            final BottariTemplateItem item1 = new BottariTemplateItem("item1", template1);
+            final BottariTemplateItem item2 = new BottariTemplateItem("item2", template2);
+            final BottariTemplateItem item3 = new BottariTemplateItem("item3", template3);
+            entityManager.persist(item1);
+            entityManager.persist(item2);
+            entityManager.persist(item3);
+
+            final Hashtag hashtag1 = new Hashtag("hashtag1");
+            final Hashtag hashtag2 = new Hashtag("hashtag2");
+            entityManager.persist(hashtag1);
+            entityManager.persist(hashtag2);
+
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(template1, hashtag1);
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(template2, hashtag2);
+            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(template3, hashtag2);
+            entityManager.persist(templateHashtag1);
+            entityManager.persist(templateHashtag2);
+            entityManager.persist(templateHashtag3);
+
+            final ReadNextBottariTemplateByHashtagRequest request = new ReadNextBottariTemplateByHashtagRequest(
+                    hashtag2.getId(),
+                    null,
+                    null,
+                    0,
+                    2,
+                    "createdAt"
+            );
+
+            // when
+            final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAllByHashTag(request);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual.contents()).hasSize(2),
+                    () -> assertThat(actual.contents().get(0).hashtags()).hasSize(1),
+                    () -> assertThat(actual.contents().get(0).hashtags().getFirst().name()).isEqualTo(
+                            hashtag2.getName()),
+                    () -> assertThat(actual.contents().get(0).title()).isEqualTo("template3"),
+                    () -> assertThat(actual.contents().get(0).items()).hasSize(1),
+                    () -> assertThat(actual.contents().get(0).items().getFirst().name()).isEqualTo("item3"),
+                    () -> assertThat(actual.contents().get(1).hashtags()).hasSize(1),
+                    () -> assertThat(actual.contents().get(1).hashtags().getFirst().name()).isEqualTo(
+                            hashtag2.getName()),
+                    () -> assertThat(actual.contents().get(1).title()).isEqualTo("template2"),
+                    () -> assertThat(actual.contents().get(1).items()).hasSize(1),
+                    () -> assertThat(actual.contents().get(1).items().getFirst().name()).isEqualTo("item2"),
+                    () -> assertThat(actual.currentPage()).isEqualTo(0),
+                    () -> assertThat(actual.size()).isEqualTo(2),
+                    () -> assertThat(actual.hasNext()).isFalse(),
+                    () -> assertThat(actual.first()).isTrue(),
+                    () -> assertThat(actual.last()).isTrue(),
+                    () -> assertThat(actual.lastId()).isNotNull(),
+                    () -> assertThat(actual.lastInfo()).isNotNull()
+            );
+        }
+
+        @DisplayName("takenCount 기준으로 다음 페이지 템플릿 목록을 조회한다.")
+        @Test
+        void getNextAllByHashTag_ByTakenCount() {
+            // given
+            final Member member = new Member("ssaid", "name");
+            entityManager.persist(member);
+
+            final BottariTemplate template1 = new BottariTemplate("template1", member);
+            final BottariTemplate template2 = new BottariTemplate("template2", member);
+            final BottariTemplate template3 = new BottariTemplate("template3", member);
+            entityManager.persist(template1);
+            entityManager.persist(template2);
+            entityManager.persist(template3);
+            entityManager.createQuery("""
+                                                  UPDATE BottariTemplate bt
+                                                  SET bt.takenCount = bt.takenCount + 1
+                                                  WHERE bt.id = :id
+                                              """)
+                    .setParameter("id", template2.getId())
+                    .executeUpdate();
+
+            final BottariTemplateItem item1 = new BottariTemplateItem("item1", template1);
+            final BottariTemplateItem item2 = new BottariTemplateItem("item2", template2);
+            final BottariTemplateItem item3 = new BottariTemplateItem("item3", template3);
+            entityManager.persist(item1);
+            entityManager.persist(item2);
+            entityManager.persist(item3);
+
+            final Hashtag hashtag1 = new Hashtag("hashtag1");
+            final Hashtag hashtag2 = new Hashtag("hashtag2");
+            entityManager.persist(hashtag1);
+            entityManager.persist(hashtag2);
+
+            final BottariTemplateHashtag templateHashtag1 = new BottariTemplateHashtag(template1, hashtag1);
+            final BottariTemplateHashtag templateHashtag2 = new BottariTemplateHashtag(template2, hashtag2);
+            final BottariTemplateHashtag templateHashtag3 = new BottariTemplateHashtag(template3, hashtag2);
+            entityManager.persist(templateHashtag1);
+            entityManager.persist(templateHashtag2);
+            entityManager.persist(templateHashtag3);
+
+            final ReadNextBottariTemplateByHashtagRequest request = new ReadNextBottariTemplateByHashtagRequest(
+                    hashtag2.getId(),
+                    null,
+                    "999999",
+                    0,
+                    1,
+                    "takenCount"
+            );
+
+            // when
+            final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAllByHashTag(request);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual.contents()).hasSize(1),
+                    () -> assertThat(actual.contents().getFirst().hashtags()).hasSize(1),
+                    () -> assertThat(actual.contents().getFirst().hashtags().getFirst().name()).isEqualTo(
+                            hashtag2.getName()),
+                    () -> assertThat(actual.contents().getFirst().title()).isEqualTo("template2"),
+                    () -> assertThat(actual.contents().getFirst().items()).hasSize(1),
+                    () -> assertThat(actual.contents().getFirst().items().getFirst().name()).isEqualTo("item2"),
+                    () -> assertThat(actual.currentPage()).isEqualTo(0),
+                    () -> assertThat(actual.size()).isEqualTo(1),
+                    () -> assertThat(actual.hasNext()).isTrue(),
+                    () -> assertThat(actual.first()).isTrue(),
+                    () -> assertThat(actual.last()).isFalse(),
+                    () -> assertThat(actual.lastId()).isNotNull(),
+                    () -> assertThat(actual.lastInfo()).isNotNull()
+            );
+        }
+
+        @DisplayName("존재하지 않는 정렬 기준으로 조회 시 예외를 던진다.")
+        @Test
+        void getNextAllByHashTag_Exception_InvalidSortProperty() {
+            // given
+            final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
+                    "",
+                    null,
+                    null,
+                    0,
+                    10,
+                    "invalidProperty"
+            );
+
+            // when & then
+            assertThatThrownBy(() -> bottariTemplateService.getNextAll(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("유효하지 않은 보따리 템플릿 정렬 타입입니다.");
+        }
+    }
+
+    @Nested
     class CreateTest {
 
         @DisplayName("보따리 템플릿을 생성한다.")
@@ -716,11 +883,11 @@ class BottariTemplateServiceTest {
 
             // then
             final Long actualHistoryCount = entityManager.createQuery("""
-                                             SELECT COUNT(bh)
-                                             FROM BottariTemplateHistory bh
-                                             WHERE bh.id.memberId = :memberId
-                                             AND bh.id.bottariTemplateId = :bottariTemplateId
-                            """, Long.class)
+                                                                                               SELECT COUNT(bh)
+                                                                                               FROM BottariTemplateHistory bh
+                                                                                               WHERE bh.id.memberId = :memberId
+                                                                                               AND bh.id.bottariTemplateId = :bottariTemplateId
+                                                                              """, Long.class)
                     .setParameter("memberId", member.getId())
                     .setParameter("bottariTemplateId", bottariTemplate.getId())
                     .getSingleResult();

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
@@ -621,10 +621,10 @@ class BottariTemplateServiceTest {
             entityManager.persist(template2);
             entityManager.persist(template3);
             entityManager.createQuery("""
-                                                  UPDATE BottariTemplate bt
-                                                  SET bt.takenCount = bt.takenCount + 1
-                                                  WHERE bt.id = :id
-                                              """)
+                    UPDATE BottariTemplate bt
+                    SET bt.takenCount = bt.takenCount + 1
+                    WHERE bt.id = :id
+            """)
                     .setParameter("id", template2.getId())
                     .executeUpdate();
 
@@ -719,11 +719,11 @@ class BottariTemplateServiceTest {
 
             // then
             final List<BottariTemplateItem> actualItems = entityManager.createQuery(
-                            """
-                                    SELECT i
-                                    FROM BottariTemplateItem i
-                                    WHERE i.bottariTemplate.id =: bottariTemplateId
-                                    """, BottariTemplateItem.class)
+            """
+                  SELECT i
+                  FROM BottariTemplateItem i
+                  WHERE i.bottariTemplate.id =: bottariTemplateId
+             """, BottariTemplateItem.class)
                     .setParameter("bottariTemplateId", actual)
                     .getResultList();
 
@@ -841,12 +841,12 @@ class BottariTemplateServiceTest {
 
             // then
             final BottariTemplateHistory acutalBottariTemplateHistory = entityManager.createQuery(
-                            """
-                                                     SELECT bh
-                                                     FROM BottariTemplateHistory bh
-                                                     WHERE bh.id.memberId = :memberId
-                                                     AND bh.id.bottariTemplateId = :bottariTemplateId
-                                    """, BottariTemplateHistory.class)
+            """
+                 SELECT bh
+                 FROM BottariTemplateHistory bh
+                 WHERE bh.id.memberId = :memberId
+                 AND bh.id.bottariTemplateId = :bottariTemplateId
+             """, BottariTemplateHistory.class)
                     .setParameter("memberId", member.getId())
                     .setParameter("bottariTemplateId", bottariTemplate.getId())
                     .getSingleResult();
@@ -882,12 +882,13 @@ class BottariTemplateServiceTest {
             bottariTemplateService.createBottari(bottariTemplate.getId(), ssaid);
 
             // then
-            final Long actualHistoryCount = entityManager.createQuery("""
-                                                                                               SELECT COUNT(bh)
-                                                                                               FROM BottariTemplateHistory bh
-                                                                                               WHERE bh.id.memberId = :memberId
-                                                                                               AND bh.id.bottariTemplateId = :bottariTemplateId
-                                                                              """, Long.class)
+            final Long actualHistoryCount = entityManager.createQuery(
+            """
+                       SELECT COUNT(bh)
+                       FROM BottariTemplateHistory bh
+                       WHERE bh.id.memberId = :memberId
+                       AND bh.id.bottariTemplateId = :bottariTemplateId
+            """, Long.class)
                     .setParameter("memberId", member.getId())
                     .setParameter("bottariTemplateId", bottariTemplate.getId())
                     .getSingleResult();

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/BottariTemplateServiceTest.java
@@ -14,7 +14,7 @@ import com.bottari.bottaritemplate.domain.Hashtag;
 import com.bottari.bottaritemplate.dto.CreateBottariTemplateRequest;
 import com.bottari.bottaritemplate.dto.ReadBottariTemplateResponse;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByHashtagRequest;
-import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateRequest;
+import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateByTitleRequest;
 import com.bottari.bottaritemplate.dto.ReadNextBottariTemplateResponse;
 import com.bottari.config.JpaAuditingConfig;
 import com.bottari.error.BusinessException;
@@ -351,7 +351,7 @@ class BottariTemplateServiceTest {
             entityManager.persist(templateHashtag2);
             entityManager.persist(templateHashtag3);
 
-            final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
+            final ReadNextBottariTemplateByTitleRequest request = new ReadNextBottariTemplateByTitleRequest(
                     "",
                     null,
                     null,
@@ -361,7 +361,7 @@ class BottariTemplateServiceTest {
             );
 
             // when
-            final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAll(request);
+            final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAllByTitle(request);
 
             // then
             assertAll(
@@ -409,7 +409,7 @@ class BottariTemplateServiceTest {
             entityManager.persist(templateHashtag1);
             entityManager.persist(templateHashtag2);
 
-            final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
+            final ReadNextBottariTemplateByTitleRequest request = new ReadNextBottariTemplateByTitleRequest(
                     "",
                     null,
                     "999999",
@@ -419,7 +419,7 @@ class BottariTemplateServiceTest {
             );
 
             // when
-            final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAll(request);
+            final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAllByTitle(request);
 
             // then
             assertAll(
@@ -486,7 +486,7 @@ class BottariTemplateServiceTest {
             TestTransaction.end();
             TestTransaction.start();
 
-            final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
+            final ReadNextBottariTemplateByTitleRequest request = new ReadNextBottariTemplateByTitleRequest(
                     "체크리스트",
                     null,
                     null,
@@ -498,7 +498,7 @@ class BottariTemplateServiceTest {
             entityManager.clear();
 
             // when
-            final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAll(request);
+            final ReadNextBottariTemplateResponse actual = bottariTemplateService.getNextAllByTitle(request);
 
             // then
             assertAll(
@@ -518,7 +518,7 @@ class BottariTemplateServiceTest {
         @Test
         void getNextAll_Exception_InvalidSortProperty() {
             // given
-            final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
+            final ReadNextBottariTemplateByTitleRequest request = new ReadNextBottariTemplateByTitleRequest(
                     "",
                     null,
                     null,
@@ -528,7 +528,7 @@ class BottariTemplateServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> bottariTemplateService.getNextAll(request))
+            assertThatThrownBy(() -> bottariTemplateService.getNextAllByTitle(request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("유효하지 않은 보따리 템플릿 정렬 타입입니다.");
         }
@@ -682,7 +682,7 @@ class BottariTemplateServiceTest {
         @Test
         void getNextAllByHashTag_Exception_InvalidSortProperty() {
             // given
-            final ReadNextBottariTemplateRequest request = new ReadNextBottariTemplateRequest(
+            final ReadNextBottariTemplateByTitleRequest request = new ReadNextBottariTemplateByTitleRequest(
                     "",
                     null,
                     null,
@@ -692,7 +692,7 @@ class BottariTemplateServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> bottariTemplateService.getNextAll(request))
+            assertThatThrownBy(() -> bottariTemplateService.getNextAllByTitle(request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("유효하지 않은 보따리 템플릿 정렬 타입입니다.");
         }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 해시태그에 해당하는 템플릿 조회 기능 추가

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #569 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 해시태그에 해당되는 템플릿을 커서 기반으로 조회
    - createdAt 기준으로 정렬
    - takenCount 기준으로 정렬
- 템플릿 목록 조회 리팩토링
    - BottariTemplateCursor 추상 클래스 생성
    - BottariTemplateService 계층 제네릭과 함수형 인터페이스로 공통 로직 메서드 추출
- 해쉬태그 관련 더미 데이터 추가 
- 기존 커서 기반 조회 EndPoint 변경 (/templates/cursor -> /templates/title)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 템플릿을 제목 기반 또는 해시태그 기반으로 커서(cursor) 페이지네이션 조회 가능
- **버그 수정 / 안정성**
  - 해시태그 기반 조회에서 해시태그 ID 누락 시 전용 오류 응답 추가
- **문서**
  - API 문서에 제목/해시태그 기반 커서 조회 설명 및 응답 정보 정비
- **잡무**
  - 초기 시드 데이터 확장: 해시태그 및 템플릿-해시태그 매핑 보강, 항목 데이터 보완
- **테스트**
  - 제목/해시태그 커서 관련 단위 테스트 추가 및 기존 테스트 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->