### PR TITLE
[AN] SSE 파싱 구조 변경 사항 반영

### DIFF
--- a/android/Bottari/data/src/main/java/com/bottari/data/model/remote/sse/EventDataResponse.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/remote/sse/EventDataResponse.kt
@@ -7,15 +7,13 @@ import kotlinx.serialization.Serializable
 import java.time.LocalDateTime
 
 sealed interface EventDataResponse {
-    val publishedAt: LocalDateTime
-
     fun toDomain(): EventData
 
     @Serializable
     data class TeamMemberCreateResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
+        val publishedAt: LocalDateTime,
         @SerialName("memberId")
         val memberId: Long,
         @SerialName("name")
@@ -30,61 +28,168 @@ sealed interface EventDataResponse {
     data class TeamMemberDeleteResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
-        @SerialName("exitMemberId")
-        val exitMemberId: Long,
+        val publishedAt: LocalDateTime,
         @SerialName("bottariId")
         val bottariId: String,
+        @SerialName("bottariName")
+        val bottariName: String,
+        @SerialName("exitMemberId")
+        val exitMemberId: Long,
+        @SerialName("exitMemberName")
+        val exitMemberName: String,
     ) : EventDataResponse {
-        override fun toDomain(): EventData = EventData.TeamMemberDelete(publishedAt, exitMemberId, bottariId)
+        override fun toDomain(): EventData =
+            EventData.TeamMemberDelete(
+                publishedAt,
+                bottariId,
+                bottariName,
+                exitMemberId,
+                exitMemberName,
+            )
     }
 
     @Serializable
     data class SharedItemInfoCreateResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
-        @SerialName("infoId")
-        val infoId: Long,
-        @SerialName("name")
-        val name: String,
+        val publishedAt: LocalDateTime,
+        @SerialName("teamBottariId")
+        val teamBottariId: Long,
+        @SerialName("infos")
+        val infos: List<Info>,
     ) : EventDataResponse {
-        override fun toDomain(): EventData = EventData.SharedItemInfoCreate(publishedAt, infoId, name)
+        @Serializable
+        data class Info(
+            @SerialName("id")
+            val id: Long,
+            @SerialName("name")
+            val name: String,
+        )
+
+        override fun toDomain(): EventData = EventData.SharedItemInfoCreate(publishedAt, teamBottariId, infos.toDomainInfos())
+
+        private fun List<Info>.toDomainInfos(): List<EventData.SharedItemInfoCreate.Info> =
+            map { info -> EventData.SharedItemInfoCreate.Info(info.id, info.name) }
+    }
+
+    @Serializable
+    data class SharedItemCreateResponse(
+        @SerialName("publishedAt")
+        @Serializable(with = LocalDateTimeSerializer::class)
+        val publishedAt: LocalDateTime,
+        @SerialName("teamBottariId")
+        val teamBottariId: Long,
+    ) : EventDataResponse {
+        override fun toDomain(): EventData = EventData.SharedItemCreate(publishedAt, teamBottariId)
     }
 
     @Serializable
     data class SharedItemInfoDeleteResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
+        val publishedAt: LocalDateTime,
+        @SerialName("teamBottariId")
+        val teamBottariId: Long,
+        @SerialName("infos")
+        val infos: List<Info>,
+    ) : EventDataResponse {
+        @Serializable
+        data class Info(
+            @SerialName("id")
+            val id: Long,
+            @SerialName("name")
+            val name: String,
+        )
+
+        override fun toDomain(): EventData = EventData.SharedItemInfoDelete(publishedAt, teamBottariId, infos.toDomainInfos())
+
+        private fun List<Info>.toDomainInfos(): List<EventData.SharedItemInfoDelete.Info> =
+            map { info -> EventData.SharedItemInfoDelete.Info(info.id, info.name) }
+    }
+
+    @Serializable
+    data class SharedItemDeleteResponse(
+        @SerialName("publishedAt")
+        @Serializable(with = LocalDateTimeSerializer::class)
+        val publishedAt: LocalDateTime,
+        @SerialName("teamBottariId")
+        val teamBottariId: Long,
+    ) : EventDataResponse {
+        override fun toDomain(): EventData = EventData.SharedItemDelete(publishedAt, teamBottariId)
+    }
+
+    @Serializable
+    data class SharedItemCheckResponse(
+        @SerialName("publishedAt")
+        @Serializable(with = LocalDateTimeSerializer::class)
+        val publishedAt: LocalDateTime,
         @SerialName("infoId")
         val infoId: Long,
-        @SerialName("name")
-        val name: String,
+        @SerialName("memberId")
+        val memberId: Long,
+        @SerialName("isChecked")
+        val isChecked: Boolean,
     ) : EventDataResponse {
-        override fun toDomain(): EventData = EventData.SharedItemInfoDelete(publishedAt, infoId, name)
+        override fun toDomain(): EventData = EventData.SharedItemCheck(publishedAt, infoId, memberId, isChecked)
     }
 
     @Serializable
     data class AssignedItemInfoCreateResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
-        @SerialName("infoId")
-        val infoId: Long,
-        @SerialName("name")
-        val name: String,
-        @SerialName("memberIds")
-        val memberIds: List<Long>,
+        val publishedAt: LocalDateTime,
+        @SerialName("teamBottariId")
+        val teamBottariId: Long,
+        @SerialName("infos")
+        val infos: List<Info>,
     ) : EventDataResponse {
-        override fun toDomain(): EventData = EventData.AssignedItemInfoCreate(publishedAt, infoId, name, memberIds)
+        @Serializable
+        data class Info(
+            @SerialName("id")
+            val id: Long,
+            @SerialName("name")
+            val name: String,
+            @SerialName("assignees")
+            val assignees: List<Assignee>,
+        ) {
+            @Serializable
+            data class Assignee(
+                @SerialName("memberId")
+                val memberId: Long,
+                @SerialName("name")
+                val name: String,
+            )
+        }
+
+        override fun toDomain(): EventData = EventData.AssignedItemInfoCreate(publishedAt, teamBottariId, infos.toDomainInfos())
+
+        private fun List<Info>.toDomainInfos(): List<EventData.AssignedItemInfoCreate.Info> =
+            map { info ->
+                EventData.AssignedItemInfoCreate.Info(info.id, info.name, info.assignees.toDomainAssignees())
+            }
+
+        private fun List<Info.Assignee>.toDomainAssignees(): List<EventData.AssignedItemInfoCreate.Info.Assignee> =
+            map { assignee ->
+                EventData.AssignedItemInfoCreate.Info.Assignee(assignee.memberId, assignee.name)
+            }
+    }
+
+    @Serializable
+    data class AssignedItemCreateResponse(
+        @SerialName("publishedAt")
+        @Serializable(with = LocalDateTimeSerializer::class)
+        val publishedAt: LocalDateTime,
+        @SerialName("teamBottariId")
+        val teamBottariId: Long,
+    ) : EventDataResponse {
+        override fun toDomain(): EventData = EventData.AssignedItemCreate(publishedAt, teamBottariId)
     }
 
     @Serializable
     data class AssignedItemInfoChangeResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
+        val publishedAt: LocalDateTime,
         @SerialName("infoId")
         val infoId: Long,
         @SerialName("name")
@@ -99,65 +204,59 @@ sealed interface EventDataResponse {
     data class AssignedItemInfoDeleteResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
-        @SerialName("infoId")
-        val infoId: Long,
-        @SerialName("name")
-        val name: String,
+        val publishedAt: LocalDateTime,
+        @SerialName("teamBottariId")
+        val teamBottariId: Long,
+        @SerialName("infos")
+        val infos: List<Info>,
     ) : EventDataResponse {
-        override fun toDomain(): EventData = EventData.AssignedItemInfoDelete(publishedAt, infoId, name)
+        @Serializable
+        data class Info(
+            @SerialName("id")
+            val id: Long,
+            @SerialName("name")
+            val name: String,
+            @SerialName("assignees")
+            val assignees: List<Assignee>,
+        ) {
+            @Serializable
+            data class Assignee(
+                @SerialName("memberId")
+                val memberId: Long,
+                @SerialName("name")
+                val name: String,
+            )
+        }
+
+        override fun toDomain(): EventData = EventData.AssignedItemInfoDelete(publishedAt, teamBottariId, infos.toDomainInfos())
+
+        private fun List<Info>.toDomainInfos(): List<EventData.AssignedItemInfoDelete.Info> =
+            map { info ->
+                EventData.AssignedItemInfoDelete.Info(info.id, info.name, info.assignees.toDomainAssignees())
+            }
+
+        private fun List<Info.Assignee>.toDomainAssignees(): List<EventData.AssignedItemInfoDelete.Info.Assignee> =
+            map { assignee ->
+                EventData.AssignedItemInfoDelete.Info.Assignee(assignee.memberId, assignee.name)
+            }
     }
 
     @Serializable
-    data class SharedItemChangeResponse(
+    data class AssignedItemDeleteResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
-        @SerialName("infoId")
-        val infoId: Long,
-        @SerialName("memberId")
-        val memberId: Long,
-        @SerialName("isChecked")
-        val isChecked: Boolean,
+        val publishedAt: LocalDateTime,
+        @SerialName("teamBottariId")
+        val teamBottariId: Long,
     ) : EventDataResponse {
-        override fun toDomain(): EventData = EventData.SharedItemChange(publishedAt, infoId, memberId, isChecked)
-    }
-
-    @Serializable
-    data class SharedItemCheckResponse(
-        @SerialName("publishedAt")
-        @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
-        @SerialName("infoId")
-        val infoId: Long,
-        @SerialName("memberId")
-        val memberId: Long,
-        @SerialName("isChecked")
-        val isChecked: Boolean,
-    ) : EventDataResponse {
-        override fun toDomain(): EventData = EventData.SharedItemCheck(publishedAt, infoId, memberId, isChecked)
-    }
-
-    @Serializable
-    data class AssignedItemChangeResponse(
-        @SerialName("publishedAt")
-        @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
-        @SerialName("infoId")
-        val infoId: Long,
-        @SerialName("memberId")
-        val memberId: Long,
-        @SerialName("isChecked")
-        val isChecked: Boolean,
-    ) : EventDataResponse {
-        override fun toDomain(): EventData = EventData.AssignedItemChange(publishedAt, infoId, memberId, isChecked)
+        override fun toDomain(): EventData = EventData.AssignedItemDelete(publishedAt, teamBottariId)
     }
 
     @Serializable
     data class AssignedItemCheckResponse(
         @SerialName("publishedAt")
         @Serializable(with = LocalDateTimeSerializer::class)
-        override val publishedAt: LocalDateTime,
+        val publishedAt: LocalDateTime,
         @SerialName("infoId")
         val infoId: Long,
         @SerialName("memberId")

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/remote/sse/EventResponse.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/remote/sse/EventResponse.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class EventResponse {
     CREATE,
+    DELETE,
     CHANGE,
     CHECK,
-    DELETE,
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/remote/sse/OnEventRaw.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/remote/sse/OnEventRaw.kt
@@ -35,12 +35,6 @@ fun OnEventRaw.toEvent(json: Json): EventStateResponse.OnEventResponse {
                     data,
                 )
 
-            ResourceResponse.SHARED_ITEM to EventResponse.CHANGE ->
-                json.decodeFromJsonElement(
-                    EventDataResponse.SharedItemChangeResponse.serializer(),
-                    data,
-                )
-
             ResourceResponse.SHARED_ITEM_INFO to EventResponse.CREATE ->
                 json.decodeFromJsonElement(
                     EventDataResponse.SharedItemInfoCreateResponse.serializer(),
@@ -53,9 +47,21 @@ fun OnEventRaw.toEvent(json: Json): EventStateResponse.OnEventResponse {
                     data,
                 )
 
-            ResourceResponse.ASSIGNED_ITEM to EventResponse.CHANGE ->
+            ResourceResponse.SHARED_ITEM to EventResponse.CREATE ->
                 json.decodeFromJsonElement(
-                    EventDataResponse.AssignedItemChangeResponse.serializer(),
+                    EventDataResponse.SharedItemCreateResponse.serializer(),
+                    data,
+                )
+
+            ResourceResponse.SHARED_ITEM to EventResponse.DELETE ->
+                json.decodeFromJsonElement(
+                    EventDataResponse.SharedItemDeleteResponse.serializer(),
+                    data,
+                )
+
+            ResourceResponse.SHARED_ITEM_INFO to EventResponse.CHECK ->
+                json.decodeFromJsonElement(
+                    EventDataResponse.SharedItemCheckResponse.serializer(),
                     data,
                 )
 
@@ -77,13 +83,19 @@ fun OnEventRaw.toEvent(json: Json): EventStateResponse.OnEventResponse {
                     data,
                 )
 
-            ResourceResponse.SHARED_ITEM to EventResponse.CHECK ->
+            ResourceResponse.ASSIGNED_ITEM to EventResponse.CREATE ->
                 json.decodeFromJsonElement(
-                    EventDataResponse.SharedItemCheckResponse.serializer(),
+                    EventDataResponse.AssignedItemCreateResponse.serializer(),
                     data,
                 )
 
-            ResourceResponse.ASSIGNED_ITEM to EventResponse.CHECK ->
+            ResourceResponse.ASSIGNED_ITEM to EventResponse.DELETE ->
+                json.decodeFromJsonElement(
+                    EventDataResponse.AssignedItemDeleteResponse.serializer(),
+                    data,
+                )
+
+            ResourceResponse.ASSIGNED_ITEM_INFO to EventResponse.CHECK ->
                 json.decodeFromJsonElement(
                     EventDataResponse.AssignedItemCheckResponse.serializer(),
                     data,

--- a/android/Bottari/data/src/main/java/com/bottari/data/model/remote/sse/ResourceResponse.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/model/remote/sse/ResourceResponse.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class ResourceResponse {
     TEAM_MEMBER,
-    SHARED_ITEM,
     SHARED_ITEM_INFO,
-    ASSIGNED_ITEM,
+    SHARED_ITEM,
     ASSIGNED_ITEM_INFO,
+    ASSIGNED_ITEM,
 }

--- a/android/Bottari/data/src/main/java/com/bottari/data/network/SSEClientImpl.kt
+++ b/android/Bottari/data/src/main/java/com/bottari/data/network/SSEClientImpl.kt
@@ -8,8 +8,6 @@ import com.bottari.logger.BottariLogger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.json.Json
-import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -83,7 +81,7 @@ class SSEClientImpl(
     override fun connect(teamBottariId: Long): Flow<EventStateResponse> {
         if (eventSource != null) return eventFlow
         id = teamBottariId
-        val request = createRequest(teamBottariId)
+        val request = createRequest()
         eventSource = createEventSource(request)
         BottariLogger.network("[Event] Team Bottari $id stream connect")
         return eventFlow
@@ -97,10 +95,10 @@ class SSEClientImpl(
         id = null
     }
 
-    private fun createRequest(teamBottariId: Long): Request =
+    private fun createRequest(): Request =
         Request
             .Builder()
-            .url(getUrl(teamBottariId))
+            .url(BuildConfig.BASE_URL + SSE_URL)
             .get()
             .build()
 
@@ -109,17 +107,7 @@ class SSEClientImpl(
             .createFactory(client)
             .newEventSource(request, this)
 
-    private fun getUrl(teamBottariId: Long): HttpUrl =
-        BuildConfig.BASE_URL
-            .toHttpUrl()
-            .newBuilder()
-            .addPathSegment(PATH_TEAM_BOTTARIES)
-            .addPathSegment(teamBottariId.toString())
-            .addPathSegment(PATH_SSE)
-            .build()
-
     companion object {
-        private const val PATH_TEAM_BOTTARIES = "team-bottaries"
-        private const val PATH_SSE = "sse"
+        private const val SSE_URL = "/connect/sse"
     }
 }

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/model/event/EventData.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/model/event/EventData.kt
@@ -2,6 +2,12 @@ package com.bottari.domain.model.event
 
 import java.time.LocalDateTime
 
+/*
+ * 현재 물건 관련 이벤트가 Item과 ItemInfo로 나누어져 있습니다.
+ * 하지만 실제로는 두 이벤트가 항상 동시에 발생하기 때문에 중복 처리가 생기는 문제가 있습니다.
+ * 따라서 View에서는 payload가 포함된 ItemInfo만 사용하도록 했습니다.
+ */
+
 sealed interface EventData {
     data class TeamMemberCreate(
         val publishedAt: LocalDateTime,

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/model/event/EventData.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/model/event/EventData.kt
@@ -78,6 +78,11 @@ sealed interface EventData {
                 val name: String,
             )
         }
+
+        fun containMember(memberId: Long): Boolean =
+            infos.any { info ->
+                info.assignees.any { assignee -> assignee.memberId == memberId }
+            }
     }
 
     data class AssignedItemCreate(
@@ -90,7 +95,9 @@ sealed interface EventData {
         val infoId: Long,
         val name: String,
         val memberIds: List<Long>,
-    ) : EventData
+    ) : EventData {
+        fun containMember(memberId: Long): Boolean = memberIds.contains(memberId)
+    }
 
     data class AssignedItemInfoDelete(
         val publishedAt: LocalDateTime,
@@ -107,6 +114,11 @@ sealed interface EventData {
                 val name: String,
             )
         }
+
+        fun containMember(memberId: Long): Boolean =
+            infos.any { info ->
+                info.assignees.any { assignee -> assignee.memberId == memberId }
+            }
     }
 
     data class AssignedItemDelete(

--- a/android/Bottari/domain/src/main/java/com/bottari/domain/model/event/EventData.kt
+++ b/android/Bottari/domain/src/main/java/com/bottari/domain/model/event/EventData.kt
@@ -3,76 +3,113 @@ package com.bottari.domain.model.event
 import java.time.LocalDateTime
 
 sealed interface EventData {
-    val publishedAt: LocalDateTime
-
     data class TeamMemberCreate(
-        override val publishedAt: LocalDateTime,
+        val publishedAt: LocalDateTime,
         val memberId: Long,
         val name: String,
         val isOwner: Boolean,
     ) : EventData
 
     data class TeamMemberDelete(
-        override val publishedAt: LocalDateTime,
-        val exitMemberId: Long,
+        val publishedAt: LocalDateTime,
         val bottariId: String,
+        val bottariName: String,
+        val exitMemberId: Long,
+        val exitMemberName: String,
     ) : EventData
 
     data class SharedItemInfoCreate(
-        override val publishedAt: LocalDateTime,
-        val infoId: Long,
-        val name: String,
+        val publishedAt: LocalDateTime,
+        val teamBottariId: Long,
+        val infos: List<Info>,
+    ) : EventData {
+        data class Info(
+            val id: Long,
+            val name: String,
+        )
+    }
+
+    data class SharedItemCreate(
+        val publishedAt: LocalDateTime,
+        val teamBottariId: Long,
     ) : EventData
 
     data class SharedItemInfoDelete(
-        override val publishedAt: LocalDateTime,
+        val publishedAt: LocalDateTime,
+        val teamBottariId: Long,
+        val infos: List<Info>,
+    ) : EventData {
+        data class Info(
+            val id: Long,
+            val name: String,
+        )
+    }
+
+    data class SharedItemDelete(
+        val publishedAt: LocalDateTime,
+        val teamBottariId: Long,
+    ) : EventData
+
+    data class SharedItemCheck(
+        val publishedAt: LocalDateTime,
         val infoId: Long,
-        val name: String,
+        val memberId: Long,
+        val isChecked: Boolean,
     ) : EventData
 
     data class AssignedItemInfoCreate(
-        override val publishedAt: LocalDateTime,
-        val infoId: Long,
-        val name: String,
-        val memberIds: List<Long>,
+        val publishedAt: LocalDateTime,
+        val teamBottariId: Long,
+        val infos: List<Info>,
+    ) : EventData {
+        data class Info(
+            val id: Long,
+            val name: String,
+            val assignees: List<Assignee>,
+        ) {
+            data class Assignee(
+                val memberId: Long,
+                val name: String,
+            )
+        }
+    }
+
+    data class AssignedItemCreate(
+        val publishedAt: LocalDateTime,
+        val teamBottariId: Long,
     ) : EventData
 
     data class AssignedItemInfoChange(
-        override val publishedAt: LocalDateTime,
+        val publishedAt: LocalDateTime,
         val infoId: Long,
         val name: String,
         val memberIds: List<Long>,
     ) : EventData
 
     data class AssignedItemInfoDelete(
-        override val publishedAt: LocalDateTime,
-        val infoId: Long,
-        val name: String,
-    ) : EventData
+        val publishedAt: LocalDateTime,
+        val teamBottariId: Long,
+        val infos: List<Info>,
+    ) : EventData {
+        data class Info(
+            val id: Long,
+            val name: String,
+            val assignees: List<Assignee>,
+        ) {
+            data class Assignee(
+                val memberId: Long,
+                val name: String,
+            )
+        }
+    }
 
-    data class SharedItemCheck(
-        override val publishedAt: LocalDateTime,
-        val infoId: Long,
-        val memberId: Long,
-        val isChecked: Boolean,
+    data class AssignedItemDelete(
+        val publishedAt: LocalDateTime,
+        val teamBottariId: Long,
     ) : EventData
 
     data class AssignedItemCheck(
-        override val publishedAt: LocalDateTime,
-        val infoId: Long,
-        val memberId: Long,
-        val isChecked: Boolean,
-    ) : EventData
-
-    data class SharedItemChange(
-        override val publishedAt: LocalDateTime,
-        val infoId: Long,
-        val memberId: Long,
-        val isChecked: Boolean,
-    ) : EventData
-
-    data class AssignedItemChange(
-        override val publishedAt: LocalDateTime,
+        val publishedAt: LocalDateTime,
         val infoId: Long,
         val memberId: Long,
         val isChecked: Boolean,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/checklist/TeamChecklistViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/checklist/TeamChecklistViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.bottari.di.usecase.CommonUseCaseProvider
+import com.bottari.di.usecase.MemberUseCaseProvider
 import com.bottari.di.usecase.TeamBottariItemsUseCaseProvider
 import com.bottari.domain.model.bottari.item.ChecklistItem
 import com.bottari.domain.model.event.EventData
@@ -14,6 +15,7 @@ import com.bottari.domain.model.event.EventState
 import com.bottari.domain.model.team.bottari.TeamBottariCheckList
 import com.bottari.domain.usecase.event.ConnectTeamEventUseCase
 import com.bottari.domain.usecase.event.DisconnectTeamEventUseCase
+import com.bottari.domain.usecase.member.GetMemberIdUseCase
 import com.bottari.domain.usecase.team.CheckTeamBottariItemUseCase
 import com.bottari.domain.usecase.team.FetchTeamChecklistUseCase
 import com.bottari.domain.usecase.team.UncheckTeamBottariItemUseCase
@@ -29,8 +31,8 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -41,6 +43,7 @@ class TeamChecklistViewModel(
     private val fetchTeamBottariChecklistUseCase: FetchTeamChecklistUseCase,
     private val checkTeamBottariItemUseCase: CheckTeamBottariItemUseCase,
     private val unCheckTeamBottariItemUseCase: UncheckTeamBottariItemUseCase,
+    private val getMemberIdUseCase: GetMemberIdUseCase,
     private val connectTeamEventUseCase: ConnectTeamEventUseCase,
     private val disconnectTeamEventUseCase: DisconnectTeamEventUseCase,
 ) : BaseViewModel<TeamChecklistUiState, TeamChecklistUiEvent>(TeamChecklistUiState()) {
@@ -145,21 +148,24 @@ class TeamChecklistViewModel(
             connectTeamEventUseCase(teamBottariId)
                 .filterIsInstance<EventState.OnEvent>()
                 .map { event -> event.data }
-                .filter { eventData ->
-                    when (eventData) {
-                        is EventData.TeamMemberCreate,
-                        is EventData.TeamMemberDelete,
-                        is EventData.SharedItemCheck,
-                        is EventData.AssignedItemCheck,
-                        -> false
-
-                        else -> true
-                    }
-                }.debounce(DEBOUNCE_DELAY)
+                .filterNot { eventData -> eventData.shouldIgnore() }
+                .debounce(DEBOUNCE_DELAY)
                 .onEach { fetchTeamCheckList() }
                 .launchIn(this)
         }
     }
+
+    private fun EventData.shouldIgnore(): Boolean =
+        when (this) {
+            is EventData.AssignedItemInfoCreate,
+            is EventData.AssignedItemInfoDelete,
+            is EventData.AssignedItemInfoChange,
+            is EventData.SharedItemInfoCreate,
+            is EventData.SharedItemInfoDelete,
+            -> false
+
+            else -> true
+        }
 
     private fun setTeamCheckList(checklistData: TeamBottariCheckList) {
         val newItems = checklistData.toUIModel()
@@ -321,6 +327,7 @@ class TeamChecklistViewModel(
                         TeamBottariItemsUseCaseProvider.fetchTeamChecklistUseCase,
                         TeamBottariItemsUseCaseProvider.checkTeamBottariItemUseCase,
                         TeamBottariItemsUseCaseProvider.uncheckTeamBottariItemUseCase,
+                        MemberUseCaseProvider.getMemberIdUseCase,
                         CommonUseCaseProvider.connectTeamEventUseCase,
                         CommonUseCaseProvider.disconnectTeamEventUseCase,
                     )

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/checklist/TeamChecklistViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/checklist/team/main/checklist/TeamChecklistViewModel.kt
@@ -48,6 +48,7 @@ class TeamChecklistViewModel(
     private val disconnectTeamEventUseCase: DisconnectTeamEventUseCase,
 ) : BaseViewModel<TeamChecklistUiState, TeamChecklistUiEvent>(TeamChecklistUiState()) {
     private val teamBottariId: Long = stateHandle[KEY_BOTTARI_ID] ?: error(ERROR_REQUIRE_BOTTARI_ID)
+    private var memberId: Long = -1
 
     private val pendingCheckStatusMap =
         mutableMapOf<Pair<Long, BottariItemTypeUiModel>, TeamChecklistProductUiModel>()
@@ -60,6 +61,7 @@ class TeamChecklistViewModel(
 
     init {
         fetchTeamCheckList()
+        fetchMemberId()
         handleEvent()
     }
 
@@ -120,6 +122,12 @@ class TeamChecklistViewModel(
         updateState { copy(swipedItems = this.swipedItems + item) }
     }
 
+    private fun fetchMemberId() {
+        launch {
+            memberId = getMemberIdUseCase().getOrDefault(-1)
+        }
+    }
+
     private fun List<TeamChecklistItem>.toggleItemInList(item: TeamChecklistProductUiModel): List<TeamChecklistItem> =
         this.map { listItem ->
             if (listItem.isSameItem(item).not()) return@map listItem
@@ -157,9 +165,9 @@ class TeamChecklistViewModel(
 
     private fun EventData.shouldIgnore(): Boolean =
         when (this) {
-            is EventData.AssignedItemInfoCreate,
-            is EventData.AssignedItemInfoDelete,
-            is EventData.AssignedItemInfoChange,
+            is EventData.AssignedItemInfoCreate -> containMember(memberId).not()
+            is EventData.AssignedItemInfoDelete -> containMember(memberId).not()
+            is EventData.AssignedItemInfoChange -> containMember(memberId).not()
             is EventData.SharedItemInfoCreate,
             is EventData.SharedItemInfoDelete,
             -> false

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/assigned/TeamAssignedItemEditViewModel.kt
@@ -240,12 +240,14 @@ class TeamAssignedItemEditViewModel(
 
     private fun EventData.shouldIgnore(): Boolean =
         when (this) {
-            is EventData.SharedItemChange,
-            is EventData.SharedItemInfoCreate,
-            is EventData.SharedItemInfoDelete,
-            -> true
+            is EventData.AssignedItemInfoCreate,
+            is EventData.AssignedItemInfoDelete,
+            is EventData.AssignedItemInfoChange,
+            is EventData.TeamMemberCreate,
+            is EventData.TeamMemberDelete,
+            -> false
 
-            else -> false
+            else -> true
         }
 
     companion object {

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
@@ -91,8 +91,18 @@ class TeamSharedItemEditViewModel(
 
         launch {
             fetchTeamSharedItemsUseCase(bottariId)
-                .onSuccess { items -> updateState { copy(sharedItems = items.map { BottariItemUiModel.fromDomain(it) }) } }
-                .onFailure { emitEvent(TeamSharedItemEditEvent.FetchTeamSharedItemsFailure) }
+                .onSuccess { items ->
+                    updateState {
+                        copy(
+                            sharedItems =
+                                items.map {
+                                    BottariItemUiModel.fromDomain(
+                                        it,
+                                    )
+                                },
+                        )
+                    }
+                }.onFailure { emitEvent(TeamSharedItemEditEvent.FetchTeamSharedItemsFailure) }
 
             updateState { copy(isLoading = false, isFetched = true) }
         }
@@ -100,9 +110,10 @@ class TeamSharedItemEditViewModel(
 
     private fun EventData.shouldIgnore(): Boolean =
         when (this) {
-            is EventData.SharedItemChange,
             is EventData.SharedItemInfoCreate,
             is EventData.SharedItemInfoDelete,
+            is EventData.TeamMemberCreate,
+            is EventData.TeamMemberDelete,
             -> false
 
             else -> true

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/item/shared/TeamSharedItemEditViewModel.kt
@@ -91,18 +91,8 @@ class TeamSharedItemEditViewModel(
 
         launch {
             fetchTeamSharedItemsUseCase(bottariId)
-                .onSuccess { items ->
-                    updateState {
-                        copy(
-                            sharedItems =
-                                items.map {
-                                    BottariItemUiModel.fromDomain(
-                                        it,
-                                    )
-                                },
-                        )
-                    }
-                }.onFailure { emitEvent(TeamSharedItemEditEvent.FetchTeamSharedItemsFailure) }
+                .onSuccess { items -> updateState { copy(sharedItems = items.map(BottariItemUiModel::fromDomain)) } }
+                .onFailure { emitEvent(TeamSharedItemEditEvent.FetchTeamSharedItemsFailure) }
 
             updateState { copy(isLoading = false, isFetched = true) }
         }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditViewModel.kt
@@ -20,8 +20,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -62,20 +62,41 @@ class TeamBottariEditViewModel(
             connectTeamEventUseCase(bottariId)
                 .filterIsInstance<EventState.OnEvent>()
                 .map { event -> event.data }
-                .filter { eventData -> eventData !is EventData.TeamMemberCreate }
+                .filterNot { eventData -> eventData.shouldIgnore() }
                 .debounce(DEBOUNCE_DELAY)
                 .onEach { fetchTeamBottariDetail() }
                 .launchIn(this)
         }
     }
 
+    private fun EventData.shouldIgnore(): Boolean =
+        when (this) {
+            is EventData.AssignedItemInfoCreate,
+            is EventData.AssignedItemInfoDelete,
+            is EventData.SharedItemInfoCreate,
+            is EventData.SharedItemInfoDelete,
+            -> false
+
+            else -> true
+        }
+
     private fun handleFetchTeamBottariDetail(teamBottariDetail: TeamBottariDetail) {
         val alarmUi = teamBottariDetail.bottari.alarm?.let { AlarmUiModel.fromDomain(it) }
         updateState {
             copy(
                 bottariTitle = teamBottariDetail.bottari.title,
-                personalItems = teamBottariDetail.personalItems.map { BottariItemUiModel.fromDomain(it) },
-                assignedItems = teamBottariDetail.assignedItems.map { BottariItemUiModel.fromDomain(it) },
+                personalItems =
+                    teamBottariDetail.personalItems.map {
+                        BottariItemUiModel.fromDomain(
+                            it,
+                        )
+                    },
+                assignedItems =
+                    teamBottariDetail.assignedItems.map {
+                        BottariItemUiModel.fromDomain(
+                            it,
+                        )
+                    },
                 sharedItems = teamBottariDetail.sharedItems.map { BottariItemUiModel.fromDomain(it) },
                 alarm = alarmUi,
                 alarmSwitchState = alarmUi?.isActive ?: false,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/edit/team/main/TeamBottariEditViewModel.kt
@@ -85,19 +85,9 @@ class TeamBottariEditViewModel(
         updateState {
             copy(
                 bottariTitle = teamBottariDetail.bottari.title,
-                personalItems =
-                    teamBottariDetail.personalItems.map {
-                        BottariItemUiModel.fromDomain(
-                            it,
-                        )
-                    },
-                assignedItems =
-                    teamBottariDetail.assignedItems.map {
-                        BottariItemUiModel.fromDomain(
-                            it,
-                        )
-                    },
-                sharedItems = teamBottariDetail.sharedItems.map { BottariItemUiModel.fromDomain(it) },
+                personalItems = teamBottariDetail.personalItems.map(BottariItemUiModel::fromDomain),
+                assignedItems = teamBottariDetail.assignedItems.map(BottariItemUiModel::fromDomain),
+                sharedItems = teamBottariDetail.sharedItems.map(BottariItemUiModel::fromDomain),
                 alarm = alarmUi,
                 alarmSwitchState = alarmUi?.isActive ?: false,
             )


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 서버 PushManager(https://github.com/woowacourse-teams/2025-bottari/pull/577) 도입으로 인해 발생한 SSE 파싱 구조 변경 사항 반영

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #590 

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 공유/배정 아이템 관련 실시간 이벤트 페이로드 확대(정보 목록·담당자 등) 및 이벤트 종류 세분화
  * 팀원 생성/퇴장에 이름 정보 추가로 알림 가독성 향상
  * 멤버 관련 이벤트 기준으로 체크리스트·편집화면 자동 갱신 로직 반영

* 버그 수정
  * 이벤트 매핑·필터링 개선으로 불필요한 새로고침 감소 및 상태 동기화 안정화

* 리팩터
  * 실시간 이벤트 모델 재구성 및 SSE 연결 흐름 단순화로 일관성·신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->