### PR TITLE
[BE] 인기 해시태그 계산 로직 개선

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottari/domain/Bottari.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/domain/Bottari.java
@@ -3,10 +3,10 @@ package com.bottari.bottari.domain;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.member.domain.Member;
+import com.bottari.support.BaseTimeEntity;
 import com.bottari.vo.BottariTitle;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,16 +20,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @SQLDelete(sql = "UPDATE bottari SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Bottari {
+public class Bottari extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,9 +37,6 @@ public class Bottari {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/HashtagController.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/controller/HashtagController.java
@@ -22,7 +22,7 @@ public class HashtagController implements HashtagApiDocs {
     public ResponseEntity<List<ReadHashtagWithUsageCountResponse>> readPopularHashtags(
             @RequestParam(defaultValue = "10") final int limit
     ) {
-        final List<ReadHashtagWithUsageCountResponse> responses = hashtagService.getTopHashtagsByUsageCount(limit);
+        final List<ReadHashtagWithUsageCountResponse> responses = hashtagService.getPopularHashtags(limit);
 
         return ResponseEntity.ok(responses);
     }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplate.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplate.java
@@ -4,9 +4,9 @@ import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.member.domain.Member;
 import com.bottari.support.BadWordValidator;
+import com.bottari.support.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,16 +19,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @SQLDelete(sql = "UPDATE bottari_template SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class BottariTemplate {
+public class BottariTemplate extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,9 +40,6 @@ public class BottariTemplate {
     private Member member;
 
     private int takenCount;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtag.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplateHashtag.java
@@ -1,5 +1,6 @@
 package com.bottari.bottaritemplate.domain;
 
+import com.bottari.support.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -20,7 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class BottariTemplateHashtag {
+public class BottariTemplateHashtag extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateHashtagRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateHashtagRepository.java
@@ -92,9 +92,13 @@ public interface BottariTemplateHashtagRepository extends JpaRepository<BottariT
             FROM hashtag h
             INNER JOIN bottari_template_hashtag bth ON bth.hashtag_id = h.id
             WHERE bth.deleted_at IS NULL
+              AND bth.created_at >= :since
             GROUP BY h.id, h.name
-            ORDER BY usageCount DESC, h.id ASC
+            ORDER BY usageCount DESC, h.id DESC
             LIMIT :limit
             """, nativeQuery = true)
-    List<HashtagPopularityProjection> findTopNByUsageCount(final int limit);
+    List<HashtagPopularityProjection> findTopNByUsageCountSince(
+            final LocalDateTime since,
+            final int limit
+    );
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/HashtagService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/HashtagService.java
@@ -1,7 +1,6 @@
 package com.bottari.bottaritemplate.service;
 
 import com.bottari.bottaritemplate.dto.ReadHashtagWithUsageCountResponse;
-import com.bottari.bottaritemplate.repository.BottariTemplateHashtagRepository;
 import com.bottari.bottaritemplate.repository.dto.HashtagPopularityProjection;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
@@ -14,15 +13,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class HashtagService {
 
-    private final BottariTemplateHashtagRepository bottariTemplateHashtagRepository;
+    private final TrendingHashtagProvider trendingHashtagProvider;
 
     @Transactional(readOnly = true)
-    public List<ReadHashtagWithUsageCountResponse> getTopHashtagsByUsageCount(final int limit) {
+    public List<ReadHashtagWithUsageCountResponse> getPopularHashtags(final int limit) {
         validateLimit(limit);
-        final List<HashtagPopularityProjection> projections =
-                bottariTemplateHashtagRepository.findTopNByUsageCount(limit);
+        final List<HashtagPopularityProjection> popularHashtags = trendingHashtagProvider.getPopularHashtags(limit);
 
-        return projections.stream()
+        return popularHashtags.stream()
                 .map(ReadHashtagWithUsageCountResponse::of)
                 .toList();
     }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/TrendingHashtagProvider.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/TrendingHashtagProvider.java
@@ -1,0 +1,28 @@
+package com.bottari.bottaritemplate.service;
+
+import com.bottari.bottaritemplate.repository.BottariTemplateHashtagRepository;
+import com.bottari.bottaritemplate.repository.dto.HashtagPopularityProjection;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TrendingHashtagProvider {
+
+    private final static int RECENT_DAYS = 7;
+
+    private final BottariTemplateHashtagRepository bottariTemplateHashtagRepository;
+
+    public List<HashtagPopularityProjection> getPopularHashtags(final int limit) {
+        final LocalDateTime since = calculateSince();
+
+        return bottariTemplateHashtagRepository.findTopNByUsageCountSince(since, limit);
+    }
+
+    private LocalDateTime calculateSince() {
+        return LocalDateTime.now()
+                .minusDays(RECENT_DAYS);
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/support/BaseTimeEntity.java
+++ b/backend/bottari/src/main/java/com/bottari/support/BaseTimeEntity.java
@@ -9,9 +9,9 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseTimeEntity {
 
     @CreatedDate

--- a/backend/bottari/src/main/java/com/bottari/support/BaseTimeEntity.java
+++ b/backend/bottari/src/main/java/com/bottari/support/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.bottari.support;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItemInfo.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamAssignedItemInfo.java
@@ -1,9 +1,9 @@
 package com.bottari.teambottari.domain;
 
+import com.bottari.support.BaseTimeEntity;
 import com.bottari.vo.ItemName;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,15 +15,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @SQLRestriction("deleted_at IS NULL")
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TeamAssignedItemInfo {
+public class TeamAssignedItemInfo extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,9 +31,6 @@ public class TeamAssignedItemInfo {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_bottari_id")
     private TeamBottari teamBottari;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamBottari.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamBottari.java
@@ -1,10 +1,10 @@
 package com.bottari.teambottari.domain;
 
 import com.bottari.member.domain.Member;
+import com.bottari.support.BaseTimeEntity;
 import com.bottari.vo.BottariTitle;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,16 +17,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @SQLDelete(sql = "UPDATE team_bottari SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TeamBottari {
+public class TeamBottari extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,9 +37,6 @@ public class TeamBottari {
 
     @Column(unique = true)
     private String inviteCode;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamMember.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamMember.java
@@ -1,9 +1,9 @@
 package com.bottari.teambottari.domain;
 
 import com.bottari.member.domain.Member;
+import com.bottari.support.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,16 +16,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @SQLDelete(sql = "UPDATE team_member SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TeamMember {
+public class TeamMember extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,9 +35,6 @@ public class TeamMember {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItemInfo.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamSharedItemInfo.java
@@ -1,9 +1,9 @@
 package com.bottari.teambottari.domain;
 
+import com.bottari.support.BaseTimeEntity;
 import com.bottari.vo.ItemName;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,15 +15,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @SQLRestriction("deleted_at IS NULL")
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TeamSharedItemInfo {
+public class TeamSharedItemInfo extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,9 +31,6 @@ public class TeamSharedItemInfo {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_bottari_id")
     private TeamBottari teamBottari;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 
     // Soft Delete 경우에만 사용됨
     @Column(name = "deleted_at")

--- a/backend/bottari/src/main/resources/init.sql
+++ b/backend/bottari/src/main/resources/init.sql
@@ -128,11 +128,11 @@ VALUES ('여행'),
        ('운동'),
        ('등산');
 
-INSERT INTO bottari_template_hashtag (bottari_template_id, hashtag_id)
-VALUES (1, 1),
-       (4, 1),
-       (6, 2),
-       (7, 3);
+INSERT INTO bottari_template_hashtag (bottari_template_id, hashtag_id, created_at)
+VALUES (1, 1, '2024-01-15 10:05:00'),
+       (4, 1, '2024-01-18 16:50:00'),
+       (6, 2, '2024-01-20 08:05:00'),
+       (7, 3, '2024-01-21 13:15:00');
 
 -- 보따리 템플릿 아이템 데이터
 INSERT INTO bottari_template_item (name, bottari_template_id)

--- a/backend/bottari/src/main/resources/init.sql
+++ b/backend/bottari/src/main/resources/init.sql
@@ -129,10 +129,10 @@ VALUES ('여행'),
        ('등산');
 
 INSERT INTO bottari_template_hashtag (bottari_template_id, hashtag_id, created_at)
-VALUES (1, 1, '2024-01-15 10:05:00'),
-       (4, 1, '2024-01-18 16:50:00'),
-       (6, 2, '2024-01-20 08:05:00'),
-       (7, 3, '2024-01-21 13:15:00');
+VALUES (1, 1, '2025-09-19 10:05:00'),
+       (4, 1, '2025-09-19 16:50:00'),
+       (6, 2, '2025-10-19 08:05:00'),
+       (7, 3, '2025-10-19 13:15:00');
 
 -- 보따리 템플릿 아이템 데이터
 INSERT INTO bottari_template_item (name, bottari_template_id)

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/HashtagControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/HashtagControllerTest.java
@@ -40,7 +40,7 @@ class HashtagControllerTest {
                 new ReadHashtagWithUsageCountResponse(2L, "캠핑", 35),
                 new ReadHashtagWithUsageCountResponse(3L, "등산", 28)
         );
-        given(hashtagService.getTopHashtagsByUsageCount(10))
+        given(hashtagService.getPopularHashtags(10))
                 .willReturn(responses);
 
         // when & then
@@ -57,7 +57,7 @@ class HashtagControllerTest {
         final List<ReadHashtagWithUsageCountResponse> responses = List.of(
                 new ReadHashtagWithUsageCountResponse(1L, "여행", 42)
         );
-        given(hashtagService.getTopHashtagsByUsageCount(10))
+        given(hashtagService.getPopularHashtags(10))
                 .willReturn(responses);
 
         // when & then
@@ -74,7 +74,7 @@ class HashtagControllerTest {
                 new ReadHashtagWithUsageCountResponse(1L, "여행", 42),
                 new ReadHashtagWithUsageCountResponse(2L, "캠핑", 35)
         );
-        given(hashtagService.getTopHashtagsByUsageCount(2))
+        given(hashtagService.getPopularHashtags(2))
                 .willReturn(responses);
 
         // when & then

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/HashtagServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/HashtagServiceTest.java
@@ -3,157 +3,67 @@ package com.bottari.bottaritemplate.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
-import com.bottari.bottaritemplate.domain.BottariTemplate;
-import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
-import com.bottari.bottaritemplate.domain.Hashtag;
 import com.bottari.bottaritemplate.dto.ReadHashtagWithUsageCountResponse;
-import com.bottari.config.JpaAuditingConfig;
+import com.bottari.bottaritemplate.repository.dto.HashtagPopularityProjection;
 import com.bottari.error.BusinessException;
-import com.bottari.member.domain.Member;
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({HashtagService.class, JpaAuditingConfig.class})
+@ExtendWith(MockitoExtension.class)
 class HashtagServiceTest {
 
-    @Autowired
+    @InjectMocks
     private HashtagService hashtagService;
 
-    @Autowired
-    private EntityManager entityManager;
+    @Mock
+    private TrendingHashtagProvider trendingHashtagProvider;
 
     @Nested
+    @DisplayName("인기 해시태그 조회")
     class GetTopHashtagsByUsageCountTest {
 
-        @DisplayName("인기 해시태그를 사용 횟수가 많은 순으로 조회한다.")
+        @DisplayName("해시태그 Provider로부터 받은 데이터를 응답 DTO로 변환하여 반환한다.")
         @Test
         void getTopHashtagsByUsageCount() {
             // given
-            final Member member = new Member("ssaid", "name");
-            entityManager.persist(member);
+            final int limit = 10;
+            final HashtagPopularityProjection projection1 = mock(HashtagPopularityProjection.class);
+            given(projection1.getHashtagId()).willReturn(1L);
+            given(projection1.getHashtagName()).willReturn("여행");
+            given(projection1.getUsageCount()).willReturn(100);
 
-            final Hashtag hashtag1 = new Hashtag("여행");
-            final Hashtag hashtag2 = new Hashtag("캠핑");
-            final Hashtag hashtag3 = new Hashtag("등산");
-            entityManager.persist(hashtag1);
-            entityManager.persist(hashtag2);
-            entityManager.persist(hashtag3);
+            final HashtagPopularityProjection projection2 = mock(HashtagPopularityProjection.class);
+            given(projection2.getHashtagId()).willReturn(2L);
+            given(projection2.getHashtagName()).willReturn("캠핑");
+            given(projection2.getUsageCount()).willReturn(50);
 
-            final BottariTemplate template1 = new BottariTemplate("title1", "description1", member);
-            final BottariTemplate template2 = new BottariTemplate("title2", "description2", member);
-            final BottariTemplate template3 = new BottariTemplate("title3", "description3", member);
-            final BottariTemplate template4 = new BottariTemplate("title4", "description4", member);
-            entityManager.persist(template1);
-            entityManager.persist(template2);
-            entityManager.persist(template3);
-            entityManager.persist(template4);
-
-            // hashtag1: 3번 사용 (1위)
-            entityManager.persist(new BottariTemplateHashtag(template1, hashtag1));
-            entityManager.persist(new BottariTemplateHashtag(template2, hashtag1));
-            entityManager.persist(new BottariTemplateHashtag(template3, hashtag1));
-
-            // hashtag2: 2번 사용 (2위)
-            entityManager.persist(new BottariTemplateHashtag(template1, hashtag2));
-            entityManager.persist(new BottariTemplateHashtag(template2, hashtag2));
-
-            // hashtag3: 1번 사용 (3위)
-            entityManager.persist(new BottariTemplateHashtag(template4, hashtag3));
-
-            entityManager.flush();
-            entityManager.clear();
+            given(trendingHashtagProvider.getPopularHashtags(limit))
+                    .willReturn(List.of(projection1, projection2));
 
             // when
-            final List<ReadHashtagWithUsageCountResponse> responses = hashtagService.getTopHashtagsByUsageCount(10);
+            final List<ReadHashtagWithUsageCountResponse> responses = hashtagService.getPopularHashtags(limit);
 
             // then
-            assertAll(() -> assertThat(responses).hasSize(3),
-                    () -> assertThat(responses.getFirst().name()).isEqualTo("여행"),
-                    () -> assertThat(responses.getFirst().usageCount()).isEqualTo(3),
+            assertAll(
+                    () -> assertThat(responses).hasSize(2),
+                    () -> assertThat(responses.get(0).id()).isEqualTo(1L),
+                    () -> assertThat(responses.get(0).name()).isEqualTo("여행"),
+                    () -> assertThat(responses.get(0).usageCount()).isEqualTo(100L),
+                    () -> assertThat(responses.get(1).id()).isEqualTo(2L),
                     () -> assertThat(responses.get(1).name()).isEqualTo("캠핑"),
-                    () -> assertThat(responses.get(1).usageCount()).isEqualTo(2),
-                    () -> assertThat(responses.get(2).name()).isEqualTo("등산"),
-                    () -> assertThat(responses.get(2).usageCount()).isEqualTo(1));
-        }
-
-        @DisplayName("사용 횟수가 같을 경우, ID가 작은 순서로 정렬된다.")
-        @Test
-        void getTopHashtagsByUsageCount_SameUsageCount_OrderById() {
-            // given
-            final Member member = new Member("ssaid", "name");
-            entityManager.persist(member);
-
-            final Hashtag hashtag1 = new Hashtag("가나다");
-            final Hashtag hashtag2 = new Hashtag("라마바");
-            entityManager.persist(hashtag1);
-            entityManager.persist(hashtag2);
-
-            final BottariTemplate template1 = new BottariTemplate("title1", "description1", member);
-            final BottariTemplate template2 = new BottariTemplate("title2", "description2", member);
-            entityManager.persist(template1);
-            entityManager.persist(template2);
-
-            // 둘 다 1번씩 사용
-            entityManager.persist(new BottariTemplateHashtag(template1, hashtag1));
-            entityManager.persist(new BottariTemplateHashtag(template2, hashtag2));
-
-            entityManager.flush();
-            entityManager.clear();
-
-            // when
-            final List<ReadHashtagWithUsageCountResponse> responses = hashtagService.getTopHashtagsByUsageCount(10);
-
-            // then
-            assertAll(() -> assertThat(responses).hasSize(2),
-                    () -> assertThat(responses.getFirst().id()).isLessThan(responses.get(1).id()));
-        }
-
-        @DisplayName("삭제된 보따리 템플릿 해시태그는 집계에서 제외된다.")
-        @Test
-        void getTopHashtagsByUsageCount_ExcludeDeleted() {
-            // given
-            final Member member = new Member("ssaid", "name");
-            entityManager.persist(member);
-
-            final Hashtag hashtag = new Hashtag("여행");
-            entityManager.persist(hashtag);
-
-            final BottariTemplate template1 = new BottariTemplate("title1", "description1", member);
-            final BottariTemplate template2 = new BottariTemplate("title2", "description2", member);
-            entityManager.persist(template1);
-            entityManager.persist(template2);
-
-            final BottariTemplateHashtag activeHashtag = new BottariTemplateHashtag(template1, hashtag);
-            final BottariTemplateHashtag deletedHashtag = new BottariTemplateHashtag(template2, hashtag);
-            entityManager.persist(activeHashtag);
-            entityManager.persist(deletedHashtag);
-
-            entityManager.flush();
-
-            // 하나를 soft delete
-            entityManager.createNativeQuery("UPDATE bottari_template_hashtag SET deleted_at = NOW() WHERE id = :id")
-                    .setParameter("id", deletedHashtag.getId()).executeUpdate();
-
-            entityManager.clear();
-
-            // when
-            final List<ReadHashtagWithUsageCountResponse> responses = hashtagService.getTopHashtagsByUsageCount(10);
-
-            // then
-            assertAll(() -> assertThat(responses).hasSize(1),
-                    () -> assertThat(responses.get(0).usageCount()).isEqualTo(1));
+                    () -> assertThat(responses.get(1).usageCount()).isEqualTo(50L)
+            );
         }
 
         @DisplayName("limit이 0 이하일 경우, 예외를 던진다.")
@@ -161,8 +71,9 @@ class HashtagServiceTest {
         @ValueSource(ints = {0, -1, -10})
         void getTopHashtagsByUsageCount_Exception_LimitTooLow(final int limit) {
             // when & then
-            assertThatThrownBy(() -> hashtagService.getTopHashtagsByUsageCount(limit)).isInstanceOf(
-                    BusinessException.class).hasMessage("인기 해시태그 조회 limit이 너무 적습니다. - 조회는 1개 이상 가능합니다.");
+            assertThatThrownBy(() -> hashtagService.getPopularHashtags(limit))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("인기 해시태그 조회 limit이 너무 적습니다. - 조회는 1개 이상 가능합니다.");
         }
 
         @DisplayName("limit이 100을 초과할 경우, 예외를 던진다.")
@@ -170,8 +81,9 @@ class HashtagServiceTest {
         @ValueSource(ints = {101, 200, 1000})
         void getTopHashtagsByUsageCount_Exception_LimitTooHigh(final int limit) {
             // when & then
-            assertThatThrownBy(() -> hashtagService.getTopHashtagsByUsageCount(limit)).isInstanceOf(
-                    BusinessException.class).hasMessage("인기 해시태그 조회 limit이 너무 높습니다. - 조회는 100개 이하 가능합니다.");
+            assertThatThrownBy(() -> hashtagService.getPopularHashtags(limit))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("인기 해시태그 조회 limit이 너무 높습니다. - 조회는 100개 이하 가능합니다.");
         }
     }
 }

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/TrendingHashtagProviderTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/TrendingHashtagProviderTest.java
@@ -1,0 +1,125 @@
+package com.bottari.bottaritemplate.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.bottari.bottaritemplate.domain.BottariTemplate;
+import com.bottari.bottaritemplate.domain.BottariTemplateHashtag;
+import com.bottari.bottaritemplate.domain.Hashtag;
+import com.bottari.bottaritemplate.repository.dto.HashtagPopularityProjection;
+import com.bottari.config.JpaAuditingConfig;
+import com.bottari.member.domain.Member;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TrendingHashtagProvider.class, JpaAuditingConfig.class})
+class TrendingHashtagProviderTest {
+
+    @Autowired
+    private TrendingHashtagProvider trendingHashtagProvider;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Nested
+    @DisplayName("최근 인기 해시태그 조회")
+    class GetPopularHashtags {
+
+        @DisplayName("최근 7일간 가장 많이 사용된 해시태그를 순서대로 조회한다.")
+        @Test
+        void getPopularHashtags() {
+            // given
+            final Member member = new Member("ssaid", "name");
+            entityManager.persist(member);
+
+            final Hashtag hashtag1 = new Hashtag("최신인기"); // 최근 2번
+            final Hashtag hashtag2 = new Hashtag("인기"); // 최근 1번
+            final Hashtag hashtag3 = new Hashtag("비인기"); // 최근 0번
+            entityManager.persist(hashtag1);
+            entityManager.persist(hashtag2);
+            entityManager.persist(hashtag3);
+
+            final BottariTemplate template = new BottariTemplate("title", "desc", member);
+            entityManager.persist(template);
+
+            // hashtag1: 최근 2번
+            entityManager.persist(new BottariTemplateHashtag(template, hashtag1));
+            entityManager.persist(new BottariTemplateHashtag(template, hashtag1));
+
+            // hashtag2: 최근 1번
+            entityManager.persist(new BottariTemplateHashtag(template, hashtag2));
+
+            // hashtag3: 8일 전 3번 (집계되지 않아야 함)
+            final BottariTemplateHashtag oldHashtag1 = new BottariTemplateHashtag(template, hashtag3);
+            final BottariTemplateHashtag oldHashtag2 = new BottariTemplateHashtag(template, hashtag3);
+            final BottariTemplateHashtag oldHashtag3 = new BottariTemplateHashtag(template, hashtag3);
+            entityManager.persist(oldHashtag1);
+            entityManager.persist(oldHashtag2);
+            entityManager.persist(oldHashtag3);
+            entityManager.flush();
+            entityManager.createNativeQuery("UPDATE bottari_template_hashtag SET created_at = :date WHERE id IN (:id1, :id2, :id3)")
+                    .setParameter("date", LocalDateTime.now().minusDays(8))
+                    .setParameter("id1", oldHashtag1.getId())
+                    .setParameter("id2", oldHashtag2.getId())
+                    .setParameter("id3", oldHashtag3.getId())
+                    .executeUpdate();
+
+            entityManager.clear();
+
+            // when
+            final List<HashtagPopularityProjection> popularHashtags = trendingHashtagProvider.getPopularHashtags(5);
+
+            // then
+            assertAll(
+                    () -> assertThat(popularHashtags).hasSize(2),
+                    () -> assertThat(popularHashtags.get(0).getHashtagName()).isEqualTo("최신인기"),
+                    () -> assertThat(popularHashtags.get(0).getUsageCount()).isEqualTo(2),
+                    () -> assertThat(popularHashtags.get(1).getHashtagName()).isEqualTo("인기"),
+                    () -> assertThat(popularHashtags.get(1).getUsageCount()).isEqualTo(1)
+            );
+        }
+
+        @DisplayName("사용 횟수가 같을 경우, ID가 큰 순서로 정렬된다.")
+        @Test
+        void getPopularHashtags_SameUsageCount_OrderById() {
+            // given
+            final Member member = new Member("ssaid", "name");
+            entityManager.persist(member);
+
+            final Hashtag hashtag1 = new Hashtag("가나다");
+            final Hashtag hashtag2 = new Hashtag("라마바");
+            entityManager.persist(hashtag1);
+            entityManager.persist(hashtag2);
+
+            final BottariTemplate template = new BottariTemplate("title", "desc", member);
+            entityManager.persist(template);
+
+            // 둘 다 최근 1번씩 사용
+            entityManager.persist(new BottariTemplateHashtag(template, hashtag1));
+            entityManager.persist(new BottariTemplateHashtag(template, hashtag2));
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            final List<HashtagPopularityProjection> popularHashtags = trendingHashtagProvider.getPopularHashtags(5);
+
+            // then
+            assertAll(
+                    () -> assertThat(popularHashtags).hasSize(2),
+                    () -> assertThat(popularHashtags.get(0).getHashtagId())
+                            .isGreaterThan(popularHashtags.get(1).getHashtagId())
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 인기 해시태그 로직을 개선하고, 약간의 리팩터링

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #604 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->

### 주요 변경사항

- 인기 해시태그 집계 기준 변경
    - (AS-IS): 전체 기간의 누적 사용량
    - (TO-BE): 최근 7일간의 사용량을 기준으로 집계하여, 최신 트렌드를 더 정확하게 반영하도록 개선함
- `TrendingHashtagProvider` 계층 도입
    - '인기'를 판단하는 기준(알고리즘)과 데이터 조회 전략을 캡슐화하는 TrendingHashtagProvider를 추가함
    - "어떤 해시태그가 인기 있는가"를 결정하는 정책 로직을 `Service` 계층과 명확히 분리하고, 향후 조회 기준(예: 주간/월간/누적 등) 확장에 유연성을 확보함  
- `HashtagService` 역할 재정의
     - `HashtagService`는 이제 비즈니스 유스케이스 처리, 트랜잭션 관리, 입력값 검증에만 집중함  
     - 실제 데이터 집계 및 조회는 `TrendingHashtagProvider`에 위임하여 역할 책임을 명확히 분리함

### 리팩터링 배경 및 기대효과

'인기'의 기준은 비즈니스 요구사항에 따라 변동될 가능성이 높음
특히, 실 데이터가 부족한 상황에서 어떤 것이 인기인지 정의하기 매우 어려운 상태임
따라서 관련 정책을 Provider에 모아둠으로써, 향후 기준 변경(예: 집계 기간 변경, 가중치 추가)이 필요할 때 수정 범위를 최소화 가능함

Service는 무엇을 할지, Provider는 어떻게 할지에 집중시킴
- Provider는 향후 캐싱, 통계 테이블 조회 등 다양한 데이터 조회 최적화 전략을 독립적으로 발전시킬 수 있음

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- Provider를 인터페이스로 추상화하여 여러 인기 해시태그 조회 전략을 교체할 수 있도록 만드는 방안도 고려했으나, 현재 여러 전략이 공존할 가능성은 낮다고 판단하여, 오버엔지니어링을 피하고자 구체 클래스로 구현했어요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인기 해시태그 조회가 최근 7일 활동 기준으로 필터링되어 더 최신 트렌드를 제공합니다.

* **Refactor**
  * 생성/수정 시간 추적을 공통 기반 클래스로 통합해 일관된 타임스탬프 관리가 적용되었습니다.
  * 해시태그 관련 API가 명확한 이름(getPopularHashtags)으로 정리되었습니다.

* **Tests**
  * 관련 단위/통합 테스트가 갱신 및 추가되어 새로운 필터링 및 정렬 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->