### PR TITLE
[BE] 보따리 템플릿 조회 시 삭제된 템플릿이 조회되는 문제

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateRepository.java
@@ -40,7 +40,8 @@ public interface BottariTemplateRepository extends JpaRepository<BottariTemplate
                            m.name AS memberName
                 FROM bottari_template bt
                 JOIN member m ON m.id = bt.member_id
-                WHERE (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
+                WHERE bt.deleted_at IS NULL 
+                    AND (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
                     AND(
                             bt.created_at < :lastCreatedAt
                                 OR (bt.created_at = :lastCreatedAt AND bt.id < :lastId)
@@ -66,7 +67,8 @@ public interface BottariTemplateRepository extends JpaRepository<BottariTemplate
                   m.name AS memberName
             FROM bottari_template bt
             JOIN member m ON m.id = bt.member_id
-            WHERE (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
+            WHERE bt.deleted_at IS NULL
+                AND (:query = '' OR MATCH(bt.title) AGAINST(:query IN BOOLEAN MODE))
                 AND (
                     bt.taken_count < :lastTakenCount
                         OR (bt.taken_count = :lastTakenCount AND bt.id < :lastId)

--- a/backend/bottari/src/main/java/com/bottari/vo/BottariTitle.java
+++ b/backend/bottari/src/main/java/com/bottari/vo/BottariTitle.java
@@ -3,10 +3,12 @@ package com.bottari.vo;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.support.BadWordValidator;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
 public record BottariTitle(
+        @Column(name = "title")
         String value
 ) {
 

--- a/backend/bottari/src/main/java/com/bottari/vo/ItemName.java
+++ b/backend/bottari/src/main/java/com/bottari/vo/ItemName.java
@@ -3,10 +3,12 @@ package com.bottari.vo;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.support.BadWordValidator;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
 public record ItemName(
+        @Column(name = "name")
         String value
 ) {
 

--- a/backend/bottari/src/main/resources/application-dev.yml
+++ b/backend/bottari/src/main/resources/application-dev.yml
@@ -5,7 +5,7 @@ spring:
     hibernate:
       ddl-auto: update
     defer-datasource-initialization: true
-    open-in-view: true
+    open-in-view: false
     database-platform: org.hibernate.dialect.MySQLDialect
   datasource:
     master:

--- a/backend/bottari/src/main/resources/application-prod.yml
+++ b/backend/bottari/src/main/resources/application-prod.yml
@@ -5,7 +5,7 @@ spring:
     hibernate:
       ddl-auto: validate
     defer-datasource-initialization: true
-    open-in-view: true
+    open-in-view: false
     database-platform: org.hibernate.dialect.MySQLDialect
   datasource:
     master:

--- a/backend/bottari/src/main/resources/application.yml
+++ b/backend/bottari/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     hibernate:
       ddl-auto: create
     defer-datasource-initialization: true
-    open-in-view: true
+    open-in-view: false
     database-platform: org.hibernate.dialect.MySQLDialect
     properties:
       hibernate:


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 보따리 템플릿 조회 시 삭제된 템플릿이 조회되는 문제

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #623

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 보따리 템플릿 조회 시 삭제된 템플릿까지 함께 조회되는 문제가 있었음
- 원인은 `nativeQuery` 에서는 `@SQLRestriction("deleted_at IS NULL")` 이 적용되지 않는다는 점에 있었음
- 이에 따라 native 쿼리에 `deleted_at IS NULL` 조건을 명시적으로 추가하여 문제를 해결함

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

- `nativeQuery` 사용 시 해당 부분 유의해야함 !

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 삭제된 템플릿이 검색 결과에 포함되지 않도록 필터링 강화

* **개선 사항**
  * 엔티티 필드의 DB 매핑 명시로 데이터 일관성 향상
  * JPA 오픈세션인뷰(Open Session in View) 비활성화로 트랜잭션/성능 안정성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->