### PR TITLE
[BE] 보따리 템플릿 설명 빈 값 허용

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplate.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/domain/BottariTemplate.java
@@ -74,8 +74,8 @@ public class BottariTemplate extends BaseTimeEntity {
     }
 
     private void validateDescription(final String description) {
-        if (description.isBlank()) {
-            throw new BusinessException(ErrorCode.BOTTARI_TEMPLATE_DESCRIPTION_BLANK);
+        if (description == null) {
+            throw new BusinessException(ErrorCode.BOTTARI_TEMPLATE_DESCRIPTION_NULL);
         }
         if (description.length() > 30) {
             throw new BusinessException(ErrorCode.BOTTARI_TEMPLATE_DESCRIPTION_TOO_LONG, "최대 30자까지 입력 가능합니다.");

--- a/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
+++ b/backend/bottari/src/main/java/com/bottari/error/ErrorCode.java
@@ -51,7 +51,7 @@ public enum ErrorCode {
     BOTTARI_TEMPLATE_TITLE_BLANK(HttpStatus.BAD_REQUEST, "보따리 템플릿 제목은 공백일 수 없습니다."),
     BOTTARI_TEMPLATE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "보따리 템플릿 제목이 너무 깁니다. 최대 15자까지 입력 가능합니다."),
     BOTTARI_TEMPLATE_TITLE_OFFENSIVE(HttpStatus.BAD_REQUEST, "보따리 템플릿 제목에 비속어를 입력할 수 없습니다."),
-    BOTTARI_TEMPLATE_DESCRIPTION_BLANK(HttpStatus.BAD_REQUEST, "보따리 템플릿 설명은 공백일 수 없습니다."),
+    BOTTARI_TEMPLATE_DESCRIPTION_NULL(HttpStatus.BAD_REQUEST, "보따리 템플릿 설명은 null일 수 없습니다."),
     BOTTARI_TEMPLATE_DESCRIPTION_TOO_LONG(HttpStatus.BAD_REQUEST, "보따리 템플릿 설명이 너무 깁니다."),
     BOTTARI_TEMPLATE_DESCRIPTION_OFFENSIVE(HttpStatus.BAD_REQUEST, "보따리 템플릿 설명에 비속어를 입력할 수 없습니다."),
     BOTTARI_TEMPLATE_INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 보따리 템플릿 정렬 타입입니다."),

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateTest.java
@@ -69,7 +69,7 @@ class BottariTemplateTest {
             // when & then
             assertThatThrownBy(() -> new BottariTemplate("title", null, member))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage("보따리 템플릿 설명은 공백일 수 없습니다.");
+                    .hasMessage("보따리 템플릿 설명은 null일 수 없습니다.");
         }
 
         @DisplayName("보따리 템플릿 설명이 30자를 초과하는 경우, 예외를 던진다.")

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/domain/BottariTemplateTest.java
@@ -7,6 +7,7 @@ import com.bottari.error.BusinessException;
 import com.bottari.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -59,15 +60,14 @@ class BottariTemplateTest {
     @Nested
     class ValidateDescriptionTest {
 
-        @DisplayName("보따리 템플릿 설명이 공백인 경우, 예외를 던진다.")
-        @ParameterizedTest
-        @ValueSource(strings = {"", "   "})
-        void validateDescription_Blank(final String description) {
+        @DisplayName("보따리 템플릿 설명이 null인 경우, 예외를 던진다.")
+        @Test
+        void validateDescription_Null() {
             // given
             final Member member = new Member("ssaid", "name");
 
             // when & then
-            assertThatThrownBy(() -> new BottariTemplate("title", description, member))
+            assertThatThrownBy(() -> new BottariTemplate("title", null, member))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("보따리 템플릿 설명은 공백일 수 없습니다.");
         }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 보따리 템플릿 설명 빈 값 허용

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #633

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 기존) description이 입력되지 않았다면 default 메시지를 클라이언트에서 작성해서 요청하려고 했음
- 그러나, default 메시지가 사용자의 기기에 따라 달라지기 때문에, 템플릿에 빈 값이 존재하는 경우 클라이언트에서 이를 처리하기로 함
- 결국, 빈 값은 허용하고 null 검증만 하도록 변경

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 보따리 템플릿 설명 입력 시 null 값에 대한 오류 처리를 개선했습니다. 이제 null 입력과 공백 입력을 구별하여 더 정확한 오류 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->