### PR TITLE
[BE] SSE 연결을 재수립할 때 새로운 SseEmitter가 등록되지 않고 참조가 사라지는 문제

### DIFF
--- a/backend/sse/src/main/java/com/bottari/sse/sse/SseService.java
+++ b/backend/sse/src/main/java/com/bottari/sse/sse/SseService.java
@@ -16,21 +16,23 @@ public class SseService {
             final SseEmitter sseEmitter
     ) {
         final MemberChannelTopic topic = MemberChannelTopic.from(memberId);
-        sseEmitter.onCompletion(() -> cleanup(topic, memberId));
-        sseEmitter.onTimeout(() -> cleanup(topic, memberId));
-        sseEmitter.onError(t -> cleanup(topic, memberId));
+
+        sseEmitter.onCompletion(() -> cleanUpIfSame(topic, memberId, sseEmitter));
+        sseEmitter.onTimeout(() -> cleanUpIfSame(topic, memberId, sseEmitter));
+        sseEmitter.onError(t -> cleanUpIfSame(topic, memberId, sseEmitter));
+
         sseSessions.save(memberId, sseEmitter);
         subscribeManager.subscribe(topic);
     }
 
-    private void cleanup(
+    private void cleanUpIfSame(
             final MemberChannelTopic topic,
-            final Long memberId
+            final Long memberId,
+            final SseEmitter targetEmitter
     ) {
-        try {
+        final boolean removed = sseSessions.removeIfSame(memberId, targetEmitter);
+        if (removed && sseSessions.findByMemberId(memberId).isEmpty()) {
             subscribeManager.unsubscribe(topic);
-        } finally {
-            sseSessions.remove(memberId);
         }
     }
 }

--- a/backend/sse/src/main/java/com/bottari/sse/sse/SseSessions.java
+++ b/backend/sse/src/main/java/com/bottari/sse/sse/SseSessions.java
@@ -34,15 +34,16 @@ public class SseSessions {
             final Long memberId,
             final SseEmitter sseEmitter
     ) {
-        sseEmittersByMemberId.compute(memberId, (id, existingSseEmitter) -> {
-            if (existingSseEmitter != null) {
-                existingSseEmitter.complete();
-            }
-            return sseEmitter;
-        });
+        final SseEmitter prevSseEmitter = sseEmittersByMemberId.put(memberId, sseEmitter);
+        if (prevSseEmitter != null) {
+            prevSseEmitter.complete();
+        }
     }
 
-    public void remove(final Long memberId) {
-        sseEmittersByMemberId.remove(memberId);
+    public boolean removeIfSame(
+            final Long memberId,
+            final SseEmitter sseEmitter
+    ) {
+        return sseEmittersByMemberId.remove(memberId, sseEmitter);
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- SSE 연결을 재수립할 때 새로운 SseEmitter가 등록되지 않고 참조가 사라지는 문제

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #635 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->

### 문제 원인

- 새로운 `SseEmitter` 등록 시, `SseSessions`에 동일한 `memberId`가 존재하면 기존 `SseEmitter`를 `complete()` 처리한다.
- 기존 `SseEmitter`는 종료 콜백을 통해 아래 `cleanup` 메서드를 실행한다.

````java
private void cleanup(
        final MemberChannelTopic topic,
        final Long memberId
) {
    try {
        subscribeManager.unsubscribe(topic);
    } finally {
        sseSessions.remove(memberId);
    }
}
````

- 그러나 이 종료 콜백은 **비동기(async)** 로 수행되므로,
  - 신규 `SseEmitter` 저장보다 **늦게 실행될 수도 있고**
  - 그 경우 `cleanup()`이 실행되며 **방금 저장한 최신 `SseEmitter`까지 제거되는 문제가 발생**한다.
- 또한 종료된 과거 `SseEmitter`가 먼저 삭제되더라도 `unsubscribe()`가 먼저 수행되면,
  - 세션은 살아 있지만 **토픽 메시지를 수신할 수 없는 상태**가 될 수 있다.



> complete() 호출 스레드와 자원 정리 콜백 메서드 수행 스레드를 각각 로그로 확인한 결과, 아래와 같이 비동기로 수행되는 것을 확인할 수 있었음.
```
complete 호출 thread = Thread-1
callback thread = http-nio-8080-exec-2
 ```



결과적으로,
- 애플리케이션은 최신 `SseEmitter`에 대한 참조를 잃고
- 실제 소켓은 유지되므로 **자원 누수(leak)** 가 발생한다.

---

### 해결 방법

- 종료 콜백 등록 시 **현재 `SseEmitter` 참조를 캡쳐**한다.
- `cleanup()` 수행 시, `SseSessions`에 저장된 `SseEmitter`가 **동일한 객체일 때만 삭제**하도록 변경한다.
- 즉, 참조가 다르면 이미 새로운 `SseEmitter`가 저장된 상태이므로 삭제하지 않는다.

````java
private void cleanUpIfSame(
        final MemberChannelTopic topic,
        final Long memberId,
        final SseEmitter targetEmitter
) {
    final boolean removed = sseSessions.removeIfSame(memberId, targetEmitter);
    if (removed && sseSessions.findByMemberId(memberId).isEmpty()) {
        subscribeManager.unsubscribe(topic);
    }
}
````

---

### 동시성 관점 비교

AS-IS

````java
sseEmittersByMemberId.compute(memberId, (id, existingSseEmitter) -> {
    if (existingSseEmitter != null) {
        existingSseEmitter.complete();
    }
    return sseEmitter;
});
````

TO-BE

````java
final SseEmitter prevSseEmitter = sseEmittersByMemberId.put(memberId, sseEmitter);
if (prevSseEmitter != null) {
    prevSseEmitter.complete();
}
````

- `compute()`는 람다 내부 처리 시간이 길면 **락이 오래 유지될 위험**이 있다.
- `put() → complete()` 구조는 더 단순하고 **동시성 정합성 면에서 안전**하다.

---

### 결론

- 핵심 문제: **비동기 종료 콜백 타이밍으로 인해 최신 `SseEmitter`가 삭제될 수 있음**
- 해결 방법: **참조 동일성 기반 조건 삭제 방식으로 변경**
- 기대 효과
  - 세션 정합성 보장
  - 토픽 구독 유지
  - 자원 누수 방지

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 실시간 연결 종료 시 리소스 정리 로직을 개선했습니다. 마지막 연결이 제거될 때만 구독을 해제하여 더 안정적인 연결 관리를 제공합니다.

* **리팩토링**
  * 조건부 정리 메커니즘으로 변경하여 불필요한 정리 작업을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->