### PR TITLE
[AN] 초대 코드 자동 입력

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariScreen.kt
@@ -89,9 +89,11 @@ fun MyBottariScreen(
         if (uiState.value.showDialogType == MyBottariDialogType.CODE) {
             val clipData = clipboard.nativeClipboard.primaryClip
             clipData?.let { clipData ->
-                val firstItem = clipData.getItemAt(0)
-                val inviteLink = firstItem.text.toString()
-                dialogText = DeeplinkHelper.getInviteCode(inviteLink) ?: ""
+                if (clipData.itemCount > 0) {
+                    val firstItem = clipData.getItemAt(0)
+                    val inviteLink = firstItem.text.toString()
+                    dialogText = DeeplinkHelper.getInviteCode(inviteLink) ?: ""
+                }
             }
         }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.Lifecycle

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.Lifecycle
@@ -17,6 +19,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bottari.presentation.R
+import com.bottari.presentation.util.DeeplinkHelper
 
 @Composable
 fun MyBottariScreen(
@@ -48,6 +51,7 @@ fun MyBottariScreen(
     val uiEvent = viewModel.uiEvent.collectAsStateWithLifecycle(null)
 
     val context = LocalContext.current
+    val clipboard = LocalClipboard.current
 
     var dialogText by rememberSaveable { mutableStateOf("") }
 
@@ -79,6 +83,17 @@ fun MyBottariScreen(
 
             is MyBottariUiEvent.CreateTeamBottariSuccess ->
                 onNavigateToTeamEdit(event.bottariId, true)
+        }
+    }
+
+    LaunchedEffect(uiState.value.showDialogType) {
+        if (uiState.value.showDialogType == MyBottariDialogType.CODE) {
+            val clipData = clipboard.nativeClipboard.primaryClip
+            clipData?.let { clipData ->
+                val firstItem = clipData.getItemAt(0)
+                val inviteLink = firstItem.text.toString()
+                dialogText = DeeplinkHelper.getInviteCode(inviteLink) ?: ""
+            }
         }
     }
 


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 초대 코드 자동 입력

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #650 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 초대 코드 입력 다이얼로그 출력 시 클립보드에서 자동으로 초대 코드 분리 후 입력

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
| Before | After |
|--------|-------|
| (이전 화면) | (변경된 화면) |

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앱의 초대 코드 입력 다이얼로그가 클립보드를 자동 검사하여 초대 코드를 감지하면 해당 값으로 입력 필드가 자동 채워집니다. 사용자는 복사한 초대 코드를 별도 붙여넣기 없이 빠르게 적용할 수 있어 초대 수락 흐름이 간편해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->