### PR TITLE
[BE] 팀 보따리 탈퇴 아이템 수정 관련 버그

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamAssignedItemRepository.java
@@ -39,7 +39,12 @@ public interface TeamAssignedItemRepository extends JpaRepository<TeamAssignedIt
             """)
     List<TeamAssignedItem> findAllByTeamMemberId(final Long teamMemberId);
 
-    void deleteAllByInfo(final TeamAssignedItemInfo teamAssignedItemInfo);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = """
+            DELETE FROM team_assigned_item
+            WHERE team_assigned_item_info_id = :teamAssignedItemInfoId
+            """, nativeQuery = true)
+    void deleteAllByInfo(final Long teamAssignedItemInfoId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""

--- a/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/repository/TeamSharedItemRepository.java
@@ -39,7 +39,12 @@ public interface TeamSharedItemRepository extends JpaRepository<TeamSharedItem, 
             """)
     List<TeamSharedItem> findAllByTeamMemberId(final Long teamMemberId);
 
-    void deleteAllByInfo(final TeamSharedItemInfo teamSharedItemInfo);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = """
+            DELETE FROM team_shared_item
+            WHERE team_shared_item_info_id = :teamSharedItemInfoId
+            """, nativeQuery = true)
+    void deleteAllByInfo(final Long teamSharedItemInfoId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamAssignedItemService.java
@@ -107,7 +107,7 @@ public class TeamAssignedItemService {
         final TeamAssignedItemInfo teamAssignedItemInfo = teamAssignedItemInfoRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NOT_FOUND, "담당"));
         validateMemberInTeam(teamAssignedItemInfo.getTeamBottari().getId(), ssaid);
-        teamAssignedItemRepository.deleteAllByInfo(teamAssignedItemInfo);
+        teamAssignedItemRepository.deleteAllByInfo(teamAssignedItemInfo.getId());
         teamAssignedItemInfoRepository.delete(teamAssignedItemInfo);
         publishDeleteEvent(id, teamAssignedItemInfo);
     }

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamSharedItemService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamSharedItemService.java
@@ -78,7 +78,7 @@ public class TeamSharedItemService {
         final TeamSharedItemInfo teamSharedItemInfo = teamSharedItemInfoRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_BOTTARI_ITEM_NOT_FOUND, "공통"));
         validateMemberInTeam(teamSharedItemInfo.getTeamBottari().getId(), ssaid);
-        teamSharedItemRepository.deleteAllByInfo(teamSharedItemInfo);
+        teamSharedItemRepository.deleteAllByInfo(teamSharedItemInfo.getId());
         teamSharedItemInfoRepository.delete(teamSharedItemInfo);
         publishDeleteInfoEvent(teamSharedItemInfo);
     }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- 팀 보따리 탈퇴 후, 탈퇴한 인원이 만든 공통, 담당 물품을 남아있는 인원이 지울 수 없는 버그 해결

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #657 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
## 🧩 문제 상황

팀 보따리에서 팀원이 나갈 때, 해당 인원의 담당/공통 물품은 Soft Delete(deleted_at 설정)로 처리함.

이후 남아 있는 팀원이 담당 물품 또는 공통 물품을 삭제할 경우, 관련된 team_shared_item, team_assigned_item을 모두 삭제하고
마지막으로 team_shared_item_info를 삭제하도록 동작함.

하지만 @SQLRestriction("deleted_at IS NULL")로 인해 Soft Delete된 아이템은 JPQL 삭제 대상에서 제외됨.

그 결과, Soft Delete된 아이템이 DB에 남아 있어 외래키 제약(FK constraint) 으로 인해 team_shared_item_info 삭제 시 오류가 발생함.

## ⚙️ 원인

@SQLRestriction("deleted_at IS NULL")은 모든 JPQL 쿼리에 자동으로 적용됨.
→ Soft Delete된 데이터가 항상 쿼리 대상에서 제외됨.

따라서 “하드 삭제”를 수행해야 하는 상황에서도 Soft Delete된 row가 필터링되어 실제로는 삭제되지 않음.

## ✅ 해결 내용

아이템 삭제 시, Soft Delete된 데이터도 함께 Hard Delete 되도록 수정.

team_shared_item, team_assigned_item 삭제 시 deleted_at IS NULL 조건을 우회하기 위해 Native Query를 사용하여 관련된 모든 row(deleted_at 여부 무관)를 완전히 삭제하도록 변경.


<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 데이터 삭제 작업의 성능을 최적화했습니다. 내부 데이터베이스 쿼리 처리 방식을 개선하여 시스템 안정성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->