### PR TITLE
[AN] 강제 업데이트 다이얼로그가 가려지는 문제 수정

### DIFF
--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainActivity.kt
@@ -11,7 +11,6 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.bottari.logger.BottariLogger
 import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseActivity
 import com.bottari.presentation.common.extension.showSnackbar

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainActivity.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainActivity.kt
@@ -8,6 +8,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.bottari.logger.BottariLogger
 import com.bottari.presentation.R
 import com.bottari.presentation.common.base.BaseActivity
 import com.bottari.presentation.common.extension.showSnackbar
@@ -25,6 +29,7 @@ import com.bottari.presentation.view.common.alert.DialogListener
 import com.bottari.presentation.view.common.alert.DialogPresetType
 import com.bottari.presentation.view.invite.InviteActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::inflate) {
@@ -37,9 +42,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen().apply {
-            setKeepOnScreenCondition {
-                viewModel.uiState.value?.isReady == false
-            }
+            setKeepOnScreenCondition { !viewModel.uiState.value.isReady }
         }
         super.onCreate(savedInstanceState)
         setupObserver()
@@ -54,17 +57,21 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     }
 
     private fun setupObserver() {
-        viewModel.uiEvent.observe(this) { uiEvent ->
-            when (uiEvent) {
-                is MainUiEvent.LoginSuccess -> checkPermissionAndNavigate(uiEvent.permissionFlag)
-                MainUiEvent.IncompletePermissionFlow -> showPermissionDescriptionDialog()
-                MainUiEvent.ForceUpdate -> showForceUpdateDialog()
-                MainUiEvent.RegisterFailure,
-                MainUiEvent.LoginFailure,
-                MainUiEvent.GetPermissionFlagFailure,
-                MainUiEvent.SavePermissionFlagFailure,
-                -> finishAffinity()
-            }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) { viewModel.uiEvent.collect(::handleUiEvent) }
+        }
+    }
+
+    private fun handleUiEvent(uiEvent: MainUiEvent) {
+        when (uiEvent) {
+            is MainUiEvent.LoginSuccess -> checkPermissionAndNavigate(uiEvent.permissionFlag)
+            MainUiEvent.IncompletePermissionFlow -> showPermissionDescriptionDialog()
+            MainUiEvent.ForceUpdate -> showForceUpdateDialog()
+            MainUiEvent.RegisterFailure,
+            MainUiEvent.LoginFailure,
+            MainUiEvent.GetPermissionFlagFailure,
+            MainUiEvent.SavePermissionFlagFailure,
+            -> finishAffinity()
         }
     }
 
@@ -144,6 +151,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     private fun launchPlayStore() {
         val intent = Intent(Intent.ACTION_VIEW)
         intent.data = "market://details?id=$packageName".toUri()
+        intent.`package` = "com.android.vending"
         startActivity(intent)
         finishAffinity()
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainUiState.kt
@@ -1,7 +1,6 @@
 package com.bottari.presentation.view.main
 
 data class MainUiState(
-    val isLoading: Boolean = false,
     val hasPermissionFlag: Boolean = false,
     val isReady: Boolean = false,
 )

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
@@ -38,7 +38,7 @@ class MainViewModel @Inject constructor(
     fun checkRegisteredMember() {
         launch {
             checkRegisteredMemberUseCase()
-                .onSuccess { result -> handleCheckRegistrationResult(result) }
+                .onSuccess(::handleCheckRegistrationResult)
                 .onFailure { emitEvent(MainUiEvent.LoginFailure) }
         }
     }
@@ -53,18 +53,19 @@ class MainViewModel @Inject constructor(
             checkForceUpdateUseCase(BuildConfig.APP_VERSION_CODE)
                 .onSuccess { isForceUpdate ->
                     if (isForceUpdate) {
+                        updateState { copy(isReady = true) }
                         emitEvent(MainUiEvent.ForceUpdate)
                         return@onSuccess
                     }
                     checkPermissionFlag()
                 }.onFailure { exception -> BottariLogger.error(exception.message, exception) }
-        }.invokeOnCompletion { updateState { copy(isReady = true) } }
+        }
     }
 
     private fun checkPermissionFlag() {
         launch {
             getPermissionFlagUseCase()
-                .onSuccess { flag -> handlePermissionFlag(flag) }
+                .onSuccess(::handlePermissionFlag)
                 .onFailure { emitEvent(MainUiEvent.GetPermissionFlagFailure) }
         }
     }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
@@ -44,10 +44,10 @@ class MainViewModel @Inject constructor(
     }
 
     private fun checkForceUpdate() {
-//        if (BuildConfig.DEBUG) {
-//            checkPermissionFlag()
-//            return
-//        }
+        if (BuildConfig.DEBUG) {
+            checkPermissionFlag()
+            return
+        }
 
         launch {
             checkForceUpdateUseCase(BuildConfig.APP_VERSION_CODE)

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
@@ -9,7 +9,7 @@ import com.bottari.domain.usecase.member.CheckRegisteredMemberUseCase
 import com.bottari.domain.usecase.member.RegisterMemberUseCase
 import com.bottari.logger.BottariLogger
 import com.bottari.presentation.BuildConfig
-import com.bottari.presentation.common.base.BaseViewModel
+import com.bottari.presentation.common.base.FlowBaseViewModel
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.tasks.await
@@ -23,19 +23,9 @@ class MainViewModel @Inject constructor(
     private val saveFcmTokenUseCase: SaveFcmTokenUseCase,
     private val getPermissionFlagUseCase: GetPermissionFlagUseCase,
     private val checkForceUpdateUseCase: CheckForceUpdateUseCase,
-) : BaseViewModel<MainUiState, MainUiEvent>(MainUiState()) {
+) : FlowBaseViewModel<MainUiState, MainUiEvent>(MainUiState()) {
     init {
         checkForceUpdate()
-    }
-
-    fun checkRegisteredMember() {
-        updateState { copy(isLoading = true) }
-
-        launch {
-            checkRegisteredMemberUseCase()
-                .onSuccess { result -> handleCheckRegistrationResult(result) }
-                .onFailure { emitEvent(MainUiEvent.LoginFailure) }
-        }
     }
 
     fun savePermissionFlag() {
@@ -45,64 +35,90 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun checkRegisteredMember() {
+        launch {
+            checkRegisteredMemberUseCase()
+                .onSuccess { result -> handleCheckRegistrationResult(result) }
+                .onFailure { emitEvent(MainUiEvent.LoginFailure) }
+        }
+    }
+
+    private fun checkForceUpdate() {
+//        if (BuildConfig.DEBUG) {
+//            checkPermissionFlag()
+//            return
+//        }
+
+        launch {
+            checkForceUpdateUseCase(BuildConfig.APP_VERSION_CODE)
+                .onSuccess { isForceUpdate ->
+                    if (isForceUpdate) {
+                        emitEvent(MainUiEvent.ForceUpdate)
+                        return@onSuccess
+                    }
+                    checkPermissionFlag()
+                }.onFailure { exception -> BottariLogger.error(exception.message, exception) }
+        }.invokeOnCompletion { updateState { copy(isReady = true) } }
+    }
+
     private fun checkPermissionFlag() {
         launch {
             getPermissionFlagUseCase()
-                .onSuccess { permissionFlag -> handlePermissionFlag(permissionFlag) }
+                .onSuccess { flag -> handlePermissionFlag(flag) }
                 .onFailure { emitEvent(MainUiEvent.GetPermissionFlagFailure) }
         }
     }
 
-    private fun handleCheckRegistrationResult(result: RegisteredMember) {
-        if (result.isRegistered) return saveFcmToken()
-        registerMember()
-    }
-
     private fun handlePermissionFlag(permissionFlag: Boolean) {
         updateState { copy(hasPermissionFlag = permissionFlag) }
+
         if (!permissionFlag) {
             updateState { copy(isReady = true) }
             emitEvent(MainUiEvent.IncompletePermissionFlow)
             return
         }
+
         checkRegisteredMember()
+    }
+
+    private fun handleCheckRegistrationResult(result: RegisteredMember) {
+        if (result.isRegistered) {
+            saveFcmToken()
+            return
+        }
+        registerMember()
     }
 
     private fun registerMember() {
         launch {
-            val fcmToken = FirebaseMessaging.getInstance().token.await()
+            val fcmToken = fetchFcmToken()
+            if (fcmToken == null) {
+                emitEvent(MainUiEvent.RegisterFailure)
+                return@launch
+            }
+
             registerMemberUseCase(fcmToken)
+                .onSuccess { onLoginReady() }
                 .onFailure { emitEvent(MainUiEvent.RegisterFailure) }
-                .onSuccess {
-                    updateState { copy(isLoading = false, isReady = true) }
-                    emitEvent(MainUiEvent.LoginSuccess(currentState.hasPermissionFlag))
-                }
         }
     }
 
     private fun saveFcmToken() {
         launch {
-            val fcmToken = FirebaseMessaging.getInstance().token.await()
-            saveFcmTokenUseCase(fcmToken)
-                .onFailure { exception -> BottariLogger.error(exception.message, exception) }
-
-            updateState { copy(isLoading = false, isReady = true) }
-            emitEvent(MainUiEvent.LoginSuccess(currentState.hasPermissionFlag))
-        }
+            fetchFcmToken()?.let { fcmToken ->
+                saveFcmTokenUseCase(fcmToken)
+                    .onFailure { exception -> BottariLogger.error(exception.message, exception) }
+            }
+        }.invokeOnCompletion { onLoginReady() }
     }
 
-    private fun checkForceUpdate() {
-        if (BuildConfig.DEBUG) return checkPermissionFlag()
-        updateState { copy(isLoading = true) }
-
-        launch {
-            checkForceUpdateUseCase(BuildConfig.APP_VERSION_CODE)
-                .onSuccess { isForceUpdate ->
-                    if (isForceUpdate) return@onSuccess emitEvent(MainUiEvent.ForceUpdate)
-                    checkPermissionFlag()
-                }.onFailure { exception -> BottariLogger.error(exception.message, exception) }
-
-            updateState { copy(isLoading = false) }
-        }
+    private fun onLoginReady() {
+        updateState { copy(isReady = true) }
+        emitEvent(MainUiEvent.LoginSuccess(currentState.hasPermissionFlag))
     }
+
+    private suspend fun fetchFcmToken(): String? =
+        runCatching { FirebaseMessaging.getInstance().token.await() }
+            .onFailure { exception -> BottariLogger.error(exception.message, exception) }
+            .getOrNull()
 }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- Flow 기반으로 변경
- 강제 업데이트가 필요한 경우 Splash 화면을 종료하도록 변경
- 스토어를 플레이 스토어로 타겟팅

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #649 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
### Flow 기반으로 변경
MainActivity, MainViewModel Flow 기반으로 마이그레이션

### 문제 해결
강제 업데이트 다이얼로그가 Splash 화면에 가려지는 문제가 있었는데,
강제 업데이트가 필요한 경우 Splash 화면을 종료하도록 변경하였습니다.

### 플레이스토어 타겟팅
package를 추가하여 플레이스토어만 타겟팅 되도록 하였습니다.
```kotlin
// 이전
intent.data = "market://details?id=$packageName".toUri()

// 이후
intent.data = "market://details?id=$packageName".toUri()
intent.`package` = "com.android.vending"
```




<br>

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * UI 이벤트 처리 비동기화 — 앱 상태 수집 방식 개선으로 화면 반응성 향상
  * 로그인·등록 흐름 및 푸시 토큰 처리 개선 — 인증 준비 상태와 재시도 안정성 증가
  * 수명주기 기반 실행 보강 — 리소스 안전성 개선
  * Google Play 스토어 연결 강화 — 스토어로 직접 이동

* **변경 사항**
  * UI 상태 단순화 — 불필요한 로딩 플래그 제거로 상태 관리 간소화

* **신규 기능**
  * 권한 저장 기능 추가 — 사용자 권한 선택을 앱에 저장하여 재사용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->