### PR TITLE
[BE] 인기 해시태그 기능 캐싱 적용

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/alarm/controller/AlarmController.java
+++ b/backend/bottari/src/main/java/com/bottari/alarm/controller/AlarmController.java
@@ -1,8 +1,8 @@
 package com.bottari.alarm.controller;
 
-import com.bottari.alarm.service.AlarmService;
 import com.bottari.alarm.dto.CreateAlarmRequest;
 import com.bottari.alarm.dto.UpdateAlarmRequest;
+import com.bottari.alarm.service.AlarmService;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/backend/bottari/src/main/java/com/bottari/alarm/dto/AlarmResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/alarm/dto/AlarmResponse.java
@@ -2,8 +2,8 @@ package com.bottari.alarm.dto;
 
 import com.bottari.alarm.domain.Alarm;
 import com.bottari.alarm.domain.LocationAlarm;
-import com.bottari.alarm.domain.RoutineAlarm;
 import com.bottari.alarm.domain.RepeatType;
+import com.bottari.alarm.domain.RoutineAlarm;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/backend/bottari/src/main/java/com/bottari/alarm/dto/CreateAlarmRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/alarm/dto/CreateAlarmRequest.java
@@ -1,8 +1,8 @@
 package com.bottari.alarm.dto;
 
 import com.bottari.alarm.domain.LocationAlarm;
-import com.bottari.alarm.domain.RoutineAlarm;
 import com.bottari.alarm.domain.RepeatType;
+import com.bottari.alarm.domain.RoutineAlarm;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/backend/bottari/src/main/java/com/bottari/alarm/dto/UpdateAlarmRequest.java
+++ b/backend/bottari/src/main/java/com/bottari/alarm/dto/UpdateAlarmRequest.java
@@ -1,8 +1,8 @@
 package com.bottari.alarm.dto;
 
 import com.bottari.alarm.domain.LocationAlarm;
-import com.bottari.alarm.domain.RoutineAlarm;
 import com.bottari.alarm.domain.RepeatType;
+import com.bottari.alarm.domain.RoutineAlarm;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/backend/bottari/src/main/java/com/bottari/alarm/service/AlarmService.java
+++ b/backend/bottari/src/main/java/com/bottari/alarm/service/AlarmService.java
@@ -1,13 +1,13 @@
 package com.bottari.alarm.service;
 
 import com.bottari.alarm.domain.Alarm;
-import com.bottari.alarm.repository.AlarmRepository;
-import com.bottari.bottari.domain.Bottari;
 import com.bottari.alarm.dto.CreateAlarmRequest;
 import com.bottari.alarm.dto.UpdateAlarmRequest;
+import com.bottari.alarm.repository.AlarmRepository;
+import com.bottari.bottari.domain.Bottari;
+import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
-import com.bottari.bottari.repository.BottariRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend/bottari/src/main/java/com/bottari/bottari/service/BottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/bottari/service/BottariService.java
@@ -1,19 +1,19 @@
 package com.bottari.bottari.service;
 
 import com.bottari.alarm.domain.Alarm;
+import com.bottari.alarm.dto.AlarmResponse;
+import com.bottari.alarm.repository.AlarmRepository;
 import com.bottari.bottari.domain.Bottari;
 import com.bottari.bottari.domain.BottariItem;
-import com.bottari.bottari.repository.BottariItemRepository;
-import com.bottari.bottari.repository.BottariRepository;
-import com.bottari.member.domain.Member;
-import com.bottari.alarm.dto.AlarmResponse;
 import com.bottari.bottari.dto.CreateBottariRequest;
 import com.bottari.bottari.dto.ReadBottariPreviewResponse;
 import com.bottari.bottari.dto.ReadBottariResponse;
 import com.bottari.bottari.dto.UpdateBottariRequest;
+import com.bottari.bottari.repository.BottariItemRepository;
+import com.bottari.bottari.repository.BottariRepository;
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
-import com.bottari.alarm.repository.AlarmRepository;
+import com.bottari.member.domain.Member;
 import com.bottari.member.repository.MemberRepository;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadHashtagWithUsageCountResponse.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/dto/ReadHashtagWithUsageCountResponse.java
@@ -5,16 +5,16 @@ import com.bottari.bottaritemplate.repository.dto.HashtagPopularityProjection;
 public record ReadHashtagWithUsageCountResponse(
         Long id,
         String name,
-        int usageCount
+        Long usageCount
 ) {
 
     public static ReadHashtagWithUsageCountResponse of(
             final HashtagPopularityProjection projection
     ) {
         return new ReadHashtagWithUsageCountResponse(
-                projection.getHashtagId(),
-                projection.getHashtagName(),
-                projection.getUsageCount()
+                projection.hashtagId(),
+                projection.hashtagName(),
+                projection.usageCount()
         );
     }
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateHashtagRepository.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/BottariTemplateHashtagRepository.java
@@ -84,19 +84,19 @@ public interface BottariTemplateHashtagRepository extends JpaRepository<BottariT
             final Pageable pageable
     );
 
-    @Query(value = """
-            SELECT
-                h.id AS hashtagId,
-                h.name AS hashtagName,
-                COUNT(bth.id) AS usageCount
-            FROM hashtag h
-            INNER JOIN bottari_template_hashtag bth ON bth.hashtag_id = h.id
-            WHERE bth.deleted_at IS NULL
-              AND bth.created_at >= :since
+    @Query("""
+            SELECT new com.bottari.bottaritemplate.repository.dto.HashtagPopularityProjection(
+                h.id,
+                h.name,
+                COUNT(bth.id)
+            )
+            FROM Hashtag h
+            INNER JOIN BottariTemplateHashtag bth ON bth.hashtag.id = h.id
+            WHERE bth.deletedAt IS NULL
+              AND bth.createdAt >= :since
             GROUP BY h.id, h.name
-            ORDER BY usageCount DESC, h.id DESC
-            LIMIT :limit
-            """, nativeQuery = true)
+            ORDER BY COUNT(bth.id) DESC, h.id DESC
+            """)
     List<HashtagPopularityProjection> findTopNByUsageCountSince(
             final LocalDateTime since,
             final int limit

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/dto/HashtagPopularityProjection.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/repository/dto/HashtagPopularityProjection.java
@@ -1,10 +1,8 @@
 package com.bottari.bottaritemplate.repository.dto;
 
-public interface HashtagPopularityProjection {
-
-    Long getHashtagId();
-
-    String getHashtagName();
-
-    Integer getUsageCount();
+public record HashtagPopularityProjection(
+        Long hashtagId,
+        String hashtagName,
+        Long usageCount
+) {
 }

--- a/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/TrendingHashtagProvider.java
+++ b/backend/bottari/src/main/java/com/bottari/bottaritemplate/service/TrendingHashtagProvider.java
@@ -5,6 +5,7 @@ import com.bottari.bottaritemplate.repository.dto.HashtagPopularityProjection;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,6 +16,7 @@ public class TrendingHashtagProvider {
 
     private final BottariTemplateHashtagRepository bottariTemplateHashtagRepository;
 
+    @Cacheable(value = "popularHashtags", key = "'limit:' + #limit")
     public List<HashtagPopularityProjection> getPopularHashtags(final int limit) {
         final LocalDateTime since = calculateSince();
 

--- a/backend/bottari/src/main/java/com/bottari/config/CacheConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/CacheConfig.java
@@ -16,7 +16,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class CacheConfig {
 
     @Bean
-    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+    public RedisCacheManager cacheManager(final RedisConnectionFactory connectionFactory) {
         final RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))

--- a/backend/bottari/src/main/java/com/bottari/config/CacheConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/CacheConfig.java
@@ -1,0 +1,30 @@
+package com.bottari.config;
+
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        final RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(30))
+                .disableCachingNullValues();
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/backend/bottari/src/main/java/com/bottari/config/datasource/RoutingDataSourceConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/datasource/RoutingDataSourceConfig.java
@@ -4,7 +4,6 @@ import com.zaxxer.hikari.HikariDataSource;
 import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;

--- a/backend/bottari/src/main/java/com/bottari/error/GlobalExceptionHandler.java
+++ b/backend/bottari/src/main/java/com/bottari/error/GlobalExceptionHandler.java
@@ -1,8 +1,8 @@
 package com.bottari.error;
 
-import com.bottari.log.entry.ExceptionLogEntry;
 import com.bottari.log.LogFormatter;
 import com.bottari.log.entry.BusinessExceptionLogEntry;
+import com.bottari.log.entry.ExceptionLogEntry;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/backend/bottari/src/main/java/com/bottari/member/service/MemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/member/service/MemberService.java
@@ -2,13 +2,13 @@ package com.bottari.member.service;
 
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
-import com.bottari.push.notification.fcm.domain.FcmToken;
-import com.bottari.push.notification.fcm.repository.FcmTokenRepository;
 import com.bottari.member.domain.Member;
 import com.bottari.member.dto.CheckRegistrationResponse;
 import com.bottari.member.dto.CreateMemberRequest;
 import com.bottari.member.dto.UpdateMemberRequest;
 import com.bottari.member.repository.MemberRepository;
+import com.bottari.push.notification.fcm.domain.FcmToken;
+import com.bottari.push.notification.fcm.repository.FcmTokenRepository;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;

--- a/backend/bottari/src/main/java/com/bottari/push/notification/fcm/service/FcmChannel.java
+++ b/backend/bottari/src/main/java/com/bottari/push/notification/fcm/service/FcmChannel.java
@@ -6,9 +6,9 @@ import static com.bottari.error.ErrorCode.FCM_MESSAGE_SEND_FAIL;
 
 import com.bottari.error.BusinessException;
 import com.bottari.push.ChannelType;
+import com.bottari.push.message.PushMessage;
 import com.bottari.push.notification.NotificationChannel;
 import com.bottari.push.notification.fcm.domain.FcmToken;
-import com.bottari.push.message.PushMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.messaging.FirebaseMessaging;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/adapter/TeamBottariMessageConverter.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/adapter/TeamBottariMessageConverter.java
@@ -7,7 +7,6 @@ import com.bottari.push.message.MessageResourceType;
 import com.bottari.push.message.PushMessage;
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;
 import com.bottari.teambottari.domain.TeamBottari;
-import com.bottari.teambottari.domain.TeamMember;
 import com.bottari.teambottari.domain.TeamSharedItemInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamPersonalItem.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/domain/TeamPersonalItem.java
@@ -2,8 +2,8 @@ package com.bottari.teambottari.domain;
 
 import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
-import jakarta.persistence.Column;
 import com.bottari.vo.ItemName;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamBottariService.java
@@ -4,8 +4,6 @@ import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.member.domain.Member;
 import com.bottari.member.repository.MemberRepository;
-import com.bottari.push.PushManager;
-import com.bottari.teambottari.adapter.TeamBottariMessageConverter;
 import com.bottari.teambottari.domain.InviteCodeGenerator;
 import com.bottari.teambottari.domain.TeamAssignedItem;
 import com.bottari.teambottari.domain.TeamAssignedItemInfo;

--- a/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
+++ b/backend/bottari/src/main/java/com/bottari/teambottari/service/TeamMemberService.java
@@ -4,7 +4,6 @@ import com.bottari.error.BusinessException;
 import com.bottari.error.ErrorCode;
 import com.bottari.member.domain.Member;
 import com.bottari.member.repository.MemberRepository;
-import com.bottari.push.ChannelType;
 import com.bottari.push.PushManager;
 import com.bottari.push.message.MessageEventType;
 import com.bottari.push.message.MessageResourceType;

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/HashtagControllerTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/controller/HashtagControllerTest.java
@@ -36,9 +36,9 @@ class HashtagControllerTest {
     void readPopularHashtags() throws Exception {
         // given
         final List<ReadHashtagWithUsageCountResponse> responses = List.of(
-                new ReadHashtagWithUsageCountResponse(1L, "여행", 42),
-                new ReadHashtagWithUsageCountResponse(2L, "캠핑", 35),
-                new ReadHashtagWithUsageCountResponse(3L, "등산", 28)
+                new ReadHashtagWithUsageCountResponse(1L, "여행", 42L),
+                new ReadHashtagWithUsageCountResponse(2L, "캠핑", 35L),
+                new ReadHashtagWithUsageCountResponse(3L, "등산", 28L)
         );
         given(hashtagService.getPopularHashtags(10))
                 .willReturn(responses);
@@ -55,7 +55,7 @@ class HashtagControllerTest {
     void readPopularHashtags_DefaultLimit() throws Exception {
         // given
         final List<ReadHashtagWithUsageCountResponse> responses = List.of(
-                new ReadHashtagWithUsageCountResponse(1L, "여행", 42)
+                new ReadHashtagWithUsageCountResponse(1L, "여행", 42L)
         );
         given(hashtagService.getPopularHashtags(10))
                 .willReturn(responses);
@@ -71,8 +71,8 @@ class HashtagControllerTest {
     void readPopularHashtags_WithLimit() throws Exception {
         // given
         final List<ReadHashtagWithUsageCountResponse> responses = List.of(
-                new ReadHashtagWithUsageCountResponse(1L, "여행", 42),
-                new ReadHashtagWithUsageCountResponse(2L, "캠핑", 35)
+                new ReadHashtagWithUsageCountResponse(1L, "여행", 42L),
+                new ReadHashtagWithUsageCountResponse(2L, "캠핑", 35L)
         );
         given(hashtagService.getPopularHashtags(2))
                 .willReturn(responses);

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/HashtagServiceTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/HashtagServiceTest.java
@@ -39,14 +39,14 @@ class HashtagServiceTest {
             // given
             final int limit = 10;
             final HashtagPopularityProjection projection1 = mock(HashtagPopularityProjection.class);
-            given(projection1.getHashtagId()).willReturn(1L);
-            given(projection1.getHashtagName()).willReturn("여행");
-            given(projection1.getUsageCount()).willReturn(100);
+            given(projection1.hashtagId()).willReturn(1L);
+            given(projection1.hashtagName()).willReturn("여행");
+            given(projection1.usageCount()).willReturn(100L);
 
             final HashtagPopularityProjection projection2 = mock(HashtagPopularityProjection.class);
-            given(projection2.getHashtagId()).willReturn(2L);
-            given(projection2.getHashtagName()).willReturn("캠핑");
-            given(projection2.getUsageCount()).willReturn(50);
+            given(projection2.hashtagId()).willReturn(2L);
+            given(projection2.hashtagName()).willReturn("캠핑");
+            given(projection2.usageCount()).willReturn(50L);
 
             given(trendingHashtagProvider.getPopularHashtags(limit))
                     .willReturn(List.of(projection1, projection2));

--- a/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/TrendingHashtagProviderTest.java
+++ b/backend/bottari/src/test/java/com/bottari/bottaritemplate/service/TrendingHashtagProviderTest.java
@@ -82,10 +82,10 @@ class TrendingHashtagProviderTest {
             // then
             assertAll(
                     () -> assertThat(popularHashtags).hasSize(2),
-                    () -> assertThat(popularHashtags.get(0).getHashtagName()).isEqualTo("최신인기"),
-                    () -> assertThat(popularHashtags.get(0).getUsageCount()).isEqualTo(2),
-                    () -> assertThat(popularHashtags.get(1).getHashtagName()).isEqualTo("인기"),
-                    () -> assertThat(popularHashtags.get(1).getUsageCount()).isEqualTo(1)
+                    () -> assertThat(popularHashtags.get(0).hashtagName()).isEqualTo("최신인기"),
+                    () -> assertThat(popularHashtags.get(0).usageCount()).isEqualTo(2),
+                    () -> assertThat(popularHashtags.get(1).hashtagName()).isEqualTo("인기"),
+                    () -> assertThat(popularHashtags.get(1).usageCount()).isEqualTo(1)
             );
         }
 
@@ -117,8 +117,8 @@ class TrendingHashtagProviderTest {
             // then
             assertAll(
                     () -> assertThat(popularHashtags).hasSize(2),
-                    () -> assertThat(popularHashtags.get(0).getHashtagId())
-                            .isGreaterThan(popularHashtags.get(1).getHashtagId())
+                    () -> assertThat(popularHashtags.get(0).hashtagId())
+                            .isGreaterThan(popularHashtags.get(1).hashtagId())
             );
         }
     }


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요

- 인기 해시태그 조회 API에 Redis 캐싱을 적용하여 반복 조회 시 불필요한 DB 접근을 줄이고 응답 속도를 개선함
    - 더 좋은 아이디어나 개선 방향 보이면 리뷰 부탁 [변경 커밋](https://github.com/woowacourse-teams/2025-bottari/pull/665/files/8d2388498667a09b9ea290c890d0337ed4db9b84..6ceeb629bdc70277816e7340e668973f2ca72f1d)

<br>

## 🎯 관련 이슈
- Closed #614 
    - 이슈 댓글에 실험 자료들 올려둠

<br>

## 다른 방법은?

집계 테이블 대신 캐시를 우선 적용한 이유는...

- 병목 구간이 명확
    - 이전 부하 테스트에서 주요 병목이 DB에 집중되는 것을 확인함
    - 따라서 쿼리 실행 자체를 줄이는 것이 가장 직접적인 성능 개선 방법이라고 판단함
- 적용과 실험이 쉬운편
    - 통계 테이블을 도입하려면 스키마 변경과 마이그레이션이 필요하지만, 캐시는 기존 구조를 그대로 유지한 채 실험적으로 도입할 수 있었음 (이미 Redis를 사용하고 있었기 때문)

결론적으로, 이번 변경은 DB에 집중된 부하를 분산시키기 위한 선택이었습니다.


## 🔍 변경 내용

- 기존 pub/sub 용 Redis 인스턴스를 캐시 저장소로 재활용
- `@Cacheable` 어노테이션을 이용한 캐시 적용 (`TrendingHashtagProvider`)
- `RedisCacheManager` 설정 추가 (`CacheConfig`)
  - JSON 직렬화(`GenericJackson2JsonRedisSerializer`) 기반 저장
  - 기본 TTL 30분 설정
- 기존 인터페이스 기반 Projection을 `record` DTO로 변경하여 직렬화 호환성 개선

<br>

## 💬 기타 참고사항

- 추가적으로 필요한 부분은 코멘트로 남겨둘게
- Redis 부하나 메모리 사용량은 현재 테스트 기준으로 문제가 없는 수준임
- 머지되면 이전 부하테스트와 동일한 환경으로 해보면 좋을 듯 (AWS 인스턴스에서)

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 트렌딩 해시태그 조회에 Redis 기반 캐시 추가(기본 TTL 30분)

* **Refactor**
  * 해시태그 인기 집계 프로젝션을 인터페이스→레코드로 변경하고 usageCount 타입을 int→Long으로 변경
  * 집계 쿼리를 JPQL로 전환하여 매핑 및 정렬 개선

* **Chores**
  * 내부 임포트 정렬 및 미사용 임포트 정리

* **Tests**
  * 변경된 타입/레코드에 맞춰 테스트 코드 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->