### PR TITLE
[AN] 나의 보따리 화면 오프라인 처리

### DIFF
--- a/android/Bottari/core/ui/src/main/java/com/bottari/core/ui/component/OfflineContent.kt
+++ b/android/Bottari/core/ui/src/main/java/com/bottari/core/ui/component/OfflineContent.kt
@@ -1,0 +1,91 @@
+package com.bottari.presentation.compose.common.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bottari.presentation.compose.common.theme.BottariTheme
+
+@Composable
+fun OfflineContent(
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = Icons.Default.WifiOff,
+            contentDescription = "오프라인",
+            modifier = Modifier.size(80.dp),
+        )
+        Spacer(modifier = Modifier.height(BottariTheme.spacing.spaceSmall))
+        Text(
+            text = "네트워크에 연결되어 있지 않아요",
+            color = BottariTheme.colors.black,
+            style = BottariTheme.typography.medium20.toTextStyle(),
+        )
+        Spacer(modifier = Modifier.height(BottariTheme.spacing.space2xSmall))
+        Text(
+            text = "연결 상태를 확인하고 다시 시도해주세요",
+            color = BottariTheme.colors.gray700,
+            style = BottariTheme.typography.medium16.toTextStyle(),
+        )
+        Spacer(modifier = Modifier.height(BottariTheme.spacing.spaceSmall))
+        RetryButton(onRetryClick = onRetryClick)
+    }
+}
+
+@Composable
+private fun RetryButton(
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(
+        onClick = onRetryClick,
+        modifier = modifier,
+        shape = RoundedCornerShape(12.dp),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = BottariTheme.colors.primary,
+                contentColor = Color.White,
+            ),
+        elevation =
+            ButtonDefaults.buttonElevation(
+                defaultElevation = 2.dp,
+                pressedElevation = 0.dp,
+            ),
+    ) {
+        Text(
+            text = "다시 시도",
+            color = BottariTheme.colors.white,
+            style = BottariTheme.typography.semiBold16.toTextStyle(),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun OfflineContentPreview() {
+    BottariTheme {
+        OfflineContent(
+            onRetryClick = {},
+        )
+    }
+}

--- a/android/Bottari/core/ui/src/main/java/com/bottari/core/ui/component/OfflineContent.kt
+++ b/android/Bottari/core/ui/src/main/java/com/bottari/core/ui/component/OfflineContent.kt
@@ -5,17 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.WifiOff
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bottari.bottari.designsystem.component.BottariButton
@@ -52,34 +48,6 @@ fun OfflineContent(
         BottariButton(
             text = "다시 시도",
             onClick = onRetryClick,
-        )
-    }
-}
-
-@Composable
-private fun RetryButton(
-    onRetryClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    TextButton(
-        onClick = onRetryClick,
-        modifier = modifier,
-        shape = RoundedCornerShape(12.dp),
-        colors =
-            ButtonDefaults.buttonColors(
-                containerColor = BottariTheme.colors.primary,
-                contentColor = Color.White,
-            ),
-        elevation =
-            ButtonDefaults.buttonElevation(
-                defaultElevation = 2.dp,
-                pressedElevation = 0.dp,
-            ),
-    ) {
-        Text(
-            text = "다시 시도",
-            color = BottariTheme.colors.white,
-            style = BottariTheme.typography.semiBold16.toTextStyle(),
         )
     }
 }

--- a/android/Bottari/core/ui/src/main/java/com/bottari/core/ui/component/OfflineContent.kt
+++ b/android/Bottari/core/ui/src/main/java/com/bottari/core/ui/component/OfflineContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.bottari.bottari.designsystem.component.BottariButton
 import com.bottari.bottari.designsystem.theme.BottariTheme
 
 @Composable
@@ -48,7 +49,10 @@ fun OfflineContent(
             style = BottariTheme.typography.medium16.toTextStyle(),
         )
         Spacer(modifier = Modifier.height(BottariTheme.spacing.spaceSmall))
-        RetryButton(onRetryClick = onRetryClick)
+        BottariButton(
+            text = "다시 시도",
+            onClick = onRetryClick,
+        )
     }
 }
 

--- a/android/Bottari/core/ui/src/main/java/com/bottari/core/ui/component/OfflineContent.kt
+++ b/android/Bottari/core/ui/src/main/java/com/bottari/core/ui/component/OfflineContent.kt
@@ -1,4 +1,4 @@
-package com.bottari.presentation.compose.common.component
+package com.bottari.core.ui.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -18,7 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bottari.presentation.compose.common.theme.BottariTheme
+import com.bottari.bottari.designsystem.theme.BottariTheme
 
 @Composable
 fun OfflineContent(

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariScreen.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariScreen.kt
@@ -30,16 +30,23 @@ fun MyBottariScreen(
     onNavigateToTeamChecklist: (Long, String) -> Unit,
     viewModel: MyBottariViewModel = viewModel(),
 ) {
-    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val isConnected = viewModel.isConnected.collectAsStateWithLifecycle().value
     val context = LocalContext.current
     val clipboard = LocalClipboard.current
 
     var dialogText by rememberSaveable { mutableStateOf("") }
 
-    LifecycleEventEffect(Lifecycle.Event.ON_START) { viewModel.fetchTeamBottaries() }
+    LifecycleEventEffect(Lifecycle.Event.ON_START) {
+        viewModel.fetchTeamBottaries()
+    }
 
-    LaunchedEffect(uiState.value.showDialogType) {
-        if (uiState.value.showDialogType == MyBottariDialogType.CODE) {
+    LaunchedEffect(isConnected) {
+        viewModel.fetchTeamBottaries()
+    }
+
+    LaunchedEffect(uiState.showDialogType) {
+        if (uiState.showDialogType == MyBottariDialogType.CODE) {
             val clipData = clipboard.nativeClipboard.primaryClip
             clipData?.let { data ->
                 if (data.itemCount > 0) {
@@ -86,7 +93,7 @@ fun MyBottariScreen(
 
     val defaultBottariTitle = stringResource(id = R.string.bottari_create_default_title_text)
 
-    uiState.value.showDialogType?.let { type ->
+    uiState.showDialogType?.let { type ->
         MyBottariDialogs(
             dialogType = type,
             text = dialogText,
@@ -104,7 +111,9 @@ fun MyBottariScreen(
     }
 
     MyBottariContent(
-        uiState = uiState.value,
+        uiState = uiState,
+        isConnected = isConnected,
+        onRetryClick = viewModel::fetchTeamBottaries,
         onClickPersonalBottari = onNavigateToPersonalChecklist,
         onClickTeamBottari = onNavigateToTeamChecklist,
         onDeletePersonalBottari = viewModel::deletePersonalBottari,

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariUiState.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariUiState.kt
@@ -16,8 +16,8 @@ data class MyBottariUiState(
     val showDialogType: MyBottariDialogType? = null,
 ) {
     val isFetched: Boolean = isPersonalFetched && isTeamFetched
-    val isPersonalEmpty: Boolean = isFetched && personalBottaries.isEmpty()
-    val isTeamEmpty: Boolean = isFetched && teamBottaries.isEmpty()
+    val isPersonalEmpty: Boolean = isPersonalFetched && personalBottaries.isEmpty()
+    val isTeamEmpty: Boolean = isTeamFetched && teamBottaries.isEmpty()
     val allBottaries: List<MyBottariUiModel> = teamBottaries + personalBottaries
     val isAllEmpty: Boolean = isFetched && allBottaries.isEmpty()
 }

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariViewModel.kt
@@ -42,8 +42,6 @@ class MyBottariViewModel @Inject constructor(
     }
 
     fun fetchTeamBottaries() {
-        if (isConnected.value.not()) return
-
         launch {
             updateState { copy(isLoading = true) }
             fetchTeamBottariesUseCase()

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariViewModel.kt
@@ -2,6 +2,7 @@ package com.bottari.presentation.compose.home.bottari
 
 import androidx.lifecycle.viewModelScope
 import com.bottari.core.domain.model.notification.Notification
+import com.bottari.core.domain.network.NetworkManager
 import com.bottari.core.domain.usecase.bottari.CreateBottariUseCase
 import com.bottari.core.domain.usecase.bottari.DeleteBottariUseCase
 import com.bottari.core.domain.usecase.bottari.FetchBottariesUseCase
@@ -9,7 +10,7 @@ import com.bottari.core.domain.usecase.team.CreateTeamBottariUseCase
 import com.bottari.core.domain.usecase.team.ExitTeamBottariUseCase
 import com.bottari.core.domain.usecase.team.FetchTeamBottariesUseCase
 import com.bottari.core.domain.usecase.team.JoinTeamBottariUseCase
-import com.bottari.presentation.common.base.FlowBaseViewModel
+import com.bottari.presentation.common.base.NetworkBaseViewModel
 import com.bottari.presentation.compose.home.bottari.component.MyBottariDialogType
 import com.bottari.presentation.model.bottari.MyBottariUiModel
 import com.bottari.presentation.model.bottari.personal.BottariUiModel
@@ -23,6 +24,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyBottariViewModel @Inject constructor(
+    networkManager: NetworkManager,
     private val fetchBottariesUseCase: FetchBottariesUseCase,
     private val fetchTeamBottariesUseCase: FetchTeamBottariesUseCase,
     private val createBottariUseCase: CreateBottariUseCase,
@@ -31,18 +33,25 @@ class MyBottariViewModel @Inject constructor(
     private val deleteTeamBottariUseCase: ExitTeamBottariUseCase,
     private val joinTeamBottariUseCase: JoinTeamBottariUseCase,
     private val alarmScheduler: AlarmScheduler,
-) : FlowBaseViewModel<MyBottariUiState, MyBottariUiEvent>(MyBottariUiState()) {
+) : NetworkBaseViewModel<MyBottariUiState, MyBottariUiEvent>(
+        initialState = MyBottariUiState(),
+        networkManager = networkManager,
+    ) {
     init {
         fetchPersonalBottaries()
     }
 
     fun fetchTeamBottaries() {
+        if (isConnected.value.not()) return
+
         launch {
             updateState { copy(isLoading = true) }
             fetchTeamBottariesUseCase()
                 .onSuccess { bottaries ->
                     updateState { copy(teamBottaries = bottaries.map(TeamBottariUiModel::fromDomain)) }
-                }.onFailure { emitEvent(MyBottariUiEvent.FetchBottariFailure) }
+                }.onFailure {
+                    emitEvent(MyBottariUiEvent.FetchBottariFailure)
+                }
         }.invokeOnCompletion { updateState { copy(isLoading = false, isTeamFetched = true) } }
     }
 

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/MyBottariViewModel.kt
@@ -42,6 +42,11 @@ class MyBottariViewModel @Inject constructor(
     }
 
     fun fetchTeamBottaries() {
+        if (isConnected.value.not()) {
+            updateState { copy(isTeamFetched = true) }
+            return
+        }
+
         launch {
             updateState { copy(isLoading = true) }
             fetchTeamBottariesUseCase()

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/component/MyBottariContent.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/component/MyBottariContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.bottari.bottari.designsystem.component.BottariCircularLoader
 import com.bottari.bottari.designsystem.theme.BottariTheme
 import com.bottari.core.ui.component.BottariTabBar
+import com.bottari.core.ui.component.OfflineContent
 import com.bottari.presentation.R
 import com.bottari.presentation.compose.home.bottari.MyBottariUiState
 import com.bottari.presentation.model.bottari.MyBottariUiModel

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/component/MyBottariContent.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/compose/home/bottari/component/MyBottariContent.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.delay
 @Composable
 fun MyBottariContent(
     uiState: MyBottariUiState,
+    isConnected: Boolean,
+    onRetryClick: () -> Unit,
     onClickPersonalBottari: (Long, String) -> Unit,
     onClickTeamBottari: (Long, String) -> Unit,
     onDeletePersonalBottari: (Long) -> Unit,
@@ -47,6 +49,13 @@ fun MyBottariContent(
     var isFabVisible by remember { mutableStateOf(true) }
     var openedMenuBottariId by remember { mutableStateOf<Long?>(null) }
 
+    val pageTitles =
+        listOf(
+            stringResource(R.string.all_bottari_text),
+            stringResource(R.string.personal_bottari_text),
+            stringResource(R.string.team_bottari_text),
+        )
+    val pagerState = rememberPagerState { pageTitles.size }
     val allListState = rememberLazyListState()
     val personalListState = rememberLazyListState()
     val teamListState = rememberLazyListState()
@@ -75,16 +84,9 @@ fun MyBottariContent(
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            val pageTitles =
-                listOf(
-                    stringResource(R.string.all_bottari_text),
-                    stringResource(R.string.personal_bottari_text),
-                    stringResource(R.string.team_bottari_text),
-                )
-
             BottariTabBar(
                 pageTitles = pageTitles,
-                pagerState = rememberPagerState(initialPage = 0) { pageTitles.size },
+                pagerState = pagerState,
             ) { page ->
                 val onBottariClick = onBottariClick@{ bottari: MyBottariUiModel ->
                     if (isFabExpanded || openedMenuBottariId != null) {
@@ -99,37 +101,52 @@ fun MyBottariContent(
                     )
                 }
 
-                when (page) {
-                    0 -> if (uiState.isAllEmpty) MyBottariEmptyView()
-                    1 -> if (uiState.isPersonalEmpty) MyBottariEmptyView()
-                    2 -> if (uiState.isTeamEmpty) MyBottariEmptyView()
+                val isEmpty =
+                    when (page) {
+                        0 -> uiState.isAllEmpty
+                        1 -> uiState.isPersonalEmpty
+                        2 -> uiState.isTeamEmpty
+                        else -> true
+                    }
+
+                when {
+                    isConnected.not() && page == 2 -> {
+                        OfflineContent(
+                            onRetryClick = onRetryClick,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+
+                    isEmpty -> MyBottariEmptyView()
+
+                    else -> {
+                        val currentListState =
+                            when (page) {
+                                0 -> allListState
+                                1 -> personalListState
+                                2 -> teamListState
+                                else -> error("유효하지 않은 페이지")
+                            }
+
+                        val currentList =
+                            when (page) {
+                                0 -> uiState.allBottaries
+                                1 -> uiState.personalBottaries
+                                2 -> uiState.teamBottaries
+                                else -> emptyList()
+                            }
+
+                        BottariList(
+                            bottaries = currentList,
+                            listState = currentListState,
+                            onBottariClick = onBottariClick,
+                            onDeletePersonalBottari = onDeletePersonalBottari,
+                            onDeleteTeamBottari = onDeleteTeamBottari,
+                            onEditPersonalBottari = onEditPersonalBottari,
+                            onEditTeamBottari = onEditTeamBottari,
+                        )
+                    }
                 }
-
-                val currentListState =
-                    when (page) {
-                        0 -> allListState
-                        1 -> personalListState
-                        2 -> teamListState
-                        else -> error("유효하지 않은 페이지")
-                    }
-
-                val currentList =
-                    when (page) {
-                        0 -> uiState.allBottaries
-                        1 -> uiState.personalBottaries
-                        2 -> uiState.teamBottaries
-                        else -> emptyList()
-                    }
-
-                BottariList(
-                    bottaries = currentList,
-                    listState = currentListState,
-                    onBottariClick = onBottariClick,
-                    onDeletePersonalBottari = onDeletePersonalBottari,
-                    onDeleteTeamBottari = onDeleteTeamBottari,
-                    onEditPersonalBottari = onEditPersonalBottari,
-                    onEditTeamBottari = onEditTeamBottari,
-                )
             }
         }
 
@@ -207,6 +224,8 @@ private fun MyBottariContentPreview() {
     BottariTheme {
         MyBottariContent(
             uiState = fakeUiState,
+            isConnected = true,
+            onRetryClick = {},
             onClickPersonalBottari = { _, _ -> },
             onClickTeamBottari = { _, _ -> },
             onDeletePersonalBottari = {},

--- a/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
+++ b/android/Bottari/presentation/src/main/java/com/bottari/presentation/view/main/MainViewModel.kt
@@ -35,13 +35,15 @@ class MainViewModel @Inject constructor(
     fun savePermissionFlag() {
         launch {
             savePermissionFlagUseCase(true)
-                .onSuccess { updateState { copy(hasPermissionFlag = true) } }
                 .onFailure { emitEvent(MainUiEvent.SavePermissionFlagFailure) }
         }
     }
 
     fun checkRegisteredMember() {
-        if (isConnected.value.not()) return handleOffline()
+        if (isConnected.value.not()) {
+            emitEvent(MainUiEvent.Offline(false))
+            return
+        }
 
         launch {
             checkRegisteredMemberUseCase()


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- `NetworkManager`를 통한 나의 보따리 화면 오프라인 처리

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #683 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 네트워크 상태 변수 `isConnected`를 통한 오프라인 처리
- 오프라인 상태 시 `OfflineContent` 호출

<br>

## 📸 스크린샷 (선택)
<!-- 시각적 변경사항이 있다면 스크린샷 첨부해주세요. -->
<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/86284d47-033a-4046-b63f-5e8e22f63e83" />

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->
- `OfflineContent` 디자인에 대한 의견 부탁드려요~
```kotlin
            when {
                    isConnected.not() && page == 2 -> {
                        OfflineContent(
                            onRetryClick = onRetryClick,
                            modifier = Modifier.fillMaxSize(),
                        )
                    }

                    isEmpty -> {
                        MyBottariEmptyView()
                    }

                    else -> {
                        val currentListState =
                            when (page) {
                                0 -> allListState
                                1 -> personalListState
                                2 -> teamListState
                                else -> error("유효하지 않은 페이지")
                            }

                        val currentList =
                            when (page) {
                                0 -> uiState.allBottaries
                                1 -> uiState.personalBottaries
                                2 -> uiState.teamBottaries
                                else -> emptyList()
                            }

                        BottariList(
                            bottaries = currentList,
                            listState = currentListState,
                            onBottariClick = onBottariClick,
                            onDeletePersonalBottari = onDeletePersonalBottari,
                            onDeleteTeamBottari = onDeleteTeamBottari,
                            onEditPersonalBottari = onEditPersonalBottari,
                            onEditTeamBottari = onEditTeamBottari,
                        )
                    }
                }
```
- `MyBottariContent` 내부에서 특정 상태에 따라 다른 UI를 보여주기 위해 위처럼 분기 처리를 했는데, 더 좋은 방법이 있을까요? 가령 `sealed interface`를 통해 화면의 상태를 나타낸다거나.. 화면에 상태가 너무 많고 기존의 로직이 복잡해서 좀 어지러운 코드가 나온 것 같아요.

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 오프라인 상태에서 팀 페이지 접근 시 재시도 버튼이 있는 오프라인 안내 UI 추가
  * 네트워크 연결 변화에 따라 자동으로 팀 목록을 새로고침하는 동작 추가

* **개선 사항**
  * 컴포넌트 상태 관리 개선으로 UI 반응성 및 빈 상태 판별 로직 정교화
  * 일부 공개 컴포저블이 연결 상태(isConnected)와 재시도 콜백(onRetry)을 받도록 업데이트하여 오프라인 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->