### PR TITLE
[BE] Swagger UI가 HTTP로 요청을 보내 API 호출이 실패하는 문제

### DIFF
--- a/backend/bottari/src/main/java/com/bottari/config/OpenApiServerProperties.java
+++ b/backend/bottari/src/main/java/com/bottari/config/OpenApiServerProperties.java
@@ -1,0 +1,10 @@
+package com.bottari.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "bottari.openapi.server")
+public record OpenApiServerProperties(
+    String url,
+    String description
+) {
+}

--- a/backend/bottari/src/main/java/com/bottari/config/PropertiesConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/PropertiesConfig.java
@@ -1,0 +1,9 @@
+package com.bottari.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan
+public class PropertiesConfig {
+}

--- a/backend/bottari/src/main/java/com/bottari/config/SwaggerConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/SwaggerConfig.java
@@ -8,25 +8,26 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.customizers.OperationCustomizer;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConfigurationPropertiesScan
+@RequiredArgsConstructor
 public class SwaggerConfig {
 
-    @Value("${bottari.openapi.server.url:http://localhost:8080}")
-    private String serverUrl;
-
-    @Value("${bottari.openapi.server.description:Local}")
-    private String serverDescription;
+    private final OpenApiServerProperties openApiServerProperties;
 
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(apiInfo())
-                .servers(List.of(new Server().url(serverUrl).description(serverDescription)))
+                .servers(List.of(new Server()
+                        .url(openApiServerProperties.url())
+                        .description(openApiServerProperties.description())))
                 .addSecurityItem(getSecurityRequirement())
                 .components(getComponents());
     }

--- a/backend/bottari/src/main/java/com/bottari/config/SwaggerConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/SwaggerConfig.java
@@ -6,17 +6,27 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    @Value("${bottari.openapi.server-url:http://localhost:8080}")
+    private String serverUrl;
+
+    @Value("${bottari.openapi.server-description:Local}")
+    private String serverDescription;
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(apiInfo())
+                .servers(List.of(new Server().url(serverUrl).description(serverDescription)))
                 .addSecurityItem(getSecurityRequirement())
                 .components(getComponents());
     }

--- a/backend/bottari/src/main/java/com/bottari/config/SwaggerConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/SwaggerConfig.java
@@ -16,10 +16,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    @Value("${bottari.openapi.server:url:http://localhost:8080}")
+    @Value("${bottari.openapi.server.url:http://localhost:8080}")
     private String serverUrl;
 
-    @Value("${bottari.openapi.server:description:Local}")
+    @Value("${bottari.openapi.server.description:Local}")
     private String serverDescription;
 
     @Bean

--- a/backend/bottari/src/main/java/com/bottari/config/SwaggerConfig.java
+++ b/backend/bottari/src/main/java/com/bottari/config/SwaggerConfig.java
@@ -16,10 +16,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    @Value("${bottari.openapi.server-url:http://localhost:8080}")
+    @Value("${bottari.openapi.server:url:http://localhost:8080}")
     private String serverUrl;
 
-    @Value("${bottari.openapi.server-description:Local}")
+    @Value("${bottari.openapi.server:description:Local}")
     private String serverDescription;
 
     @Bean

--- a/backend/bottari/src/main/resources/application-dev.yml
+++ b/backend/bottari/src/main/resources/application-dev.yml
@@ -50,3 +50,8 @@ firebase:
   service:
     key-path: ${FIREBASE_SERVICE_ACCOUNT_JSON}
 
+bottari:
+  openapi:
+    server-url: https://dev.bottari.app
+    description: Dev
+

--- a/backend/bottari/src/main/resources/application-dev.yml
+++ b/backend/bottari/src/main/resources/application-dev.yml
@@ -52,6 +52,7 @@ firebase:
 
 bottari:
   openapi:
-    server-url: https://dev.bottari.app
-    description: Dev
+    server:
+      url: https://dev.bottari.app
+      description: Dev
 

--- a/backend/bottari/src/main/resources/application-prod.yml
+++ b/backend/bottari/src/main/resources/application-prod.yml
@@ -43,5 +43,6 @@ firebase:
 
 bottari:
   openapi:
-    server-url: https://bottari.app
-    description: Prod
+    server:
+      url: https://bottari.app
+      description: Prod

--- a/backend/bottari/src/main/resources/application-prod.yml
+++ b/backend/bottari/src/main/resources/application-prod.yml
@@ -40,3 +40,8 @@ management:
 firebase:
   service:
     key-path: ${FIREBASE_SERVICE_ACCOUNT_JSON}
+
+bottari:
+  openapi:
+    server-url: https://bottari.app
+    description: Prod

--- a/backend/bottari/src/main/resources/application.yml
+++ b/backend/bottari/src/main/resources/application.yml
@@ -50,5 +50,6 @@ firebase:
 
 bottari:
   openapi:
-    server-url: http://localhost:8080
-    description: Local
+    server:
+      url: http://localhost:8080
+      description: Local

--- a/backend/bottari/src/main/resources/application.yml
+++ b/backend/bottari/src/main/resources/application.yml
@@ -47,3 +47,8 @@ spring:
 firebase:
   service:
     key-path: ${FIREBASE_SERVICE_ACCOUNT_JSON}
+
+bottari:
+  openapi:
+    server-url: http://localhost:8080
+    description: Local

--- a/backend/sse/src/main/java/com/bottari/sse/config/OpenApiServerProperties.java
+++ b/backend/sse/src/main/java/com/bottari/sse/config/OpenApiServerProperties.java
@@ -1,0 +1,10 @@
+package com.bottari.sse.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "bottari.openapi.server")
+public record OpenApiServerProperties(
+    String url,
+    String description
+) {
+}

--- a/backend/sse/src/main/java/com/bottari/sse/config/PropertiesConfig.java
+++ b/backend/sse/src/main/java/com/bottari/sse/config/PropertiesConfig.java
@@ -1,0 +1,9 @@
+package com.bottari.sse.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan
+public class PropertiesConfig {
+}

--- a/backend/sse/src/main/java/com/bottari/sse/config/RedisTaskExecutorProperties.java
+++ b/backend/sse/src/main/java/com/bottari/sse/config/RedisTaskExecutorProperties.java
@@ -3,9 +3,7 @@ package com.bottari.sse.config;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
-@Component
 @ConfigurationProperties(prefix = "sse.async")
 @Getter
 @Setter

--- a/backend/sse/src/main/java/com/bottari/sse/config/SwaggerConfig.java
+++ b/backend/sse/src/main/java/com/bottari/sse/config/SwaggerConfig.java
@@ -6,17 +6,27 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    @Value("${bottari.openapi.server-url:http://localhost:8080}")
+    private String serverUrl;
+
+    @Value("${bottari.openapi.server-description:Local}")
+    private String serverDescription;
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(apiInfo())
+                .servers(List.of(new Server().url(serverUrl).description(serverDescription)))
                 .addSecurityItem(getSecurityRequirement())
                 .components(getComponents());
     }

--- a/backend/sse/src/main/java/com/bottari/sse/config/SwaggerConfig.java
+++ b/backend/sse/src/main/java/com/bottari/sse/config/SwaggerConfig.java
@@ -16,10 +16,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    @Value("${bottari.openapi.server:url:http://localhost:8080}")
+    @Value("${bottari.openapi.server.url:http://localhost:8080}")
     private String serverUrl;
 
-    @Value("${bottari.openapi.server:description:Local}")
+    @Value("${bottari.openapi.server.description:Local}")
     private String serverDescription;
 
     @Bean

--- a/backend/sse/src/main/java/com/bottari/sse/config/SwaggerConfig.java
+++ b/backend/sse/src/main/java/com/bottari/sse/config/SwaggerConfig.java
@@ -16,10 +16,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    @Value("${bottari.openapi.server-url:http://localhost:8080}")
+    @Value("${bottari.openapi.server:url:http://localhost:8080}")
     private String serverUrl;
 
-    @Value("${bottari.openapi.server-description:Local}")
+    @Value("${bottari.openapi.server:description:Local}")
     private String serverDescription;
 
     @Bean

--- a/backend/sse/src/main/java/com/bottari/sse/config/SwaggerConfig.java
+++ b/backend/sse/src/main/java/com/bottari/sse/config/SwaggerConfig.java
@@ -8,25 +8,24 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.customizers.OperationCustomizer;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
 
-    @Value("${bottari.openapi.server.url:http://localhost:8080}")
-    private String serverUrl;
-
-    @Value("${bottari.openapi.server.description:Local}")
-    private String serverDescription;
+    private final OpenApiServerProperties openApiServerProperties;
 
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(apiInfo())
-                .servers(List.of(new Server().url(serverUrl).description(serverDescription)))
+                .servers(List.of(new Server()
+                        .url(openApiServerProperties.url())
+                        .description(openApiServerProperties.description())))
                 .addSecurityItem(getSecurityRequirement())
                 .components(getComponents());
     }

--- a/backend/sse/src/main/resources/application-dev.yml
+++ b/backend/sse/src/main/resources/application-dev.yml
@@ -18,3 +18,8 @@ spring:
       host: ${REDIS_DEV_HOST}
       port: ${REDIS_DEV_PORT}
       password: ${REDIS_DEV_PASSWORD}
+
+bottari:
+  openapi:
+    server-url: https://dev.bottari.app
+    description: Dev

--- a/backend/sse/src/main/resources/application-dev.yml
+++ b/backend/sse/src/main/resources/application-dev.yml
@@ -21,5 +21,6 @@ spring:
 
 bottari:
   openapi:
-    server-url: https://dev.bottari.app
-    description: Dev
+    server:
+      url: https://dev.bottari.app
+      description: Dev

--- a/backend/sse/src/main/resources/application-prod.yml
+++ b/backend/sse/src/main/resources/application-prod.yml
@@ -9,5 +9,6 @@ spring:
 
 bottari:
   openapi:
-    server-url: https://bottari.app
-    description: Prod
+    server:
+      url: https://bottari.app
+      description: Prod

--- a/backend/sse/src/main/resources/application-prod.yml
+++ b/backend/sse/src/main/resources/application-prod.yml
@@ -6,3 +6,8 @@ spring:
       host: ${REDIS_PROD_HOST}
       port: ${REDIS_PROD_PORT}
       password: ${REDIS_PROD_PASSWORD}
+
+bottari:
+  openapi:
+    server-url: https://bottari.app
+    description: Prod

--- a/backend/sse/src/main/resources/application.yml
+++ b/backend/sse/src/main/resources/application.yml
@@ -19,3 +19,8 @@ sse:
     thread-name-prefix: ${SSE_ASYNC_THREAD_NAME_PREFIX:sse-async-}
     wait-for-tasks-to-complete-on-shutdown: ${SSE_ASYNC_WAIT_FOR_TASKS:true}
     await-termination-seconds: ${SSE_ASYNC_AWAIT_TERMINATION_SECONDS:30}
+
+bottari:
+  openapi:
+    server-url: http://localhost:8080
+    description: Local

--- a/backend/sse/src/main/resources/application.yml
+++ b/backend/sse/src/main/resources/application.yml
@@ -23,5 +23,5 @@ sse:
 bottari:
   openapi:
     server:
-      url: http://localhost:8080
+      url: http://localhost:8081
       description: Local

--- a/backend/sse/src/main/resources/application.yml
+++ b/backend/sse/src/main/resources/application.yml
@@ -22,5 +22,6 @@ sse:
 
 bottari:
   openapi:
-    server-url: http://localhost:8080
-    description: Local
+    server:
+      url: http://localhost:8080
+      description: Local


### PR DESCRIPTION
<!-- PR 제목 예시: [AN] 로그인 화면 UI 구현 / [BE] 회원가입 API 추가 / [ALL] 공통 유틸 정리 -->

## ✅ 작업 개요
<!-- 어떤 기능/수정/리팩토링인지 한 줄로 설명 (예: 로그인 화면 UI 구현) -->
- Swagger UI가 HTTP로 요청을 보내 API 호출이 실패하는 문제

<br>

## 🎯 관련 이슈
<!-- 관련된 이슈 번호를 태깅해주세요. -->
- Closed #696 

<br>

## 🔍 상세 내용
<!-- 
작업한 내용을 구체적으로 작성해주세요.
- 로그인 화면 UI 구성 (이메일, 비밀번호 입력란, 로그인 버튼)
- 입력값 유효성 검사 추가
- ViewModel 및 상태 관리 로직 연동
-->
- 기존 Swagger에서 요청 시, 서버 URL이 `http://~`로 설정되어 있어 CORS 문제 발생
- 이를 각 프로필 별 `application.yml`에서 https로 요청을 보내도록 지정
- 설정값 누락 시, `http://localhost:8080`으로 default값 지정
<img width="1032" height="320" alt="image" src="https://github.com/user-attachments/assets/b9605a9b-a570-4cf3-b07e-1d537c1c267b" />

<br>

## 💬 기타 참고사항
<!-- 
코드 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
- 추후 `회원가입` 화면에서도 재사용 가능한 UI 컴포넌트로 분리할 예정입니다.
- `AuthViewModel` 내 중복 로직은 이후 리팩토링에서 정리 예정입니다.
-->

배포 후에 적용 되는 걸 기대해봅시다....^^

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서 개선**
  * API 문서에 환경별 서버 정보(로컬/개발/프로덕션)가 추가되어 각 환경에 맞는 엔드포인트와 설명이 표시됩니다.
* **신규 기능**
  * 배포 환경에 따른 OpenAPI 서버 정보가 구성에서 자동으로 반영되어 문서가 환경별로 즉시 갱신됩니다.
* **설정**
  * 환경 설정이 자동으로 로드되어 API 문서 반영이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->